### PR TITLE
Add live tests and sanitize gptel tool JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 EMACS ?= emacs
+EMACSCLIENT ?= emacsclient
 EMACS_BATCH = $(EMACS) -Q --batch
 
 # Auto-detect dependency paths
@@ -66,7 +67,7 @@ SRCS = magent-config.el \
 
 COMPILED = $(SRCS:.el=.elc)
 
-.PHONY: all compile clean test help
+.PHONY: all compile clean test test-unit test-live test-live-smoke help
 
 all: compile
 
@@ -75,7 +76,10 @@ help:
 	@echo ""
 	@echo "Targets:"
 	@echo "  compile       - Byte compile all Elisp files"
-	@echo "  test          - Run unit tests"
+	@echo "  test          - Run unit tests and deterministic live smoke tests"
+	@echo "  test-unit     - Run batch unit tests"
+	@echo "  test-live     - Run real live gptel tests; consumes tokens and requires Emacs server"
+	@echo "  test-live-smoke - Run live Emacs smoke tests with stubbed gptel transport"
 	@echo "  clean         - Remove compiled files"
 	@echo "  help          - Show this help message"
 
@@ -89,12 +93,22 @@ compile: $(COMPILED)
 	printf "%s\n" "$$out" | grep -v "^Compiling" | grep -v "^Wrote" || true; \
 	exit $$status
 
-test:
+test: test-unit test-live-smoke
+
+test-unit:
 	@echo "Running unit tests..."
 	@$(EMACS) -Q --batch $(LOADPATH) \
 		-l ert \
 		-l test/magent-test.el \
 		-f ert-run-tests-batch-and-exit
+
+test-live:
+	@echo "Running real live Emacs/gptel tests..."
+	@$(EMACSCLIENT) -e "(progn (load-file \"$(CURDIR)/test/magent-live-test.el\") (magent-live-test-run))"
+
+test-live-smoke:
+	@echo "Running live Emacs smoke tests..."
+	@$(EMACSCLIENT) -e "(progn (load-file \"$(CURDIR)/test/magent-live-test.el\") (magent-live-test-run-smoke))"
 
 clean:
 	@echo "Cleaning compiled files..."

--- a/magent-config.el
+++ b/magent-config.el
@@ -14,6 +14,9 @@
 
 ;;; Code:
 
+(require 'cl-lib)
+(require 'json)
+
 (defgroup magent nil
   "Magent AI coding agent for Emacs."
   :prefix "magent-"
@@ -443,6 +446,124 @@ and project.el.  Unless NO-FALLBACK is non-nil, return DIRECTORY
                 (car (with-no-warnings (project-roots proj)))))))
         (unless no-fallback
           default-directory))))
+
+;;; JSON helpers
+
+(defun magent-json--symbol-value (value)
+  "Return VALUE as a JSON string value."
+  (let ((name (symbol-name value)))
+    (if (string-prefix-p ":" name)
+        (substring name 1)
+      name)))
+
+(defun magent-json-safe-name (name &optional fallback)
+  "Return NAME as a JSON-safe string.
+FALLBACK is used when NAME is nil."
+  (cond
+   ((stringp name) name)
+   ((symbolp name) (magent-json--symbol-value name))
+   ((null name) (or fallback "unknown"))
+   (t (format "%s" name))))
+
+(defun magent-json--object-key (key)
+  "Return KEY as a stable symbol key for JSON object alists."
+  (cond
+   ((keywordp key)
+    (intern (substring (symbol-name key) 1)))
+   ((symbolp key) key)
+   ((stringp key) (intern key))
+   (t (intern (format "%s" key)))))
+
+(defun magent-json--plist-p (value)
+  "Return non-nil when VALUE is a keyword plist."
+  (and (listp value)
+       (let ((tail value)
+             (ok t))
+         (while (and ok tail)
+           (if (and (consp tail)
+                    (keywordp (car tail))
+                    (consp (cdr tail)))
+               (setq tail (cddr tail))
+             (setq ok nil)))
+         ok)))
+
+(defun magent-json--alist-p (value)
+  "Return non-nil when VALUE is a proper alist."
+  (and (consp value)
+       (let ((tail value)
+             (ok t))
+         (while (and ok tail)
+           (if (and (consp tail)
+                    (consp (car tail))
+                    (not (keywordp (caar tail))))
+               (setq tail (cdr tail))
+             (setq ok nil)))
+         (and ok (null tail)))))
+
+(defun magent-json-safe-value (value)
+  "Return VALUE converted to data accepted by Emacs JSON encoders.
+This is used at Magent/gptel boundaries where live provider data can contain
+Lisp symbols or lists that `json-serialize' rejects."
+  (cond
+   ((null value) :null)
+   ((or (stringp value) (numberp value)
+        (eq value t)
+        (eq value :json-false)
+        (eq value :null))
+    value)
+   ((symbolp value)
+    (magent-json--symbol-value value))
+   ((vectorp value)
+    (vconcat (mapcar #'magent-json-safe-value (append value nil))))
+   ((hash-table-p value)
+    (let ((table (make-hash-table :test #'equal)))
+      (maphash (lambda (key val)
+                 (puthash (if (stringp key) key (format "%s" key))
+                          (magent-json-safe-value val)
+                          table))
+               value)
+      table))
+   ((magent-json--plist-p value)
+    (let (out)
+      (while value
+        (let ((key (pop value))
+              (val (pop value)))
+          (setq out (append out
+                            (list key (magent-json-safe-value val))))))
+      out))
+   ((magent-json--alist-p value)
+    (mapcar (lambda (entry)
+              (cons (magent-json--object-key (car entry))
+                    (magent-json-safe-value (cdr entry))))
+            value))
+   ((consp value)
+    (vconcat (mapcar #'magent-json-safe-value value)))
+   (t
+    (format "%S" value))))
+
+(defun magent-json-safe-tool-args (args)
+  "Return JSON-safe tool ARGS for display, persistence, and prompt reuse.
+Nil values in keyword plists are omitted because gptel parses JSON null tool
+arguments as nil, and optional nil arguments should not round-trip as `{}`."
+  (cond
+   ((null args) nil)
+   ((magent-json--plist-p args)
+    (let (out)
+      (while args
+        (let ((key (pop args))
+              (val (pop args)))
+          (unless (null val)
+            (setq out (append out
+                              (list key (magent-json-safe-value val)))))))
+      out))
+   (t
+    (magent-json-safe-value args))))
+
+(defun magent-json-encode (value)
+  "Encode VALUE as JSON after converting it with `magent-json-safe-value'."
+  (let ((json-null :null)
+        (json-false :json-false))
+    (json-encode (magent-json-safe-value value))))
 
 ;;; Logging stub
 ;; Defined here so all modules can call magent-log unconditionally.

--- a/magent-fsm-tools.el
+++ b/magent-fsm-tools.el
@@ -542,7 +542,7 @@ must not be forwarded to the actual tool implementation."
        :args args-plist))))
 
 (defun magent-fsm--handle-tool-call-confirmation-with-permission
-    (permission tool-calls &optional request-context)
+    (permission tool-calls &optional request-context result-callback done-callback)
   "Handle TOOL-CALLS using PERMISSION rules."
   (magent-tool-orchestrator-handle-tool-calls
    (magent-tool-orchestrator-create
@@ -552,17 +552,22 @@ must not be forwarded to the actual tool implementation."
     :audit-function #'magent-fsm--audit-permission-decision
     :file-arg-index-function #'magent-fsm--find-file-arg-index
     :args-to-plist-function #'magent-fsm--args-to-plist
-    :summarize-function #'magent-fsm--summarize-args)
+    :summarize-function #'magent-fsm--summarize-args
+    :result-callback result-callback
+    :done-callback done-callback)
    tool-calls))
 
-(defun magent-fsm--prompt-next-tool-call (tool-calls &optional request-context)
+(defun magent-fsm--prompt-next-tool-call
+    (tool-calls &optional request-context result-callback done-callback)
   "Prompt for the next tool call in TOOL-CALLS."
   (when tool-calls
+    (require 'magent-tools)
     (let* ((tc (car tool-calls))
            (rest (cdr tool-calls))
            (tool-spec (car tc))
            (arg-values (cadr tc))
            (cb (caddr tc))
+           (raw-call (nth 3 tc))
            (tool-name (gptel-tool-name tool-spec))
            (perm-key (magent-tools-permission-key tool-name))
            (approval-session (or (and request-context
@@ -584,23 +589,50 @@ must not be forwarded to the actual tool implementation."
          (pcase decision
            ('allow-once
             (magent-log "PERM user allowed (once): %s" tool-name)
-            (magent-fsm--run-tool tool-spec cb arg-values))
+            (magent-fsm--run-tool
+             tool-spec
+             (lambda (result)
+               (when cb (funcall cb result))
+               (when result-callback
+                 (funcall result-callback tool-spec arg-values raw-call result))
+               (when (and (null rest) done-callback)
+                 (funcall done-callback)))
+             arg-values))
            ('deny-once
             (magent-log "PERM user denied (once): %s" tool-name)
-           (funcall cb (format "Error: tool '%s' denied by user" tool-name)))
+            (let ((result (format "Error: tool '%s' denied by user" tool-name)))
+              (when cb (funcall cb result))
+              (when result-callback
+                (funcall result-callback tool-spec arg-values raw-call result))
+              (when (and (null rest) done-callback)
+                (funcall done-callback))))
            ('allow-session
             (magent-log "PERM user always-allow: %s" tool-name)
             (when perm-key
               (magent-permission-set-session-override
                perm-key 'allow approval-session))
-            (magent-fsm--run-tool tool-spec cb arg-values))
+            (magent-fsm--run-tool
+             tool-spec
+             (lambda (result)
+               (when cb (funcall cb result))
+               (when result-callback
+                 (funcall result-callback tool-spec arg-values raw-call result))
+               (when (and (null rest) done-callback)
+                 (funcall done-callback)))
+             arg-values))
            ('deny-session
             (magent-log "PERM user always-deny: %s" tool-name)
             (when perm-key
               (magent-permission-set-session-override
                perm-key 'deny approval-session))
-            (funcall cb (format "Error: tool '%s' denied by user" tool-name))))
-         (magent-fsm--prompt-next-tool-call rest request-context))))))
+            (let ((result (format "Error: tool '%s' denied by user" tool-name)))
+              (when cb (funcall cb result))
+              (when result-callback
+                (funcall result-callback tool-spec arg-values raw-call result))
+              (when (and (null rest) done-callback)
+                (funcall done-callback)))))
+         (magent-fsm--prompt-next-tool-call rest request-context
+                                           result-callback done-callback))))))
 
 (defun magent-fsm--run-tool (tool-spec cb arg-values)
   "Execute TOOL-SPEC with ARG-VALUES and call CB with the result."

--- a/magent-fsm.el
+++ b/magent-fsm.el
@@ -21,6 +21,7 @@
 (require 'magent-events)
 (require 'magent-fsm-tools)
 (require 'magent-runtime)
+(require 'magent-session)
 (declare-function magent-ui-start-streaming "magent-ui")
 (declare-function magent-ui-continue-streaming "magent-ui")
 (declare-function magent-ui-insert-streaming "magent-ui")
@@ -30,6 +31,10 @@
 (declare-function magent-ui-finish-streaming-fontify "magent-ui")
 (declare-function magent-log "magent-config")
 (declare-function gptel-abort "gptel")
+(declare-function gptel--handle-post "gptel-request")
+(declare-function gptel--handle-wait "gptel-request")
+(declare-function gptel--error-p "gptel-request")
+(declare-function gptel--tool-use-p "gptel-request")
 
 (defvar magent-include-reasoning)
 
@@ -104,9 +109,17 @@ Both t and `ignore' keep reasoning in STATE.  Only nil discards it."
       (not (magent-request-context-p request-state))
       (magent-request-context-ui-visible-p request-state)))
 
+(defun magent-fsm-backend-gptel--managed-context-p (context)
+  "Return non-nil when gptel CONTEXT marks a Magent request."
+  (and (listp context)
+       (plist-get context :magent-managed)))
+
 (defun magent-fsm-backend-gptel--managed-info-p (info)
   "Return non-nil when INFO belongs to a Magent-managed request."
-  (and info (plist-get info :magent-managed)))
+  (and info
+       (or (plist-get info :magent-managed)
+           (magent-fsm-backend-gptel--managed-context-p
+            (plist-get info :context)))))
 
 (defun magent-fsm-backend-gptel--final-text (state info)
   "Return the final assistant text assembled from STATE and INFO."
@@ -189,9 +202,73 @@ Both t and `ignore' keep reasoning in STATE.  Only nil discards it."
                do (cl-loop for tc across (plist-get msg :tool_calls)
                            for func = (plist-get tc :function)
                            for name = (and func (plist-get func :name))
-                           when (equal name tool-name)
-                           do (cl-incf count))))
+                            when (equal name tool-name)
+                            do (cl-incf count))))
     count))
+
+(defun magent-fsm-backend-gptel--normalize-name (name &optional fallback)
+  "Return NAME as a JSON-safe tool name string.
+FALLBACK is used when NAME is nil."
+  (magent-json-safe-name name fallback))
+
+(defun magent-fsm-backend-gptel--sanitize-tool-call (tool-call)
+  "Sanitize one gptel TOOL-CALL plist in place and return it."
+  (when (listp tool-call)
+    (when (plist-member tool-call :name)
+      (plist-put tool-call
+                 :name
+                 (magent-fsm-backend-gptel--normalize-name
+                  (plist-get tool-call :name))))
+    (when (plist-member tool-call :args)
+      (plist-put tool-call
+                 :args
+                 (magent-json-safe-tool-args
+                  (plist-get tool-call :args)))))
+  tool-call)
+
+(defun magent-fsm-backend-gptel--sanitize-tool-use (info)
+  "Sanitize gptel INFO's `:tool-use' values in place."
+  (when-let ((tool-use (and info (plist-get info :tool-use))))
+    (dolist (tool-call tool-use)
+      (magent-fsm-backend-gptel--sanitize-tool-call tool-call))))
+
+(defun magent-fsm-backend-gptel--sanitize-assistant-tool-calls (info)
+  "Sanitize assistant tool call history in gptel INFO's request data.
+Some provider/gptel paths preserve raw Lisp symbols in streamed tool call
+metadata.  Emacs 31's native JSON serializer rejects those symbols when gptel
+logs or sends the continuation request, so Magent normalizes this boundary."
+  (let* ((data (and info (plist-get info :data)))
+         (messages (and data (plist-get data :messages))))
+    (when (vectorp messages)
+      (cl-loop for msg across messages
+               when (and (listp msg)
+                         (equal (plist-get msg :role) "assistant")
+                         (vectorp (plist-get msg :tool_calls)))
+               do (cl-loop for tc across (plist-get msg :tool_calls)
+                           do (let ((func (and (listp tc)
+                                               (plist-get tc :function))))
+                                (when (listp func)
+                                  (when (plist-member func :name)
+                                    (plist-put func
+                                               :name
+                                               (magent-fsm-backend-gptel--normalize-name
+                                                (plist-get func :name))))
+                                  (when (plist-member func :arguments)
+                                    (let ((arguments
+                                           (plist-get func :arguments)))
+                                      (unless (stringp arguments)
+                                        (plist-put
+                                         func
+                                         :arguments
+                                         (magent-json-encode
+                                          (magent-json-safe-tool-args
+                                           arguments)))))))))))))
+
+(defun magent-fsm-backend-gptel--sanitize-info (info)
+  "Sanitize gptel INFO structures that may be serialized as JSON."
+  (magent-fsm-backend-gptel--sanitize-tool-use info)
+  (magent-fsm-backend-gptel--sanitize-assistant-tool-calls info)
+  info)
 
 (defun magent-fsm-backend-gptel--emacs-eval-limit-message ()
   "Return the hard-stop message for repeated emacs_eval exploration."
@@ -201,6 +278,87 @@ Both t and `ignore' keep reasoning in STATE.  Only nil discards it."
       (concat "Error: tool_use_limit_reached. emacs_eval exceeded the configured "
               "per-turn limit. Stop exploring and answer the user directly. "
               (magent-fsm--emacs-eval-direct-answer-guidance)))))
+
+(defun magent-fsm-backend-gptel--make-sampling-fsm ()
+  "Create a gptel FSM that stops after one model sampling request.
+Unlike gptel's default request FSM, this does not execute tools or inject
+tool results.  Tool continuation is owned by Magent."
+  (gptel-make-fsm
+   :table `((INIT . ((t . WAIT)))
+            (WAIT . ((t . TYPE)))
+            (TYPE . ((,#'gptel--error-p . ERRS)
+                     (,#'gptel--tool-use-p . TOOL)
+                     (t . DONE)))
+            (TOOL . ((t . DONE))))
+   :handlers `((WAIT ,#'gptel--handle-wait)
+               (TOOL ,#'magent-fsm-backend-gptel--handle-tool-use)
+               (DONE ,#'gptel--handle-post)
+               (ERRS ,#'gptel--handle-post)
+               (ABRT ,#'gptel--handle-post))))
+
+(defun magent-fsm-backend-gptel--handle-tool-use (fsm)
+  "Report pending tool calls from FSM to Magent without running them."
+  (when-let* ((info (gptel-fsm-info fsm))
+              (callback (plist-get info :callback))
+              (tools (plist-get info :tools))
+              (_ (magent-fsm-backend-gptel--sanitize-info info))
+              (tool-use (cl-remove-if (lambda (tc) (plist-get tc :result))
+                                      (plist-get info :tool-use))))
+    (let (pending-calls)
+      (dolist (tool-call tool-use)
+        (let* ((name (plist-get tool-call :name))
+               (tool-spec (cl-find-if
+                           (lambda (ts) (equal (gptel-tool-name ts) name))
+                           tools))
+               (args (plist-get tool-call :args)))
+          (push (list tool-spec args nil tool-call) pending-calls)))
+      (funcall callback (cons 'tool-call (nreverse pending-calls)) info))))
+
+(defun magent-fsm-backend-gptel--map-tool-args (tool-spec args-plist)
+  "Return positional arg values for TOOL-SPEC from ARGS-PLIST."
+  (mapcar
+   (lambda (arg)
+     (plist-get args-plist (intern (concat ":" (plist-get arg :name)))))
+   (gptel-tool-args tool-spec)))
+
+(defun magent-fsm-backend-gptel--normalize-tool-call (call)
+  "Return CALL as (TOOL-SPEC ARG-VALUES CB RAW-CALL)."
+  (let* ((tool-spec (nth 0 call))
+         (raw-args (magent-json-safe-tool-args (nth 1 call)))
+         ;; In Magent-owned continuation mode the provider callback must not
+         ;; be invoked; Magent records the tool result and starts the next
+         ;; sampling request itself.
+         (cb nil)
+         (raw-call (magent-fsm-backend-gptel--sanitize-tool-call
+                    (or (nth 3 call)
+                        (list :name (and (gptel-tool-p tool-spec)
+                                         (gptel-tool-name tool-spec))
+                              :args raw-args))))
+         (arg-values
+          (if (and (gptel-tool-p tool-spec)
+                   (listp raw-args)
+                   (or (keywordp (car raw-args))
+                       (null raw-args)))
+              (magent-fsm-backend-gptel--map-tool-args tool-spec raw-args)
+            raw-args)))
+    (list tool-spec arg-values cb raw-call)))
+
+(defun magent-fsm-backend-gptel--record-tool-result
+    (params tool-spec arg-values raw-call result)
+  "Record TOOL-SPEC RESULT in PARAMS' session for Magent-owned continuation."
+  (when-let ((session (plist-get params :session)))
+    (magent-session-add-tool-message
+     session
+     (or (plist-get raw-call :id)
+         (magent-events-generate-id))
+     (if (gptel-tool-p tool-spec)
+         (gptel-tool-name tool-spec)
+       (or (plist-get raw-call :name) "unknown"))
+     (magent-json-safe-tool-args
+      (if (gptel-tool-p tool-spec)
+          (magent-fsm--args-to-plist (gptel-tool-args tool-spec) arg-values)
+        (or (plist-get raw-call :args) nil)))
+     result)))
 
 (defun magent-fsm-backend-gptel-create (&rest args)
   "Create gptel FSM from keyword ARGS (returns plist with parameters).
@@ -219,6 +377,8 @@ Accepts the same keyword arguments as `magent-fsm-create'."
         :request-state (plist-get args :request-state)
         :abort-controller (magent-fsm--abort-controller-create)
         :tool-queue nil
+        :tool-guard-state nil
+        :tool-round-count 0
         :request-buffer nil
         :live-p (plist-get args :live-p)
         :callback (plist-get args :callback)
@@ -226,7 +386,10 @@ Accepts the same keyword arguments as `magent-fsm-create'."
 
 (defun magent-fsm-backend-gptel-start (params)
   "Start gptel request with PARAMS plist."
-  (let* ((prompt-list (plist-get params :prompt-list))
+  (let* ((session (plist-get params :session))
+         (prompt-list (if session
+                          (magent-session-to-gptel-prompt-list session)
+                        (plist-get params :prompt-list)))
          (system-prompt (plist-get params :system-prompt))
          (tools (plist-get params :tools))
          (event-context (plist-get params :event-context))
@@ -242,7 +405,8 @@ Accepts the same keyword arguments as `magent-fsm-create'."
          (request-buffer (generate-new-buffer " *magent-gptel-request*"))
          (tool-queue (or (plist-get params :tool-queue)
                          (magent-fsm--tool-queue-create)))
-         (tool-guard-state (magent-fsm--tool-guard-state-create))
+         (tool-guard-state (or (plist-get params :tool-guard-state)
+                               (magent-fsm--tool-guard-state-create)))
          (max-tool-rounds (plist-get params :max-tool-rounds))
          ;; Install permission-aware :confirm functions and handle
          ;; `(tool-call . ...)' callbacks ourselves instead of relying on
@@ -251,15 +415,20 @@ Accepts the same keyword arguments as `magent-fsm-create'."
                         (magent-fsm--convert-tools-to-gptel
                          tools permission request-state event-context
                          abort-controller tool-queue)))
-         (stream-state (magent-fsm-backend-gptel--make-stream-state)))
+         (stream-state (or (plist-get params :stream-state)
+                           (magent-fsm-backend-gptel--make-stream-state))))
 
     (plist-put params :request-buffer request-buffer)
     (plist-put params :tool-queue tool-queue)
+    (plist-put params :tool-guard-state tool-guard-state)
+    (plist-put params :stream-state stream-state)
     (when request-state
       (setf (magent-request-context-abort-controller request-state)
             abort-controller))
 
-    (when (magent-fsm-backend-gptel--ui-visible-p request-state)
+    (when (and (magent-fsm-backend-gptel--ui-visible-p request-state)
+               (not (plist-get params :streaming-started)))
+      (plist-put params :streaming-started t)
       (magent-ui-start-streaming))
     (magent-events-emit
      'llm-request-start
@@ -276,25 +445,31 @@ Accepts the same keyword arguments as `magent-fsm-create'."
       (setq-local gptel-model model)
       (setq-local gptel-tools gptel-tools)
       (setq-local gptel-use-tools (and gptel-tools t))
-      (setq-local gptel-confirm-tool-calls 'auto)
+      ;; Magent owns tool execution and continuation.  gptel only exposes
+      ;; parsed tool-call requests for this sampling request.
+      (setq-local gptel-confirm-tool-calls t)
       (setq-local gptel-include-reasoning magent-include-reasoning)
       (let* ((gptel-fsm
               (gptel-request
                   prompt-list
                 :buffer (current-buffer)
+                :context (list :magent-managed t
+                               :magent-request-id request-id)
                 :system system-prompt
                 :stream t
+                :fsm (magent-fsm-backend-gptel--make-sampling-fsm)
                 :callback (lambda (response info)
                             (magent-fsm-backend-gptel--callback
                              response info callback ui-callback request-buffer
                              permission event-context request-state stream-state
-                             request-id backend model live-p))))
+                             request-id backend model live-p params))))
              (info (and (gptel-fsm-p gptel-fsm)
                         (gptel-fsm-info gptel-fsm))))
         (when info
           (plist-put info :magent-managed t)
           (plist-put info :magent-request-id request-id)
-          (plist-put info :magent-tool-round-count 0)
+          (plist-put info :magent-tool-round-count
+                     (or (plist-get params :tool-round-count) 0))
           (when (numberp max-tool-rounds)
             (plist-put info :magent-tool-round-limit max-tool-rounds)))))))
 
@@ -303,11 +478,12 @@ Accepts the same keyword arguments as `magent-fsm-create'."
                                                     &optional request-state
                                                     stream-state
                                                     request-id backend model
-                                                    live-p)
+                                                    live-p params)
   "Handle gptel response.
 Wraps all UI operations in `condition-case' to suppress benign
 cursor-boundary signals that can leak from evil-mode adjustments
 inside gptel's process filter."
+  (magent-fsm-backend-gptel--sanitize-info info)
   (if (not (magent-fsm-backend-gptel--request-live-p live-p))
       (progn
         (magent-log "DEBUG discarding stale gptel callback request=%s response=%S"
@@ -346,8 +522,69 @@ inside gptel's process filter."
               (funcall ui-callback response)))
            ((and (consp response) (eq (car response) 'tool-call))
             (magent-fsm-backend-gptel--close-reasoning-block state request-state)
-            (magent-fsm--handle-tool-call-confirmation-with-permission
-             permission (cdr response) request-state))
+            (if (null params)
+                (magent-fsm--handle-tool-call-confirmation-with-permission
+                 permission (cdr response) request-state)
+              (when (buffer-live-p buffer)
+                (kill-buffer buffer))
+              (when (magent-fsm-backend-gptel--ui-visible-p request-state)
+                (magent-ui-continue-streaming))
+              (let* ((tool-calls (mapcar
+                                  #'magent-fsm-backend-gptel--normalize-tool-call
+                                  (cdr response)))
+                     (round (1+ (or (plist-get params :tool-round-count) 0)))
+                     (limit (plist-get params :max-tool-rounds)))
+                (plist-put params :tool-round-count round)
+                (if (and (numberp limit) (> round limit))
+                    (let ((message
+                           (format "Error: tool loop exceeded %d round%s. The model kept requesting more tools instead of answering."
+                                   limit
+                                   (if (= limit 1) "" "s"))))
+                      (magent-log "WARN aborting Magent-owned tool loop count=%s limit=%s"
+                                  round limit)
+                      (when (and ui-callback
+                                 (magent-fsm-backend-gptel--ui-visible-p request-state))
+                        (funcall ui-callback message))
+                      (when (magent-fsm-backend-gptel--ui-visible-p request-state)
+                        (magent-ui-finish-streaming-fontify))
+                      (when callback
+                        (funcall callback message)))
+                  (let ((unknown-calls (cl-remove-if
+                                        (lambda (tc)
+                                          (gptel-tool-p (car tc)))
+                                        tool-calls)))
+                    (dolist (tc unknown-calls)
+                      (let* ((raw-call (nth 3 tc))
+                             (name (or (plist-get raw-call :name) "unknown"))
+                             (available
+                              (mapconcat
+                               (lambda (tool)
+                                 (if (gptel-tool-p tool)
+                                     (gptel-tool-name tool)
+                                   "unknown"))
+                               (delq nil (mapcar #'car tool-calls))
+                               ", "))
+                             (result
+                              (format "Error: tool '%s' not found. Available: %s"
+                                      name available)))
+                        (magent-log "WARN unknown tool '%s'(id=%S) — returned error to model"
+                                    name (plist-get raw-call :id))
+                        (magent-fsm-backend-gptel--record-tool-result
+                         params nil (nth 1 tc) raw-call result)))
+                    (setq tool-calls (cl-remove-if-not
+                                      (lambda (tc)
+                                        (gptel-tool-p (car tc)))
+                                      tool-calls))
+                    (when (null tool-calls)
+                      (magent-fsm-backend-gptel-start params)))
+                  (when tool-calls
+                  (magent-fsm--handle-tool-call-confirmation-with-permission
+                   permission tool-calls request-state
+                   (lambda (tool-spec arg-values raw-call result)
+                     (magent-fsm-backend-gptel--record-tool-result
+                      params tool-spec arg-values raw-call result))
+                   (lambda ()
+                     (magent-fsm-backend-gptel-start params))))))))
            ((and (consp response) (eq (car response) 'tool-result))
             (magent-fsm-backend-gptel--close-reasoning-block state request-state)
             (magent-log "DEBUG tool-result received stop-reason=%S"
@@ -379,10 +616,11 @@ inside gptel's process filter."
                :model (format "%s" model)
                (magent-fsm-backend-gptel--usage-plist info final-text))
               (if (plist-get info :tool-use)
-                  ;; Tool use round: gptel will continue the loop.
-                  ;; Stay in the same section — don't finalize or create a new heading.
-                  (when (magent-fsm-backend-gptel--ui-visible-p request-state)
-                    (magent-ui-continue-streaming))
+                  ;; Tool-use sampling round: the TOOL handler will dispatch
+                  ;; Magent-owned tools and continue the turn.
+                  (unless params
+                    (when (magent-fsm-backend-gptel--ui-visible-p request-state)
+                      (magent-ui-continue-streaming)))
                 ;; Final response: finalize the streaming section and finish.
                 (when (magent-fsm-backend-gptel--ui-visible-p request-state)
                   (magent-ui-finish-streaming-fontify))
@@ -472,6 +710,26 @@ silent empty final response (Variant A of the qwen3-max empty-response
 
 (advice-add 'gptel--handle-wait :before #'magent--reset-reasoning-block-a)
 
+;;; Advice to keep Magent-managed gptel request data JSON-safe
+
+(defun magent--sanitize-request-data-before-curl-a (orig-fn info &rest args)
+  "Sanitize Magent-managed INFO before gptel serializes request data."
+  (when (magent-fsm-backend-gptel--managed-info-p info)
+    (magent-fsm-backend-gptel--sanitize-info info))
+  (apply orig-fn info args))
+
+(advice-add 'gptel-curl--get-args
+            :around #'magent--sanitize-request-data-before-curl-a)
+
+(defun magent--sanitize-stream-data-after-parse-a (orig-fn backend info)
+  "Sanitize Magent-managed INFO after gptel parses streamed tool calls."
+  (prog1 (funcall orig-fn backend info)
+    (when (magent-fsm-backend-gptel--managed-info-p info)
+      (magent-fsm-backend-gptel--sanitize-info info))))
+
+(advice-add 'gptel-curl--parse-stream
+            :around #'magent--sanitize-stream-data-after-parse-a)
+
 ;;; Unknown-tool advice for gptel FSM
 
 (defun magent--handle-unknown-tools-a (orig-fn fsm)
@@ -482,6 +740,7 @@ preventing the FSM from hanging when the model hallucinates tool names."
          (patched nil))
     (if (not (magent-fsm-backend-gptel--managed-info-p info))
         (funcall orig-fn fsm)
+      (magent-fsm-backend-gptel--sanitize-info info)
       (if (magent-fsm-backend-gptel--tool-round-limit-reached-p info)
         (magent-fsm-backend-gptel--abort-tool-loop fsm info)
         (when-let* ((all-tool-use (plist-get info :tool-use))

--- a/magent-session.el
+++ b/magent-session.el
@@ -44,12 +44,23 @@
   "Return the content of message MSG (string or content-block list)."
   (cdr (assq 'content msg)))
 
+(defun magent-session--tool-content-p (content)
+  "Return non-nil when CONTENT is a structured tool-call result."
+  (and (listp content)
+       (plist-member content :name)
+       (plist-member content :result)))
+
 (defsubst magent-session--content-to-string (content)
   "Coerce CONTENT to a plain string.
 If CONTENT is a string, return it unchanged.
 If CONTENT is a list of content blocks, concatenate their text fields."
-  (if (stringp content) content
-    (mapconcat (lambda (b) (or (cdr (assq 'text b)) "")) content "")))
+  (cond
+   ((stringp content) content)
+   ((magent-session--tool-content-p content)
+    (or (plist-get content :result) ""))
+   ((listp content)
+    (mapconcat (lambda (b) (or (cdr (assq 'text b)) "")) content ""))
+   (t "")))
 
 (defun magent-session--assistant-response-reusable-p (content)
   "Return non-nil when assistant CONTENT should be reused in prompts.
@@ -339,7 +350,16 @@ Fall back to the file modification time for legacy filenames."
   (let ((role (magent-msg-role msg))
         (content (magent-msg-content msg)))
     `((role . ,(symbol-name role))
-      (content . ,(magent-session--content-to-string content)))))
+      (content . ,(if (and (eq role 'tool)
+                           (magent-session--tool-content-p content))
+                      `((id . ,(plist-get content :id))
+                        (name . ,(magent-json-safe-name
+                                  (plist-get content :name)))
+                        (args-json . ,(magent-json-encode
+                                       (magent-json-safe-tool-args
+                                        (plist-get content :args))))
+                        (result . ,(plist-get content :result)))
+                    (magent-session--content-to-string content))))))
 
 (defun magent-session--context-item-to-alist (item)
   "Convert structured context ITEM to a JSON-serializable alist."
@@ -353,7 +373,22 @@ Fall back to the file modification time for legacy filenames."
   "Reconstruct a session message from JSON-decoded ALIST."
   (let ((role (intern (cdr (assq 'role alist))))
         (content (cdr (assq 'content alist))))
-    `((role . ,role) (content . ,content))))
+    `((role . ,role)
+      (content . ,(if (and (eq role 'tool)
+                           (listp content))
+                      (let* ((args-json (cdr (assq 'args-json content)))
+                             (args (when (and (stringp args-json)
+                                              (> (length args-json) 0))
+                                     (let ((json-object-type 'plist)
+                                           (json-array-type 'list))
+                                       (ignore-errors
+                                         (json-read-from-string args-json))))))
+                        (list :id (cdr (assq 'id content))
+                              :name (magent-json-safe-name
+                                     (cdr (assq 'name content)))
+                              :args args
+                              :result (cdr (assq 'result content))))
+                    content)))))
 
 (defun magent-session-save ()
   "Save the current session to disk as <session-id>.json.
@@ -552,6 +587,17 @@ Non-message items are retained only after the retained message boundary."
         (nthcdr start items)
       items)))
 
+(defun magent-session-add-tool-message (session id name args result)
+  "Add a structured tool result message to SESSION.
+ID is the provider tool-call id, NAME is the tool name, ARGS is the
+tool argument plist, and RESULT is the model-visible tool result."
+  (magent-session-add-message
+   session 'tool
+   (list :id id
+         :name (magent-json-safe-name name)
+         :args (magent-json-safe-tool-args args)
+         :result (if (stringp result) result (format "%s" result)))))
+
 (defun magent-session-get-messages (session)
   "Get all messages from SESSION in chronological order."
   ;; Messages are now stored in chronological order, no reverse needed
@@ -581,8 +627,8 @@ Returns a condensed version of the conversation."
   "Convert SESSION messages to a gptel-request prompt list.
 Returns a list in gptel's advanced format:
   ((prompt . \"user msg\") (response . \"assistant msg\") ...)
-Tool result messages are skipped; gptel handles tool round-trips
-internally within each request.
+Structured tool result messages are emitted as `(tool . PLIST)' entries so
+gptel can serialize historical tool calls/results for the active backend.
 
 Only completed turns are reused.  When an assistant reply is empty or a
 synthetic error string, Magent drops both that reply and its paired user
@@ -590,24 +636,50 @@ prompt from future prompt reuse.  The final pending user prompt is still
 included so the current turn is preserved."
   (let ((messages (magent-session-get-messages session))
         pending-user
+        pending-tools
         prompt-list)
-    (dolist (msg messages)
-      (let ((role (magent-msg-role msg))
-            (content (magent-msg-content msg)))
-        (pcase role
-          ('user
-           (setq pending-user (magent-session--content-to-string content)))
-          ('assistant
-           (when pending-user
-             (if (magent-session--assistant-response-reusable-p content)
-                 (let ((assistant-text (magent-session--content-to-string content)))
-                   (push (cons 'prompt pending-user) prompt-list)
-                   (push (cons 'response assistant-text) prompt-list))
-               (magent-log "INFO dropping failed session turn from prompt reuse")))
-           (setq pending-user nil))
-          (_ nil))))
+    (cl-labels
+        ((append-pending-turn
+          (assistant-content)
+          (when pending-user
+            (if (magent-session--assistant-response-reusable-p assistant-content)
+                (progn
+                  (push (cons 'prompt pending-user) prompt-list)
+                  (dolist (tool (nreverse pending-tools))
+                    (push (cons 'tool tool) prompt-list))
+                  (push (cons 'response
+                              (magent-session--content-to-string assistant-content))
+                        prompt-list))
+              (magent-log "INFO dropping failed session turn from prompt reuse")))
+          (setq pending-user nil
+                pending-tools nil)))
+      (dolist (msg messages)
+        (let ((role (magent-msg-role msg))
+             (content (magent-msg-content msg)))
+          (pcase role
+            ('user
+             (setq pending-user (magent-session--content-to-string content)
+                   pending-tools nil))
+            ('tool
+             (when (and pending-user
+                        (magent-session--tool-content-p content))
+               (let ((tool (copy-sequence content)))
+                 (plist-put tool
+                            :name
+                            (magent-json-safe-name
+                             (plist-get content :name)))
+                 (plist-put tool
+                            :args
+                            (magent-json-safe-tool-args
+                             (plist-get content :args)))
+                 (push tool pending-tools))))
+            ('assistant
+             (append-pending-turn content))
+            (_ nil)))))
     (when pending-user
-      (push (cons 'prompt pending-user) prompt-list))
+      (push (cons 'prompt pending-user) prompt-list)
+      (dolist (tool (nreverse pending-tools))
+        (push (cons 'tool tool) prompt-list)))
     (nreverse prompt-list)))
 
 (provide 'magent-session)

--- a/magent-tool-orchestrator.el
+++ b/magent-tool-orchestrator.el
@@ -28,7 +28,9 @@
   audit-function
   file-arg-index-function
   args-to-plist-function
-  summarize-function)
+  summarize-function
+  result-callback
+  done-callback)
 
 (defun magent-tool-orchestrator--approval-session (request-context)
   "Return approval session for REQUEST-CONTEXT."
@@ -49,6 +51,12 @@
   (funcall (magent-tool-orchestrator-run-tool-function orchestrator)
            tool-spec cb arg-values))
 
+(defun magent-tool-orchestrator--finish-one
+    (orchestrator tool-spec arg-values raw-call result)
+  "Record one tool RESULT through ORCHESTRATOR callbacks."
+  (when-let ((fn (magent-tool-orchestrator-result-callback orchestrator)))
+    (funcall fn tool-spec arg-values raw-call result)))
+
 (defun magent-tool-orchestrator--file-arg-index (orchestrator args-spec)
   "Return file arg index for ARGS-SPEC using ORCHESTRATOR."
   (when-let ((fn (magent-tool-orchestrator-file-arg-index-function orchestrator)))
@@ -68,26 +76,45 @@
 
 (defun magent-tool-orchestrator-handle-tool-calls (orchestrator tool-calls)
   "Handle TOOL-CALLS using ORCHESTRATOR.
-TOOL-CALLS follows gptel's `(TOOL-SPEC ARG-VALUES CALLBACK)' shape."
+TOOL-CALLS follows gptel's `(TOOL-SPEC ARG-VALUES CALLBACK RAW-CALL)' shape."
   (let* ((permission (magent-tool-orchestrator-permission orchestrator))
          (request-context (magent-tool-orchestrator-request-context orchestrator))
          (approval-session
-          (magent-tool-orchestrator--approval-session request-context)))
+          (magent-tool-orchestrator--approval-session request-context))
+         (remaining (length tool-calls)))
+    (cl-labels ((complete-one
+                 (tool-spec arg-values raw-call result)
+                 (magent-tool-orchestrator--finish-one
+                  orchestrator tool-spec arg-values raw-call result)
+                 (cl-decf remaining)
+                 (when (and (<= remaining 0)
+                            (magent-tool-orchestrator-done-callback
+                             orchestrator))
+                   (funcall (magent-tool-orchestrator-done-callback
+                             orchestrator)))))
     (if (magent-permission-bypass-p)
         (dolist (tc tool-calls)
           (let* ((tool-spec (car tc))
                  (arg-values (cadr tc))
                  (cb (caddr tc))
+                 (raw-call (nth 3 tc))
                  (tool-name (gptel-tool-name tool-spec)))
             (magent-log "PERM bypass allow: %s" tool-name)
             (magent-tool-orchestrator--call-audit
              orchestrator tool-spec arg-values 'allow 'bypass)
-            (magent-tool-orchestrator--run orchestrator tool-spec cb arg-values)))
+            (magent-tool-orchestrator--run
+             orchestrator tool-spec
+             (lambda (result)
+               (when cb
+                 (funcall cb result))
+               (complete-one tool-spec arg-values raw-call result))
+             arg-values)))
       (let (pending)
         (dolist (tc tool-calls)
           (let* ((tool-spec (car tc))
                  (arg-values (cadr tc))
                  (cb (caddr tc))
+                 (raw-call (nth 3 tc))
                  (tool-name (gptel-tool-name tool-spec))
                  (perm-key (magent-tools-permission-key tool-name))
                  (file-path
@@ -97,7 +124,7 @@ TOOL-CALLS follows gptel's `(TOOL-SPEC ARG-VALUES CALLBACK)' shape."
                                 (gptel-tool-args tool-spec))))
                       (when idx
                         (nth idx arg-values)))))
-                 (resolved (when (and permission perm-key)
+                 (resolved (when perm-key
                              (magent-permission-resolve
                               permission perm-key file-path)))
                  (override (when perm-key
@@ -117,35 +144,65 @@ TOOL-CALLS follows gptel's `(TOOL-SPEC ARG-VALUES CALLBACK)' shape."
               (magent-tool-orchestrator--call-audit
                orchestrator tool-spec arg-values
                'allow 'session-override-allow)
-              (magent-tool-orchestrator--run orchestrator tool-spec cb arg-values))
+              (magent-tool-orchestrator--run
+               orchestrator tool-spec
+               (lambda (result)
+                 (when cb
+                   (funcall cb result))
+                 (complete-one tool-spec arg-values raw-call result))
+               arg-values))
              ((eq override 'deny)
               (magent-log "PERM auto-deny (session override): %s" tool-name)
               (magent-tool-orchestrator--call-audit
                orchestrator tool-spec arg-values
                'deny 'session-override-deny)
-              (funcall cb (format "Error: tool '%s' denied by session policy"
-                                  tool-name)))
+              (let ((result (format "Error: tool '%s' denied by session policy"
+                                    tool-name)))
+                (when cb
+                  (funcall cb result))
+                (complete-one tool-spec arg-values raw-call result)))
              ((eq resolved 'deny)
               (magent-log "PERM auto-deny (file rule): %s %s"
                           tool-name (or file-path ""))
               (magent-tool-orchestrator--call-audit
                orchestrator tool-spec arg-values 'deny 'file-rule-deny)
-              (funcall cb (format "Error: access denied for %s on %s"
-                                  tool-name
-                                  (or file-path "this resource"))))
+              (let ((result (format "Error: access denied for %s on %s"
+                                    tool-name
+                                    (or file-path "this resource"))))
+                (when cb
+                  (funcall cb result))
+                (complete-one tool-spec arg-values raw-call result)))
              ((and file-path (eq resolved 'allow))
               (magent-log "PERM auto-allow (file rule): %s %s"
                           tool-name file-path)
               (magent-tool-orchestrator--call-audit
                orchestrator tool-spec arg-values 'allow 'file-rule-allow)
-              (magent-tool-orchestrator--run orchestrator tool-spec cb arg-values))
+              (magent-tool-orchestrator--run
+               orchestrator tool-spec
+               (lambda (result)
+                 (when cb
+                   (funcall cb result))
+                 (complete-one tool-spec arg-values raw-call result))
+               arg-values))
+             ((eq resolved 'allow)
+              (magent-log "PERM auto-allow: %s" tool-name)
+              (magent-tool-orchestrator--call-audit
+               orchestrator tool-spec arg-values 'allow 'rule-allow)
+              (magent-tool-orchestrator--run
+               orchestrator tool-spec
+               (lambda (result)
+                 (when cb
+                   (funcall cb result))
+                 (complete-one tool-spec arg-values raw-call result))
+               arg-values))
              (t
               (push tc pending)))))
         (when pending
           (magent-tool-orchestrator-prompt-next
-           orchestrator (nreverse pending)))))))
+           orchestrator (nreverse pending) #'complete-one)))))))
 
-(defun magent-tool-orchestrator-prompt-next (orchestrator tool-calls)
+(defun magent-tool-orchestrator-prompt-next
+    (orchestrator tool-calls &optional complete-one)
   "Prompt for TOOL-CALLS one by one through ORCHESTRATOR."
   (when tool-calls
     (let* ((tc (car tool-calls))
@@ -153,6 +210,7 @@ TOOL-CALLS follows gptel's `(TOOL-SPEC ARG-VALUES CALLBACK)' shape."
            (tool-spec (car tc))
            (arg-values (cadr tc))
            (cb (caddr tc))
+           (raw-call (nth 3 tc))
            (tool-name (gptel-tool-name tool-spec))
            (perm-key (magent-tools-permission-key tool-name))
            (request-context
@@ -177,12 +235,23 @@ TOOL-CALLS follows gptel's `(TOOL-SPEC ARG-VALUES CALLBACK)' shape."
             (magent-log "PERM user allowed (once): %s" tool-name)
             (magent-tool-orchestrator--call-audit
              orchestrator tool-spec arg-values 'allow 'user-allow-once)
-            (magent-tool-orchestrator--run orchestrator tool-spec cb arg-values))
+            (magent-tool-orchestrator--run
+             orchestrator tool-spec
+             (lambda (result)
+               (when cb
+                 (funcall cb result))
+               (when complete-one
+                 (funcall complete-one tool-spec arg-values raw-call result)))
+             arg-values))
            ('deny-once
             (magent-log "PERM user denied (once): %s" tool-name)
             (magent-tool-orchestrator--call-audit
              orchestrator tool-spec arg-values 'deny 'user-deny-once)
-            (funcall cb (format "Error: tool '%s' denied by user" tool-name)))
+            (let ((result (format "Error: tool '%s' denied by user" tool-name)))
+              (when cb
+                (funcall cb result))
+              (when complete-one
+                (funcall complete-one tool-spec arg-values raw-call result))))
            ('allow-session
             (magent-log "PERM user always-allow: %s" tool-name)
             (when perm-key
@@ -190,7 +259,14 @@ TOOL-CALLS follows gptel's `(TOOL-SPEC ARG-VALUES CALLBACK)' shape."
                perm-key 'allow approval-session))
             (magent-tool-orchestrator--call-audit
              orchestrator tool-spec arg-values 'allow 'user-allow-session)
-            (magent-tool-orchestrator--run orchestrator tool-spec cb arg-values))
+            (magent-tool-orchestrator--run
+             orchestrator tool-spec
+             (lambda (result)
+               (when cb
+                 (funcall cb result))
+               (when complete-one
+                 (funcall complete-one tool-spec arg-values raw-call result)))
+             arg-values))
            ('deny-session
             (magent-log "PERM user always-deny: %s" tool-name)
             (when perm-key
@@ -198,8 +274,13 @@ TOOL-CALLS follows gptel's `(TOOL-SPEC ARG-VALUES CALLBACK)' shape."
                perm-key 'deny approval-session))
             (magent-tool-orchestrator--call-audit
              orchestrator tool-spec arg-values 'deny 'user-deny-session)
-            (funcall cb (format "Error: tool '%s' denied by user" tool-name))))
-         (magent-tool-orchestrator-prompt-next orchestrator rest))))))
+            (let ((result (format "Error: tool '%s' denied by user" tool-name)))
+              (when cb
+                (funcall cb result))
+              (when complete-one
+                (funcall complete-one tool-spec arg-values raw-call result)))))
+         (magent-tool-orchestrator-prompt-next
+          orchestrator rest complete-one))))))
 
 (provide 'magent-tool-orchestrator)
 ;;; magent-tool-orchestrator.el ends here

--- a/magent-ui.el
+++ b/magent-ui.el
@@ -59,7 +59,6 @@
 (declare-function magent-session--session-for-scope "magent-session")
 
 ;; Forward declarations for evil (loaded via with-eval-after-load)
-(declare-function evil-define-key "evil-core")
 (declare-function evil-define-key* "evil-core")
 (declare-function evil-visual-state-p "evil-states")
 (declare-function evil-insert-state "evil-states")
@@ -628,7 +627,14 @@ Skips keys already reserved by the static parts of `magent-transient-menu'."
   "Keymap for `magent-output-mode'.")
 
 (with-eval-after-load 'evil
-  (evil-define-key 'normal magent-output-mode-map (kbd "?") #'magent-transient-menu))
+  (evil-define-key* 'normal magent-output-mode-map
+    (kbd "?") #'magent-transient-menu)
+  (evil-define-key* 'normal magent-output-mode-map
+    (kbd "C-g") #'magent-interrupt)
+  (evil-define-key* '(insert replace) magent-output-mode-map
+    (kbd "C-g") #'evil-normal-state)
+  (evil-define-key* '(visual motion operator emacs) magent-output-mode-map
+    (kbd "C-g") #'keyboard-quit))
 
 (define-derived-mode magent-output-mode org-mode "M"
   "Major mode for Magent output.
@@ -954,7 +960,8 @@ Wraps in #+begin_tool block."
                       (if (stringp input)
                           input
                         (truncate-string-to-width
-                         (json-encode input) magent-ui-tool-input-max-length nil nil "...")))))
+                         (magent-json-encode input)
+                         magent-ui-tool-input-max-length nil nil "...")))))
       (insert (propertize input-str 'face 'magent-tool-args) "\n"))))
 
 (defun magent-ui-insert-tool-result (_tool-name result)

--- a/test/magent-live-test.el
+++ b/test/magent-live-test.el
@@ -1,0 +1,490 @@
+;;; magent-live-test.el --- Live Emacs tests for Magent  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; These tests run inside an already running Emacs instance via emacsclient.
+;; The :magent-live tests use the real gptel provider configured in that
+;; Emacs instance and may consume tokens.  The :magent-live-smoke tests keep a
+;; deterministic stub transport while still exercising live timers, buffers,
+;; mode state, and asynchronous callbacks.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'ert)
+(require 'subr-x)
+
+(defconst magent-live-test--root-directory
+  (expand-file-name ".."
+                    (file-name-directory (or load-file-name buffer-file-name)))
+  "Repository root for the live test suite.")
+
+(defvar magent-live-test--latest-results nil
+  "Result records from the most recent live ERT run.")
+
+(defun magent-live-test--add-load-path (directory)
+  "Add DIRECTORY to `load-path' when it exists."
+  (when (and directory (file-directory-p directory))
+    (add-to-list 'load-path (file-truename directory))))
+
+(defun magent-live-test--first-elpa-directory (pattern)
+  "Return the first ELPA directory matching PATTERN, or nil."
+  (let ((elpa-dir (expand-file-name "elpa" user-emacs-directory)))
+    (when (file-directory-p elpa-dir)
+      (car (directory-files elpa-dir t pattern t)))))
+
+(defun magent-live-test--prepare-load-path ()
+  "Add the repo and package dependency directories to `load-path'."
+  (magent-live-test--add-load-path magent-live-test--root-directory)
+  (dolist (pattern '("\\`gptel-[0-9]"
+                     "\\`magit-[0-9]"
+                     "\\`magit-section-"
+                     "\\`spinner-"
+                     "\\`transient-"
+                     "\\`cond-let-"
+                     "\\`evil-"
+                     "\\`yaml-[0-9]"
+                     "\\`llama-"
+                     "\\`with-editor-"))
+    (magent-live-test--add-load-path
+     (magent-live-test--first-elpa-directory pattern))))
+
+(defun magent-live-test--remove-fsm-advice-before-reload ()
+  "Remove Magent FSM advice before reloading source files."
+  (when (and (fboundp 'gptel--handle-wait)
+             (fboundp 'magent--reset-reasoning-block-a))
+    (advice-remove 'gptel--handle-wait #'magent--reset-reasoning-block-a))
+  (when (and (fboundp 'gptel--handle-tool-use)
+             (fboundp 'magent--handle-unknown-tools-a))
+    (advice-remove 'gptel--handle-tool-use #'magent--handle-unknown-tools-a))
+  (when (and (fboundp 'gptel-curl--get-args)
+             (fboundp 'magent--sanitize-request-data-before-curl-a))
+    (advice-remove 'gptel-curl--get-args
+                   #'magent--sanitize-request-data-before-curl-a))
+  (when (and (fboundp 'gptel-curl--parse-stream)
+             (fboundp 'magent--sanitize-stream-data-after-parse-a))
+    (advice-remove 'gptel-curl--parse-stream
+                   #'magent--sanitize-stream-data-after-parse-a)))
+
+(defun magent-live-test--load-source-file (file)
+  "Load FILE from the repository root, bypassing stale .elc files."
+  (load (expand-file-name file magent-live-test--root-directory) nil t))
+
+(defun magent-live-test-reload-source ()
+  "Reload Magent source files into the live Emacs instance."
+  (interactive)
+  (magent-live-test--prepare-load-path)
+  (magent-live-test--remove-fsm-advice-before-reload)
+  (dolist (file '("magent-config.el"
+                  "magent-events.el"
+                  "magent-audit.el"
+                  "magent-session.el"
+                  "magent-approval.el"
+                  "magent-file-loader.el"
+                  "magent-runtime.el"
+                  "magent-agent-registry.el"
+                  "magent-agent-info.el"
+                  "magent-agent-types.el"
+                  "magent-permission.el"
+                  "magent-tools.el"
+                  "magent-agent-file.el"
+                  "magent-md2org.el"
+                  "magent-fsm-tools.el"
+                  "magent-fsm.el"
+                  "magent-agent.el"
+                  "magent-skills.el"
+                  "magent-capability.el"
+                  "magent-ui.el"
+                  "magent.el"))
+    (magent-live-test--load-source-file file)))
+
+(defun magent-live-test--wait-until (predicate &optional timeout message)
+  "Wait until PREDICATE returns non-nil, or fail after TIMEOUT seconds."
+  (let ((deadline (+ (float-time) (or timeout 5.0)))
+        value)
+    (while (and (not (setq value (funcall predicate)))
+                (< (float-time) deadline))
+      (accept-process-output nil 0.05)
+      (redisplay))
+    (unless value
+      (ert-fail (or message "Timed out waiting for live Magent condition")))
+    value))
+
+(defun magent-live-test--debug-state ()
+  "Return compact live Magent state for assertion failures."
+  (format "processing=%S current-scope=%S magent-buffer=%S log-tail=%S"
+          (and (fboundp 'magent-ui-processing-p)
+               (magent-ui-processing-p))
+          (and (fboundp 'magent-session-current-scope)
+               (magent-session-current-scope))
+          (when (fboundp 'magent-ui-get-buffer)
+            (let ((buffer (magent-ui-get-buffer (magent-session-current-scope))))
+              (when (buffer-live-p buffer)
+                (with-current-buffer buffer
+                  (buffer-substring-no-properties
+                   (max (point-min) (- (point-max) 1200))
+                   (point-max))))))
+          (when (and (boundp 'magent-log-buffer-name)
+                     (get-buffer magent-log-buffer-name))
+            (with-current-buffer magent-log-buffer-name
+              (buffer-substring-no-properties
+               (max (point-min) (- (point-max) 1200))
+               (point-max))))))
+
+(defun magent-live-test--wait-for-assistant (&optional timeout)
+  "Wait for a completed assistant message and return its text."
+  (magent-live-test--wait-until
+   (lambda ()
+     (let* ((session (magent-session-get))
+            (messages (magent-session-get-messages session))
+            (last-msg (car (last messages)))
+            (content (and last-msg (magent-msg-content last-msg))))
+       (and (not (magent-ui-processing-p))
+            (eq (and last-msg (magent-msg-role last-msg)) 'assistant)
+            (stringp content)
+            (not (string-empty-p (string-trim content)))
+            content)))
+   (or timeout 120)
+   (format "Timed out waiting for a live assistant response: %s"
+           (magent-live-test--debug-state))))
+
+(defun magent-live-test--require-real-gptel ()
+  "Fail with a clear message unless live gptel is configured."
+  (require 'gptel)
+  (unless (and (boundp 'gptel-backend) gptel-backend)
+    (ert-fail "No live `gptel-backend' is configured in the running Emacs"))
+  (unless (and (boundp 'gptel-model) gptel-model)
+    (ert-fail "No live `gptel-model' is configured in the running Emacs")))
+
+(defun magent-live-test--kill-magent-test-buffers ()
+  "Kill live-test Magent buffers left by previous runs."
+  (dolist (buffer (buffer-list))
+    (when (string-prefix-p "*magent-live-test" (buffer-name buffer))
+      (kill-buffer buffer))))
+
+(defmacro magent-live-test--with-isolated-runtime (&rest body)
+  "Run BODY with isolated Magent session, audit, and UI state."
+  (declare (indent 0))
+  `(let* ((magent-buffer-name "*magent-live-test*")
+          (magent-log-buffer-name "*magent-live-test-log*")
+          (magent-audit-buffer-name "*magent-live-test-audit*")
+          (magent-session-directory (make-temp-file "magent-live-sessions-" t))
+          (magent-audit-directory (make-temp-file "magent-live-audit-" t))
+          (magent-enable-audit-log nil)
+          (magent-enable-capabilities nil)
+          (magent-auto-context nil)
+          (magent-auto-scroll nil)
+          (magent-by-pass-permission nil)
+          (magent-ui-batch-insert-delay 0.01)
+          (magent-ui--processing nil)
+          (magent-ui--request-generation 0)
+          (magent--current-fsm nil)
+          (magent--current-session nil)
+          (magent-session--current-scope 'global)
+          (magent-session--scoped-sessions (make-hash-table :test #'equal))
+          (magent-runtime--active-project-scope nil)
+          (magent-load-custom-agents nil))
+     (unwind-protect
+         (progn
+           (magent-live-test--kill-magent-test-buffers)
+           (magent-session-activate 'global)
+           ,@body)
+       (when (and (fboundp 'magent-interrupt)
+                  (boundp 'magent-ui--processing)
+                  magent-ui--processing)
+         (ignore-errors (magent-interrupt)))
+       (magent-live-test--kill-magent-test-buffers)
+       (when (file-directory-p magent-session-directory)
+         (delete-directory magent-session-directory t))
+       (when (file-directory-p magent-audit-directory)
+         (delete-directory magent-audit-directory t)))))
+
+(ert-deftest magent-live-test-buffer-input-submits-through-timer ()
+  "Submit editable buffer input through the real live UI dispatch timer."
+  :tags '(:magent-live-smoke)
+  (require 'magent)
+  (magent-live-test--with-isolated-runtime
+    (let ((response nil))
+      (cl-letf (((symbol-function 'magent--ensure-initialized) #'ignore)
+                ((symbol-function 'magent-runtime-activate-scope) #'ignore)
+                ((symbol-function 'magent-capability-capture-context) (lambda () nil))
+                ((symbol-function 'magent-capability-resolve-for-turn) (lambda (&rest _) nil))
+                ((symbol-function 'magent-agent-process)
+                 (lambda (_prompt callback &rest _args)
+                   (run-at-time
+                    0 nil
+                    (lambda ()
+                      (magent-ui-start-streaming)
+                      (magent-ui-insert-streaming "live response")
+                      (magent-ui-finish-streaming-fontify)
+                      (setq response "live response")
+                      (funcall callback "live response")))
+                   'magent-live-test-fsm)))
+        (let ((buffer (magent-ui-get-buffer 'global)))
+          (with-current-buffer buffer
+            (magent-output-mode)
+            (magent-ui--insert-input-prompt 'global)
+            (goto-char (point-max))
+            (insert "hello from live buffer")
+            (magent-input-submit))
+          (magent-live-test--wait-until
+           (lambda ()
+             (and response (not (magent-ui-processing-p))))
+           5 "Magent live buffer input did not finish")
+          (with-current-buffer buffer
+            (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+              (should (string-match-p "^\\* USER" text))
+              (should (string-match-p "hello from live buffer" text))
+              (should (string-match-p "^\\* ASSISTANT" text))
+              (should (string-match-p "live response" text))
+              (should magent-ui--input-marker)
+              (should (= (marker-position magent-ui--input-marker) (point-max))))))))))
+
+(ert-deftest magent-live-test-fsm-runs-emacs-eval-and-continues ()
+  "Run a live Magent turn through FSM tool execution and continuation."
+  :tags '(:magent-live-smoke)
+  (require 'magent)
+  (require 'gptel)
+  (magent-live-test--with-isolated-runtime
+    (let ((call-count 0)
+          (final-response nil)
+          (magent-by-pass-permission t)
+          (magent-enable-tools '(emacs_eval)))
+      (cl-letf (((symbol-function 'magent-capability-capture-context) (lambda () nil))
+                ((symbol-function 'magent-capability-resolve-for-turn) (lambda (&rest _) nil))
+                ((symbol-function 'gptel-request)
+                 (lambda (_prompt &rest kwargs)
+                   (cl-incf call-count)
+                   (let ((callback (plist-get kwargs :callback)))
+                     (pcase call-count
+                       (1
+                        (let* ((tool-spec
+                                (cl-find-if
+                                 (lambda (tool)
+                                   (equal (gptel-tool-name tool) "emacs_eval"))
+                                 gptel-tools))
+                               (args '(:sexp "(length (buffer-list))"
+                                             :reason "count live buffers"))
+                               (raw-call (list :id "call_live_1"
+                                               :name "emacs_eval"
+                                               :args args))
+                               (info (list :content ""
+                                           :tool-use (list raw-call))))
+                          (run-at-time
+                           0 nil
+                           (lambda ()
+                             (funcall callback "Checking buffers. " info)
+                             (funcall callback
+                                      (cons 'tool-call
+                                            (list (list tool-spec args nil raw-call)))
+                                      info)))))
+                       (2
+                        (let ((info (list :content "Done.")))
+                          (run-at-time
+                           0 nil
+                           (lambda ()
+                             (funcall callback "Done." info)
+                             (funcall callback t info)))))
+                       (_
+                        (run-at-time
+                         0 nil
+                         (lambda ()
+                           (funcall callback nil
+                                    (list :error "unexpected extra request")))))))
+                   nil)))
+        (magent-ui-dispatch-prompt "count live buffers" 'send-prompt nil nil t)
+        (magent-live-test--wait-until
+         (lambda ()
+           (let* ((session (magent-session-get))
+                  (messages (magent-session-get-messages session))
+                  (last-msg (car (last messages))))
+             (when (and last-msg
+                        (eq (magent-msg-role last-msg) 'assistant))
+               (setq final-response (magent-msg-content last-msg)))))
+         8 "Magent live FSM tool turn did not finish")
+        (should (equal final-response "Checking buffers. Done."))
+        (should (= call-count 2))
+        (let* ((messages (magent-session-get-messages (magent-session-get)))
+               (tool-msg (cl-find-if
+                          (lambda (msg) (eq (magent-msg-role msg) 'tool))
+                          messages))
+               (tool-content (magent-msg-content tool-msg)))
+          (should tool-msg)
+          (should (equal (plist-get tool-content :id) "call_live_1"))
+          (should (equal (plist-get tool-content :name) "emacs_eval"))
+          (should (string-match-p "\\`[0-9]+\\'"
+                                  (plist-get tool-content :result))))
+        (with-current-buffer (magent-ui-get-buffer (magent-session-current-scope))
+          (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+            (should (string-match-p "#\\+begin_tool emacs_eval" text))
+            (should (string-match-p "Checking buffers\\." text))
+            (should (string-match-p "Done\\." text))
+            (should magent-ui--input-marker)))))))
+
+(ert-deftest magent-live-test-timer-renders-symbol-tool-args ()
+  "Render non-string tool args from a timer without leaking JSON errors."
+  :tags '(:magent-live-smoke)
+  (require 'magent-ui)
+  (magent-live-test--with-isolated-runtime
+    (let ((done nil))
+      (run-at-time
+       0 nil
+       (lambda ()
+         (magent-ui-insert-tool-call "emacs_eval"
+                                     '(:tool emacs_eval :args [emacs_eval]))
+         (setq done t)))
+      (magent-live-test--wait-until
+       (lambda () done)
+       3 "Magent live timer did not render symbol tool args")
+      (with-current-buffer (magent-ui-get-buffer 'global)
+        (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+          (should (string-match-p "#\\+begin_tool emacs_eval" text))
+          (should (string-match-p "emacs_eval" text)))))))
+
+(ert-deftest magent-live-test-real-simple-prompt ()
+  "Send a real non-tool request through the configured gptel provider."
+  :tags '(:magent-live)
+  (require 'magent)
+  (magent-live-test--require-real-gptel)
+  (magent-live-test--with-isolated-runtime
+    (let ((magent-enable-tools nil)
+          (magent-include-reasoning 'ignore)
+          (prompt "Reply with exactly MAGENT_LIVE_OK and no other text."))
+      (magent-ui-dispatch-prompt prompt 'live-test nil nil t)
+      (let ((response (magent-live-test--wait-for-assistant 120)))
+        (should (string-match-p "MAGENT_LIVE_OK" response))
+        (with-current-buffer (magent-ui-get-buffer (magent-session-current-scope))
+          (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+            (should (string-match-p "^\\* USER" text))
+            (should (string-match-p "^\\* ASSISTANT" text))
+            (should (string-match-p "MAGENT_LIVE_OK" text))))))))
+
+(ert-deftest magent-live-test-real-emacs-eval-tool ()
+  "Send a real tool-use request through gptel and execute emacs_eval."
+  :tags '(:magent-live)
+  (require 'magent)
+  (magent-live-test--require-real-gptel)
+  (magent-live-test--with-isolated-runtime
+    (let ((magent-enable-tools '(emacs_eval))
+          (magent-by-pass-permission t)
+          (magent-include-reasoning 'ignore)
+          (prompt (concat
+                   "Use the emacs_eval tool exactly once to evaluate this "
+                   "Emacs Lisp form: (+ 20 22). After the tool result, "
+                   "reply exactly MAGENT_TOOL_OK=42 and no other text. "
+                   "Do not answer from memory; call the tool.")))
+      (magent-ui-dispatch-prompt prompt 'live-test nil nil t)
+      (let ((response (magent-live-test--wait-for-assistant 180)))
+        (should (string-match-p "MAGENT_TOOL_OK=42" response))
+        (let* ((messages (magent-session-get-messages (magent-session-get)))
+               (tool-msg (cl-find-if
+                          (lambda (msg)
+                            (and (eq (magent-msg-role msg) 'tool)
+                                 (equal (plist-get (magent-msg-content msg) :name)
+                                        "emacs_eval")))
+                          messages))
+               (tool-content (and tool-msg (magent-msg-content tool-msg))))
+          (should tool-msg)
+          (should (equal (plist-get tool-content :result) "42")))
+        (with-current-buffer (magent-ui-get-buffer (magent-session-current-scope))
+          (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+            (should (string-match-p "#\\+begin_tool emacs_eval" text))
+            (should (string-match-p "MAGENT_TOOL_OK=42" text))))))))
+
+(defun magent-live-test--result-description (result)
+  "Return a compact description for ERT RESULT."
+  (cond
+   ((ert-test-failed-p result)
+    (error-message-string (ert-test-failed-condition result)))
+   ((ert-test-skipped-p result)
+    (format "%S" (ert-test-skipped-condition result)))
+   (t
+    (format "%S" result))))
+
+(defun magent-live-test--unexpected-results (records)
+  "Return unexpected test result descriptions from test result RECORDS."
+  (let ((records (or records magent-live-test--latest-results))
+        unexpected)
+    (dolist (record records)
+      (let ((test (car record))
+            (result (cdr record)))
+        (unless (or (and result
+                         (ert-test-result-expected-p test result))
+                    (and result
+                         (ert-test-skipped-p result)))
+          (push (format "%s: %s"
+                        (ert-test-name test)
+                        (magent-live-test--result-description result))
+                unexpected))))
+    (nreverse unexpected)))
+
+(defun magent-live-test--listener (event &rest args)
+  "Report live ERT progress for EVENT, STATS, and ARGS."
+  (pcase event
+    ('run-started
+     (message "Magent live tests: running %d tests" (car args)))
+    ('test-ended
+     (let ((test (nth 0 args))
+           (result (nth 1 args)))
+       (message "Magent live test %s: %s"
+                (ert-test-name test)
+                (cond
+                 ((ert-test-passed-p result) "passed")
+                 ((ert-test-skipped-p result) "skipped")
+                 (t "failed")))))
+    ('run-ended
+     (pcase-let ((`(,passed ,failed ,skipped) args))
+       (message "Magent live tests finished: %d passed, %d failed, %d skipped"
+                passed failed skipped)))))
+
+(defun magent-live-test--run-selected-tests (selector)
+  "Run live tests selected by SELECTOR and return result records."
+  (let ((tests (ert-select-tests selector t))
+        records)
+    (magent-live-test--listener 'run-started (length tests))
+    (dolist (test tests)
+      (let ((result (ert-run-test test)))
+        (push (cons test result) records)
+        (magent-live-test--listener 'test-ended test result)))
+    (setq records (nreverse records)
+          magent-live-test--latest-results records)
+    (let ((passed 0)
+          (failed 0)
+          (skipped 0))
+      (dolist (record records)
+        (let ((test (car record))
+              (result (cdr record)))
+          (cond
+           ((ert-test-skipped-p result)
+            (cl-incf skipped))
+           ((ert-test-result-expected-p test result)
+            (cl-incf passed))
+           (t
+            (cl-incf failed)))))
+      (magent-live-test--listener 'run-ended passed failed skipped))
+    records))
+
+(defun magent-live-test-run (&optional selector)
+  "Reload Magent source and run real live tests selected by SELECTOR.
+Signals an error when any live test has an unexpected result so
+`emacsclient' and `make' receive a non-zero exit code."
+  (interactive)
+  (magent-live-test-reload-source)
+  (let* ((selector (or selector '(tag :magent-live)))
+         (records (magent-live-test--run-selected-tests selector))
+         (unexpected (magent-live-test--unexpected-results records)))
+    (if unexpected
+        (error "Magent live tests failed: %s"
+               (string-join unexpected "; "))
+      (message "Magent live tests passed")
+      'magent-live-tests-passed)))
+
+(defun magent-live-test-run-smoke (&optional selector)
+  "Reload Magent source and run deterministic live smoke tests.
+Smoke tests run inside the live Emacs instance but stub gptel transport, so
+they do not consume tokens."
+  (interactive)
+  (magent-live-test-run (or selector '(tag :magent-live-smoke))))
+
+(provide 'magent-live-test)
+;;; magent-live-test.el ends here

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -589,18 +589,63 @@
       (should (equal (car (nth 2 prompt-list)) 'prompt))
       (should (equal (cdr (nth 2 prompt-list)) "Tell me more.")))))
 
-(ert-deftest magent-test-session-to-gptel-prompt-list-skips-tool ()
-  "Test that tool messages are skipped in gptel prompt list."
+(ert-deftest magent-test-session-to-gptel-prompt-list-keeps-structured-tool ()
+  "Test structured tool messages are included in gptel prompt list."
+  (require 'magent-session)
+  (let ((session (magent-session-create)))
+    (magent-session-add-message session 'user "Run ls")
+    (magent-session-add-tool-message
+     session "call_1" "bash" '(:command "ls") "file1.txt\nfile2.txt")
+    (magent-session-add-message session 'assistant "Here are the files.")
+    (let ((prompt-list (magent-session-to-gptel-prompt-list session)))
+      (should (= (length prompt-list) 3))
+      (should (equal (nth 0 prompt-list) '(prompt . "Run ls")))
+      (should (equal (nth 1 prompt-list)
+                     '(tool . (:id "call_1"
+                               :name "bash"
+                               :args (:command "ls")
+                               :result "file1.txt\nfile2.txt"))))
+      (should (equal (nth 2 prompt-list)
+                     '(response . "Here are the files."))))))
+
+(ert-deftest magent-test-session-to-gptel-prompt-list-json-sanitizes-tool-args ()
+  "Test tool data reused in gptel prompts is safe for `json-serialize'."
+  (require 'magent-session)
+  (let ((session (magent-session-create)))
+    (magent-session-add-message session 'user "Run tool")
+    (magent-session-add-tool-message
+     session "call_1" 'emacs_eval
+     '(:sexp "(+ 20 22)" :tool emacs_eval :values [emacs_eval nil])
+     "42")
+    (let* ((prompt-list (magent-session-to-gptel-prompt-list session))
+           (tool (cdr (nth 1 prompt-list)))
+           (args (plist-get tool :args)))
+      (should (equal (plist-get tool :name) "emacs_eval"))
+      (should (equal args
+                     '(:sexp "(+ 20 22)"
+                       :tool "emacs_eval"
+                       :values ["emacs_eval" :null])))
+      (should
+       (if (fboundp 'json-serialize)
+           (json-serialize (list :name (plist-get tool :name)
+                                 :args args)
+                           :null-object :null
+                           :false-object :json-false)
+         (let ((json-null :null)
+               (json-false :json-false))
+           (json-encode (list :name (plist-get tool :name)
+                              :args args))))))))
+
+(ert-deftest magent-test-session-to-gptel-prompt-list-skips-legacy-tool-string ()
+  "Test old string-only tool messages are skipped in gptel prompt list."
   (require 'magent-session)
   (let ((session (magent-session-create)))
     (magent-session-add-message session 'user "Run ls")
     (magent-session-add-message session 'tool "file1.txt\nfile2.txt")
     (magent-session-add-message session 'assistant "Here are the files.")
-    (let ((prompt-list (magent-session-to-gptel-prompt-list session)))
-      ;; Tool message should be skipped
-      (should (= (length prompt-list) 2))
-      (should (equal (car (nth 0 prompt-list)) 'prompt))
-      (should (equal (car (nth 1 prompt-list)) 'response)))))
+    (should (equal (magent-session-to-gptel-prompt-list session)
+                   '((prompt . "Run ls")
+                     (response . "Here are the files."))))))
 
 (ert-deftest magent-test-session-to-gptel-prompt-list-drops-failed-turns ()
   "Test failed turns do not leak into later prompt reuse."
@@ -2360,7 +2405,7 @@
              :gptel-backend gptel-backend
              :model 'gpt-4o-mini)))
     (should (equal captured-permission permission))
-    (should (eq captured-confirm-mode 'auto))))
+    (should (eq captured-confirm-mode t))))
 
 (ert-deftest magent-test-gptel-backend-routes-tool-call-confirmation ()
   "Test gptel backend routes pending tool calls through magent permissions."
@@ -2380,6 +2425,232 @@
       (when (buffer-live-p request-buffer)
         (kill-buffer request-buffer)))
     (should (equal captured (list permission tool-calls nil)))))
+
+(ert-deftest magent-test-gptel-backend-tool-call-owned-by-magent-runtime ()
+  "Test tool calls are recorded by Magent and continued with a fresh request."
+  (require 'magent-fsm)
+  (let* ((session (magent-session-create))
+         (tool (gptel-make-tool
+                :name "grep"
+                :description "test"
+                :args '((:name "query" :type string))
+                :function (lambda (_query) "tool result")))
+         (raw-call (list :id "call_1" :name "grep" :args '(:query "abc")))
+         (request-buffer (generate-new-buffer " *magent-gptel-test*"))
+         (params (list :session session
+                       :max-tool-rounds 3
+                       :tools nil
+                       :permission nil
+                       :request-state nil
+                       :event-context nil
+                       :callback #'ignore
+                       :ui-callback nil))
+         (continued nil)
+         (gptel-cb-called nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'magent-fsm-backend-gptel-start)
+                   (lambda (_params)
+                     (setq continued t)))
+                  ((symbol-function 'magent-ui-continue-streaming) #'ignore))
+          (magent-fsm-backend-gptel--callback
+           (cons 'tool-call
+                 (list (list tool '(:query "abc")
+                             (lambda (_result)
+                               (setq gptel-cb-called t))
+                             raw-call)))
+           nil #'ignore nil request-buffer nil nil
+           nil (magent-fsm-backend-gptel--make-stream-state)
+           "req" nil nil nil params))
+      (when (buffer-live-p request-buffer)
+        (kill-buffer request-buffer)))
+    (should continued)
+    (should-not gptel-cb-called)
+    (let ((messages (magent-session-get-messages session)))
+      (should (= (length messages) 1))
+      (should (eq (magent-msg-role (car messages)) 'tool))
+      (should (equal (magent-msg-content (car messages))
+                     '(:id "call_1"
+                       :name "grep"
+                       :args (:query "abc")
+                       :result "tool result"))))))
+
+(ert-deftest magent-test-gptel-backend-sanitizes-symbol-tool-call-info ()
+  "Test gptel callback sanitizes symbol tool names and args before reuse."
+  (require 'magent-fsm)
+  (let* ((tool (gptel-make-tool
+                :name "emacs_eval"
+                :description "test"
+                :args '((:name "sexp" :type string)
+                        (:name "tool" :type string :optional t))
+                :function (lambda (_sexp _tool) "42")))
+         (raw-call (list :id "call_1"
+                         :name 'emacs_eval
+                         :args '(:sexp "(+ 20 22)"
+                                 :tool emacs_eval
+                                 :values [emacs_eval nil])))
+         (info (list :tool-use (list raw-call)
+                     :data
+                     (list :messages
+                           (vector
+                            (list :role "assistant"
+                                  :tool_calls
+                                  (vector
+                                   (list :type "function"
+                                         :id "call_1"
+                                         :function
+                                         (list :name 'emacs_eval
+                                               :arguments
+                                               '(:sexp "(+ 20 22)"
+                                                 :tool emacs_eval
+                                                 :values [emacs_eval nil])))))))))
+         (request-buffer (generate-new-buffer " *magent-gptel-test*"))
+         captured)
+    (unwind-protect
+        (cl-letf (((symbol-function 'magent-fsm--handle-tool-call-confirmation-with-permission)
+                   (lambda (_permission tool-calls &rest _)
+                     (setq captured tool-calls))))
+          (magent-fsm-backend-gptel--callback
+           (cons 'tool-call (list (list tool (plist-get raw-call :args)
+                                  nil raw-call)))
+           info nil nil request-buffer nil nil))
+      (when (buffer-live-p request-buffer)
+        (kill-buffer request-buffer)))
+    (should (equal (plist-get raw-call :name) "emacs_eval"))
+    (should (equal (plist-get raw-call :args)
+                   '(:sexp "(+ 20 22)"
+                     :tool "emacs_eval"
+                     :values ["emacs_eval" :null])))
+    (let* ((messages (plist-get (plist-get info :data) :messages))
+           (tool-calls (plist-get (aref messages 0) :tool_calls))
+           (func (plist-get (aref tool-calls 0) :function)))
+      (should (equal (plist-get func :name) "emacs_eval"))
+      (should (stringp (plist-get func :arguments)))
+      (should (string-match-p "\"tool\":\"emacs_eval\""
+                              (plist-get func :arguments)))
+      (should
+       (if (fboundp 'json-serialize)
+           (json-serialize (plist-get info :data)
+                           :null-object :null
+                           :false-object :json-false)
+         (let ((json-null :null)
+               (json-false :json-false))
+           (json-encode (plist-get info :data))))))
+    (should captured)))
+
+(ert-deftest magent-test-gptel-backend-sanitizes-context-managed-stream-info ()
+  "Test stream-parser advice sanitizes Magent info before callback dispatch."
+  (require 'magent-fsm)
+  (let* ((function-call (list :name 'emacs_eval
+                              :arguments '(:tool emacs_eval)))
+         (assistant-message
+          (list :role "assistant"
+                :tool_calls
+                (vector (list :type "function"
+                              :id "call_1"
+                              :function function-call))))
+         (info (list :context '(:magent-managed t)
+                     :tool-use (list (list :id "call_1"
+                                           :name 'emacs_eval
+                                           :args '(:tool emacs_eval)))
+                     :data (list :messages (vector assistant-message))))
+         (response
+          (magent--sanitize-stream-data-after-parse-a
+           (lambda (_backend _info) "chunk")
+           nil info)))
+    (should (equal response "chunk"))
+    (should (equal (plist-get (car (plist-get info :tool-use)) :name)
+                   "emacs_eval"))
+    (let* ((messages (plist-get (plist-get info :data) :messages))
+           (tool-calls (plist-get (aref messages 0) :tool_calls))
+           (func (plist-get (aref tool-calls 0) :function)))
+      (should (equal (plist-get func :name) "emacs_eval"))
+      (should (stringp (plist-get func :arguments)))
+      (should
+       (if (fboundp 'json-serialize)
+           (json-serialize (plist-get info :data)
+                           :null-object :null
+                           :false-object :json-false)
+         (let ((json-null :null)
+               (json-false :json-false))
+           (json-encode (plist-get info :data))))))))
+
+(ert-deftest magent-test-gptel-backend-sanitizes-context-managed-curl-data ()
+  "Test curl request advice sanitizes Magent info before JSON encoding."
+  (require 'magent-fsm)
+  (let* ((function-call (list :name 'emacs_eval
+                              :arguments '(:tool emacs_eval)))
+         (assistant-message
+          (list :role "assistant"
+                :tool_calls
+                (vector (list :type "function"
+                              :id "call_1"
+                              :function function-call))))
+         (info (list :context '(:magent-managed t)
+                     :data (list :messages (vector assistant-message))))
+         called)
+    (magent--sanitize-request-data-before-curl-a
+     (lambda (arg-info &rest _args)
+       (setq called t)
+       (if (fboundp 'json-serialize)
+           (json-serialize (plist-get arg-info :data)
+                           :null-object :null
+                           :false-object :json-false)
+         (let ((json-null :null)
+               (json-false :json-false))
+           (json-encode (plist-get arg-info :data)))))
+     info "uuid" nil)
+    (should called)
+    (let* ((messages (plist-get (plist-get info :data) :messages))
+           (tool-calls (plist-get (aref messages 0) :tool_calls))
+           (func (plist-get (aref tool-calls 0) :function)))
+      (should (equal (plist-get func :name) "emacs_eval"))
+      (should (stringp (plist-get func :arguments))))))
+
+(ert-deftest magent-test-gptel-backend-unknown-tool-records-error ()
+  "Test unknown tool calls are returned to the model as tool errors."
+  (require 'magent-fsm)
+  (let* ((session (magent-session-create))
+         (raw-call (list :id "call_missing"
+                         :name "missing_tool"
+                         :args '(:query "abc")))
+         (request-buffer (generate-new-buffer " *magent-gptel-test*"))
+         (params (list :session session
+                       :max-tool-rounds 3
+                       :tools nil
+                       :permission nil
+                       :request-state nil
+                       :event-context nil
+                       :callback #'ignore
+                       :ui-callback nil))
+         (continued nil)
+         (permission-handler-called nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'magent-fsm-backend-gptel-start)
+                   (lambda (_params)
+                     (setq continued t)))
+                  ((symbol-function 'magent-fsm--handle-tool-call-confirmation-with-permission)
+                   (lambda (&rest _args)
+                     (setq permission-handler-called t)))
+                  ((symbol-function 'magent-ui-continue-streaming) #'ignore))
+          (magent-fsm-backend-gptel--callback
+           (cons 'tool-call
+                 (list (list nil '(:query "abc") nil raw-call)))
+           nil #'ignore nil request-buffer nil nil
+           nil (magent-fsm-backend-gptel--make-stream-state)
+           "req" nil nil nil params))
+      (when (buffer-live-p request-buffer)
+        (kill-buffer request-buffer)))
+    (should continued)
+    (should-not permission-handler-called)
+    (let ((messages (magent-session-get-messages session)))
+      (should (= (length messages) 1))
+      (should (eq (magent-msg-role (car messages)) 'tool))
+      (let ((content (magent-msg-content (car messages))))
+        (should (equal (plist-get content :id) "call_missing"))
+        (should (equal (plist-get content :name) "missing_tool"))
+        (should (equal (plist-get content :args) '(:query "abc")))
+        (should (string-match-p "tool 'missing_tool' not found"
+                                (plist-get content :result)))))))
 
 (ert-deftest magent-test-gptel-backend-streams-reasoning-blocks ()
   "Test gptel backend forwards reasoning chunks to the Magent UI."
@@ -2839,17 +3110,23 @@
     (should-not (magent-approval-pending-request "req-local"))))
 
 (ert-deftest magent-test-gptel-backend-streaming-tool-roundtrip-sequence ()
-  "Test gptel backend handles streaming with a tool round-trip in order."
+  "Test Magent-owned tool continuation preserves streaming order."
   (require 'magent-fsm)
-  (let ((events nil)
-        (final-response nil)
-        (request-callback nil)
-        (gptel-backend (gptel-make-openai "test" :key "test-key")))
+  (let* ((events nil)
+         (final-response nil)
+         (request-count 0)
+         (gptel-backend (gptel-make-openai "test" :key "test-key"))
+         (tool (gptel-make-tool
+                :name "grep"
+                :description "test"
+                :args '((:name "query" :type string))
+                :function (lambda (_query) "tool result")))
+         (raw-call (list :id "call_1" :name "grep" :args '(:query "abc"))))
     (cl-letf (((symbol-function 'magent-fsm--convert-tools-to-gptel)
                (lambda (_tools _permission
                         &optional _request-state _event-context
                         _abort-controller _tool-queue)
-                 nil))
+                 (list tool)))
               ((symbol-function 'magent-ui-start-streaming)
                (lambda () (push 'start events)))
               ((symbol-function 'magent-ui-continue-streaming)
@@ -2858,17 +3135,26 @@
                (lambda () (push 'finish events)))
               ((symbol-function 'gptel-request)
                (lambda (_prompt &rest kwargs)
-                 (setq request-callback (plist-get kwargs :callback))
-                 (funcall request-callback "Hello " nil)
-                 (funcall request-callback
-                          (cons 'tool-call '((tool-spec args cb))) nil)
-                 (funcall request-callback
-                          (cons 'tool-result '((tool-spec args "ok"))) nil)
-                 (funcall request-callback "world" nil)
-                 (funcall request-callback t (list :content "Hello world"))))
+                 (cl-incf request-count)
+                 (let ((request-callback (plist-get kwargs :callback)))
+                   (if (= request-count 1)
+                       (progn
+                         (funcall request-callback "Hello " nil)
+                         (funcall request-callback
+                                  (cons 'tool-call
+                                        (list (list tool '(:query "abc")
+                                                    (lambda (_result)
+                                                      (ert-fail "gptel tool callback should not be called"))
+                                                    raw-call)))
+                                  nil))
+                     (funcall request-callback "world" nil)
+                     (funcall request-callback t (list :content "Hello world"))))))
               ((symbol-function 'magent-fsm--handle-tool-call-confirmation-with-permission)
-               (lambda (_permission tool-calls &optional _request-state)
-                 (push (list 'tool-call tool-calls) events))))
+               (lambda (_permission tool-calls &optional _request-state
+                                    result-callback done-callback)
+                 (push (list 'tool-call tool-calls) events)
+                 (funcall result-callback tool (list "abc") raw-call "tool result")
+                 (funcall done-callback))))
       (magent-fsm-backend-gptel-start
        (list :prompt-list nil
              :system-prompt "test"
@@ -2879,11 +3165,13 @@
              :gptel-backend gptel-backend
              :model 'gpt-4o-mini)))
     (should (equal final-response "Hello world"))
+    (should (= request-count 2))
     (should (equal (nreverse events)
                    (list 'start
                          (list 'chunk "Hello ")
-                         (list 'tool-call '((tool-spec args cb)))
                          'continue
+                         (list 'tool-call
+                               (list (list tool (list "abc") nil raw-call)))
                          (list 'chunk "world")
                          'finish)))))
 
@@ -3627,7 +3915,8 @@
 
 (ert-deftest magent-test-session-scope-from-directory-falls-back-to-global ()
   "Test session scope is global when no project root is detected."
-  (let ((magent-project-root-function (lambda () nil)))
+  (cl-letf (((symbol-function 'magent-project-root)
+             (lambda (&optional _directory _no-fallback) nil)))
     (should (eq (magent-session-scope-from-directory "/tmp/") 'global))))
 
 (ert-deftest magent-test-session-save-uses-project-storage-directory ()
@@ -3693,6 +3982,61 @@
                  (loaded-session (plist-get loaded :session)))
             (should (eq (magent-session-approval-override loaded-session 'bash)
                         'allow))))
+      (delete-directory magent-session-directory t))))
+
+(ert-deftest magent-test-session-save-load-preserves-tool-message ()
+  "Test structured tool messages persist through save/load."
+  (let* ((magent-session-directory (make-temp-file "magent-sessions-" t))
+         (magent-session--scoped-sessions (make-hash-table :test #'equal))
+         (magent-session--current-scope 'global)
+         (magent--current-session nil))
+    (unwind-protect
+        (progn
+          (magent-session-activate 'global)
+          (let ((session (magent-session-get)))
+            (magent-session-add-message session 'user "Run ls")
+            (magent-session-add-tool-message
+             session "call_1" "bash" '(:command "ls") "ok")
+            (magent-session-save))
+          (let* ((files (directory-files magent-session-directory t "\\.json$"))
+                 (loaded (magent-session-read-file (car files)))
+                 (loaded-session (plist-get loaded :session))
+                 (messages (magent-session-get-messages loaded-session)))
+            (should (= (length messages) 2))
+            (should (equal (magent-msg-content (nth 1 messages))
+                           '(:id "call_1"
+                             :name "bash"
+                             :args (:command "ls")
+                             :result "ok")))))
+      (delete-directory magent-session-directory t))))
+
+(ert-deftest magent-test-session-save-load-sanitizes-symbol-tool-args ()
+  "Test session persistence handles symbol tool names and arguments."
+  (let* ((magent-session-directory (make-temp-file "magent-sessions-" t))
+         (magent-session--scoped-sessions (make-hash-table :test #'equal))
+         (magent-session--current-scope 'global)
+         (magent--current-session nil))
+    (unwind-protect
+        (progn
+          (magent-session-activate 'global)
+          (let ((session (magent-session-get)))
+            (magent-session-add-message session 'user "Run tool")
+            (magent-session-add-tool-message
+             session "call_1" 'emacs_eval
+             '(:sexp "(+ 20 22)" :tool emacs_eval :values [emacs_eval nil])
+             "42")
+            (magent-session-save))
+          (let* ((files (directory-files magent-session-directory t "\\.json$"))
+                 (loaded (magent-session-read-file (car files)))
+                 (loaded-session (plist-get loaded :session))
+                 (messages (magent-session-get-messages loaded-session)))
+            (should (equal (magent-msg-content (nth 1 messages))
+                           '(:id "call_1"
+                             :name "emacs_eval"
+                             :args (:sexp "(+ 20 22)"
+                                    :tool "emacs_eval"
+                                    :values ("emacs_eval" nil))
+                             :result "42")))))
       (delete-directory magent-session-directory t))))
 
 (ert-deftest magent-test-session-list-files-prefers-project-then-global ()
@@ -4113,6 +4457,32 @@
           (should (eq (nth 1 captured) 'buffer-input)))
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
+
+(ert-deftest magent-test-evil-c-g-interrupts-only-in-normal-state ()
+  "Test Evil C-g only interrupts in normal state."
+  (skip-unless (require 'evil nil t))
+  (dolist (case '((normal . magent-interrupt)
+                  (insert . evil-normal-state)
+                  (replace . evil-normal-state)
+                  (visual . keyboard-quit)
+                  (emacs . keyboard-quit)))
+    (with-temp-buffer
+      (insert "x")
+      (magent-output-mode)
+      (evil-local-mode 1)
+      (pcase (car case)
+        ('normal (evil-normal-state))
+        ('insert (evil-insert-state))
+        ('replace (evil-replace-state))
+        ('visual
+         (set-mark (point-min))
+         (goto-char (point-max))
+         (evil-visual-state))
+        ('emacs (evil-emacs-state)))
+      (should (eq evil-state (car case)))
+      (should (eq (key-binding (kbd "C-g")) (cdr case)))
+      (unless (eq (car case) 'normal)
+        (should-not (eq (key-binding (kbd "C-g")) 'magent-interrupt))))))
 
 (ert-deftest magent-test-config-reload-preserves-ui-logger ()
   "Test reloading config does not clobber the UI log implementation."
@@ -4864,6 +5234,19 @@
       (should (equal (buffer-string) "alpha\n"))
       (should (null magent-ui--reasoning-start))
       (should magent-ui--streaming-has-text))))
+
+(ert-deftest magent-test-ui-tool-call-renders-symbol-args ()
+  "Test tool-call rendering tolerates symbol values in structured args."
+  (require 'magent-ui)
+  (magent-ui-clear-buffer)
+  (magent-ui-insert-tool-call
+   "emacs_eval"
+   '(:tool emacs_eval :values [emacs_eval nil]))
+  (with-current-buffer (magent-ui-get-buffer)
+    (let ((text (buffer-string)))
+      (should (string-match-p "#\\+begin_tool emacs_eval" text))
+      (should (string-match-p "\"tool\":\"emacs_eval\"" text))
+      (should (string-match-p "\"values\":\\[\"emacs_eval\",null\\]" text)))))
 
 (ert-deftest magent-test-mode-map-binds-diagnose-emacs ()
   "Test `magent-mode-map' binds the Emacs diagnosis command."


### PR DESCRIPTION
## Summary
- add live and smoke test targets for real/stubbed Magent interaction checks
- sanitize Magent-managed gptel tool-call names and args before JSON serialization
- preserve tool-result recording through the new Magent tool orchestrator

## Tests
- make test-unit
- make test-live-smoke