### PR TITLE
fix(agent-shell): restore Magent startup strategy

### DIFF
--- a/lisp/magent-agent-shell.el
+++ b/lisp/magent-agent-shell.el
@@ -57,6 +57,9 @@
 (defvar-local magent-agent-shell--prompt-skill-queue nil
   "Per-prompt instruction skills waiting for `agent-shell--send-command'.")
 
+(defvar-local magent-agent-shell--owns-session-strategy-p nil
+  "Non-nil when Magent installed the buffer-local session strategy.")
+
 (defun magent-agent-shell--ensure-loaded ()
   "Load `agent-shell' before using its runtime API."
   (require 'agent-shell))
@@ -86,7 +89,9 @@ Install Magent's session strategy before agent-shell snapshots its buffer-local
 startup settings.  Preserve an existing buffer-local value so explicit or
 directory-local frontend configuration keeps precedence."
   (with-current-buffer buffer
-    (unless (local-variable-p 'agent-shell-session-strategy)
+    (when (or magent-agent-shell--owns-session-strategy-p
+              (not (local-variable-p 'agent-shell-session-strategy)))
+      (setq-local magent-agent-shell--owns-session-strategy-p t)
       (setq-local agent-shell-session-strategy
                   magent-agent-shell-session-strategy)))
   (magent-acp-make-client buffer))

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -11350,7 +11350,13 @@
               (should
                (eq (buffer-local-value 'agent-shell-session-strategy
                                        (current-buffer))
-                   'new)))
+                   'new))
+              ;; agent-shell snapshots its explicit generic-picker strategy
+              ;; after the first client construction, then constructs the
+              ;; real client once more during bootstrap.
+              (setq-local agent-shell-session-strategy 'prompt)
+              (funcall client-maker (current-buffer))
+              (should (eq agent-shell-session-strategy 'new)))
             (with-temp-buffer
               (set (make-local-variable 'agent-shell-session-strategy)
                    'latest)
@@ -11360,6 +11366,29 @@
                                        (current-buffer))
                    'latest))))
         (set-default 'agent-shell-session-strategy previous-strategy)))))
+
+(ert-deftest magent-test-generic-agent-shell-start-uses-magent-session-strategy ()
+  "Test generic agent-shell startup cannot overwrite Magent's strategy."
+  (require 'magent-agent-shell)
+  (let ((agent-shell-session-strategy 'prompt)
+        (magent-agent-shell-session-strategy 'new)
+        shell-buffer)
+    (cl-letf (((symbol-function 'magent-acp--request-sender)
+               (lambda (&rest _args) nil)))
+      (unwind-protect
+          (progn
+            (setq shell-buffer
+                  (agent-shell--start
+                   :config (magent-agent-shell-make-config)
+                   :no-focus t
+                   :new-session t
+                   :session-strategy agent-shell-session-strategy))
+            (should
+             (eq (buffer-local-value 'agent-shell-session-strategy
+                                     shell-buffer)
+                 'new)))
+        (when (buffer-live-p shell-buffer)
+          (kill-buffer shell-buffer))))))
 
 (ert-deftest magent-test-agent-shell-start-uses-magent-session-strategy ()
   "Test Magent agent-shell entry points do not inherit global prompt strategy."


### PR DESCRIPTION
## Summary

- keep the Magent-owned new session strategy across agent-shell client reconstruction
- preserve explicit buffer-local and directory-local frontend configuration
- add regression coverage for the generic agent picker startup path

## Root cause

The generic agent-shell picker passes its global prompt strategy into agent-shell--start. Magent installs new during the first client construction, but agent-shell then snapshots prompt buffer-locally before constructing the real client. The old client maker treated that value as user-owned and did not restore new, which caused an extra session/list request, a Loading state, and a second session picker.

## Validation

- make compile
- make test-unit: 526/526 passed
- make test with isolated live Emacs smoke tests: passed
- real in-process ACP bootstrap: final strategy new, no startup session/list request
- 50 paired warm-start benchmark runs: median ready 243.7 ms versus 500.5 ms before the fix; P95 246.6 ms versus 508.0 ms; picker reached 0/50 versus 50/50
