### PR TITLE
refactor(commands)!: remove registration owner

### DIFF
--- a/README.org
+++ b/README.org
@@ -118,7 +118,6 @@ Magent directly from Git:
    :turn
    (magent-command-turn-spec-create
     :prompt "What is your name?")
-   :owner 'my-magent-commands
    :source-layer 'user
    :required-tools '(read_file grep bash emacs_eval)))
 #+end_src
@@ -127,7 +126,9 @@ The ~:required-tools~ list declares tools that must be available before the
 command can run; replace it with the command's actual requirements, or omit it
 for a tool-free command. Exactly one of ~:turn~ and ~:handler~ is required. A
 ~user~ command can override an installed ~package~ or ~builtin~ command with
-the same name. The core ~/compact~ name remains reserved.
+the same name. Registering the same name, layer, and canonical scope again
+replaces that slot's previous definition. The core ~/compact~ name remains
+reserved.
 
 * Configuration
 

--- a/docs/COMMANDS.org
+++ b/docs/COMMANDS.org
@@ -153,7 +153,6 @@ the same public API available to third-party packages:
     :skills '("code-review")
     :agent 'build
     :append-argument-p t))
- :owner 'magent-command-my-review
  :source-layer 'project
  :source-scope "/path/to/project"
  :requires-project t
@@ -163,12 +162,18 @@ the same public API available to third-party packages:
 Every registration must provide exactly one of ~:turn~ and ~:handler~. A
 ~:turn~ value is either one static ~magent-command-turn-spec~ or a builder
 function that receives the invocation and returns one. The example uses every
-registration field that can accompany ~:turn~: ~:description~, ~:owner~,
+registration field that can accompany ~:turn~: ~:description~,
 ~:source-layer~, ~:source-scope~, ~:requires-project~, and
 ~:required-tools~. The turn spec uses all of its fields: ~:prompt~,
 ~:buffers~, ~:skills~, ~:agent~, and ~:append-argument-p~. Use ~:handler~
 instead only when trusted Elisp must own a custom lifecycle; it cannot be
 combined with ~:turn~.
+
+The tuple ~(NAME, SOURCE-LAYER, canonical SOURCE-SCOPE)~ is one registry
+slot. Registering that slot again replaces its previous definition and makes
+the old registration token stale; unregistering the replacement does not
+restore the older same-slot definition. Different layers and project scopes
+remain independent and still participate in normal precedence resolution.
 
 ~:buffers~ follows a popwin-style ordered pattern list:
 

--- a/docs/COMMANDS.zh.org
+++ b/docs/COMMANDS.zh.org
@@ -143,7 +143,6 @@ org-roam capture 约定 ~YYYY-MM-DDtHHMM.org~。后续运行通过 file-level
     :skills '("code-review")
     :agent 'build
     :append-argument-p t))
- :owner 'magent-command-my-review
  :source-layer 'project
  :source-scope "/path/to/project"
  :requires-project t
@@ -152,11 +151,16 @@ org-roam capture 约定 ~YYYY-MM-DDtHHMM.org~。后续运行通过 file-level
 
 每个 registration 必须且只能提供 ~:turn~ 和 ~:handler~ 之一。~:turn~ 可以是静态
 ~magent-command-turn-spec~，也可以是接收 invocation 并返回 turn spec 的 builder。
-上例使用了所有可与 ~:turn~ 搭配的 registration 字段：~:description~、~:owner~、
+上例使用了所有可与 ~:turn~ 搭配的 registration 字段：~:description~、
 ~:source-layer~、~:source-scope~、~:requires-project~ 和
 ~:required-tools~；也使用了 turn spec 的全部字段：~:prompt~、~:buffers~、
 ~:skills~、~:agent~ 和 ~:append-argument-p~。只有受信任 Elisp 需要自主管理
 生命周期时才改用 ~:handler~，它不能和 ~:turn~ 同时出现。
+
+~(NAME, SOURCE-LAYER, canonical SOURCE-SCOPE)~ 这个三元组对应唯一的 registry
+slot。再次注册同一 slot 会替换旧定义，并使旧 registration token 失效；撤销新
+registration 不会恢复同一 slot 的旧定义。不同 layer 和不同 project scope 仍然
+彼此独立，并继续参与正常的优先级解析。
 
 ~:buffers~ 使用类似 popwin 的有序 pattern list：
 

--- a/lisp/magent-command-controls.el
+++ b/lisp/magent-command-controls.el
@@ -25,12 +25,11 @@
 (defun magent-command-controls-register ()
   "Register the reserved Magent session control command."
   (let ((magent-command--allow-core-registration t))
-    (magent-command-remove-source 'core nil 'magent-command-controls)
+    (magent-command-remove-source 'core)
     (magent-command-register
      "compact"
      :description "Summarize and compact the current conversation context."
      :handler #'magent-command-controls--compact
-     :owner 'magent-command-controls
      :source-layer 'core)))
 
 (provide 'magent-command-controls)

--- a/lisp/magent-command-explain.el
+++ b/lisp/magent-command-explain.el
@@ -16,7 +16,6 @@
    :turn (lambda (_invocation)
            (magent-command-turn-spec-create
             :prompt (magent-prompt-read "commands/explain.org")))
-   :owner 'magent-command-explain
    :source-layer 'builtin
    :required-tools '(read_file grep bash emacs_eval)))
 

--- a/lisp/magent-command-fix.el
+++ b/lisp/magent-command-fix.el
@@ -16,7 +16,6 @@
    :turn (lambda (_invocation)
            (magent-command-turn-spec-create
             :prompt (magent-prompt-read "commands/fix.org")))
-   :owner 'magent-command-fix
    :source-layer 'builtin
    :required-tools '(read_file write_file edit_file grep bash emacs_eval)))
 

--- a/lisp/magent-command-init.el
+++ b/lisp/magent-command-init.el
@@ -16,7 +16,6 @@
    :turn (lambda (_invocation)
            (magent-command-turn-spec-create
             :prompt (magent-prompt-read "commands/init.org")))
-   :owner 'magent-command-init
    :source-layer 'builtin
    :required-tools '(read_file write_file edit_file grep glob bash)))
 

--- a/lisp/magent-command-review.el
+++ b/lisp/magent-command-review.el
@@ -16,7 +16,6 @@
    :turn (lambda (_invocation)
            (magent-command-turn-spec-create
             :prompt (magent-prompt-read "commands/review.org")))
-   :owner 'magent-command-review
    :source-layer 'builtin
    :required-tools '(read_file grep bash)))
 

--- a/lisp/magent-command-summarize.el
+++ b/lisp/magent-command-summarize.el
@@ -16,7 +16,6 @@
    :turn (lambda (_invocation)
            (magent-command-turn-spec-create
             :prompt (magent-prompt-read "commands/summarize.org")))
-   :owner 'magent-command-summarize
    :source-layer 'builtin
    :requires-project t
    :required-tools '(read_file grep glob bash write_repo_summary)))

--- a/lisp/magent-command-test.el
+++ b/lisp/magent-command-test.el
@@ -16,7 +16,6 @@
    :turn (lambda (_invocation)
            (magent-command-turn-spec-create
             :prompt (magent-prompt-read "commands/test.org")))
-   :owner 'magent-command-test
    :source-layer 'builtin
    :required-tools '(read_file grep bash emacs_eval)))
 

--- a/lisp/magent-command.el
+++ b/lisp/magent-command.el
@@ -25,7 +25,6 @@
 (declare-function magent-command-builtins-register "magent-command-builtins")
 (declare-function magent-runtime-active-project-scope "magent-runtime")
 (declare-function magent-skill-description "magent-skills")
-(declare-function magent-skill-file-path "magent-skills")
 (declare-function magent-skill-requires-project "magent-skills")
 (declare-function magent-skill-source-layer "magent-skills")
 (declare-function magent-skill-source-scope "magent-skills")
@@ -43,7 +42,6 @@
   description
   turn
   handler
-  owner
   source-layer
   source-scope
   requires-project
@@ -89,6 +87,10 @@ and APPEND-ARGUMENT-P controls slash argument expansion."
 
 (defvar magent-command--registry nil
   "Layered list of registered `magent-command-spec' objects.")
+
+(defvar magent-command--skill-adapter-registrations
+  (make-hash-table :test #'equal)
+  "Generated skill command registrations keyed by canonical scope.")
 
 (defvar magent-command--sequence 0
   "Monotonic sequence used to resolve same-layer registrations.")
@@ -159,23 +161,17 @@ When SCOPE is nil, use the currently active project overlay."
     (or (null source-scope)
         (equal source-scope scope))))
 
-(defun magent-command--same-owner-p (left right)
-  "Return non-nil when command specs LEFT and RIGHT share an owner slot."
+(defun magent-command--same-slot-p (left right)
+  "Return non-nil when command specs LEFT and RIGHT share a registry slot."
   (and (equal (magent-command-spec-name left)
               (magent-command-spec-name right))
        (eq (magent-command-spec-source-layer left)
            (magent-command-spec-source-layer right))
        (equal (magent-command-spec-source-scope left)
-              (magent-command-spec-source-scope right))
-       (equal (magent-command-spec-owner left)
-              (magent-command-spec-owner right))))
-
-(defun magent-command--default-owner ()
-  "Return a stable default owner for the current registration site."
-  (or load-file-name buffer-file-name 'anonymous))
+              (magent-command-spec-source-scope right))))
 
 (cl-defun magent-command-register
-    (name &key description turn handler owner (source-layer 'package)
+    (name &key description turn handler (source-layer 'package)
           source-scope requires-project required-tools)
   "Register slash command NAME and return its registration token.
 
@@ -184,9 +180,9 @@ Exactly one of TURN and HANDLER must be provided.  TURN is a
 `magent-command-invocation' and returning a turn spec.  HANDLER receives the
 invocation directly and must complete it synchronously or call
 `magent-command-defer' before returning.  SOURCE-LAYER is one of `builtin',
-`package', `user', `project', or reserved `core'.  OWNER and SOURCE-SCOPE
-identify reloadable definitions.  REQUIRES-PROJECT and REQUIRED-TOOLS are
-checked before model work or HANDLER execution."
+`package', `user', `project', or reserved `core'.  NAME, SOURCE-LAYER, and
+SOURCE-SCOPE identify one replaceable registration slot.  REQUIRES-PROJECT and
+REQUIRED-TOOLS are checked before model work or HANDLER execution."
   (unless (xor (not (null turn)) (not (null handler)))
     (error "Magent command %S requires exactly one of :turn or :handler" name))
   (when (and turn
@@ -200,7 +196,6 @@ checked before model work or HANDLER execution."
   (let* ((key (magent-command--normalize-name name))
          (layer (or source-layer 'package))
          (_rank (magent-command--layer-rank layer))
-         (registration-owner (or owner (magent-command--default-owner)))
          (registration-scope
           (magent-command--canonical-scope source-scope))
          (spec (magent-command-spec-create
@@ -208,7 +203,6 @@ checked before model work or HANDLER execution."
                 :description description
                 :turn turn
                 :handler handler
-                :owner registration-owner
                 :source-layer layer
                 :source-scope registration-scope
                 :requires-project requires-project
@@ -221,22 +215,9 @@ checked before model work or HANDLER execution."
     (when (and (eq layer 'core)
                (not magent-command--allow-core-registration))
       (error "The Magent command core layer is reserved"))
-    (when-let* ((collision
-                 (cl-find-if
-                  (lambda (candidate)
-                    (and (equal key (magent-command-spec-name candidate))
-                         (eq layer
-                             (magent-command-spec-source-layer candidate))
-                         (equal registration-scope
-                                (magent-command-spec-source-scope candidate))
-                         (not (magent-command--same-owner-p candidate spec))))
-                  magent-command--registry)))
-      (magent-log
-       "WARN slash command /%s layer %s from %S shadows same-layer owner %S"
-       key layer registration-owner (magent-command-spec-owner collision)))
     (setq magent-command--registry
           (cl-remove-if (lambda (candidate)
-                          (magent-command--same-owner-p candidate spec))
+                          (magent-command--same-slot-p candidate spec))
                         magent-command--registry))
     (push spec magent-command--registry)
     (magent-command--registry-changed)
@@ -256,22 +237,23 @@ checked before model work or HANDLER execution."
       (magent-command--registry-changed)
       t)))
 
-(defun magent-command-remove-source (source-layer &optional source-scope owner)
-  "Remove registrations matching SOURCE-LAYER, SOURCE-SCOPE, and OWNER.
-Nil SOURCE-SCOPE or OWNER acts as a wildcard.  Return the removal count."
+(defun magent-command-remove-source (source-layer &optional source-scope)
+  "Remove registrations matching SOURCE-LAYER and SOURCE-SCOPE.
+Nil SOURCE-SCOPE acts as a wildcard.  Return the removal count."
   (when (and (eq source-layer 'core)
              (not magent-command--allow-core-registration))
     (error "The Magent command core layer is reserved"))
-  (let ((before (length magent-command--registry)))
+  (let ((removal-scope
+         (and source-scope
+              (magent-command--canonical-scope source-scope)))
+        (before (length magent-command--registry)))
     (setq magent-command--registry
           (cl-remove-if
            (lambda (spec)
              (and (eq source-layer (magent-command-spec-source-layer spec))
                   (or (null source-scope)
-                      (equal source-scope
-                             (magent-command-spec-source-scope spec)))
-                  (or (null owner)
-                      (equal owner (magent-command-spec-owner spec)))))
+                      (equal removal-scope
+                             (magent-command-spec-source-scope spec)))))
            magent-command--registry))
     (let ((removed (- before (length magent-command--registry))))
       (when (> removed 0)
@@ -324,27 +306,19 @@ When SCOPE is nil, resolve against the currently active project overlay."
     ('user 'user)
     (_ 'package)))
 
-(defun magent-command--skill-adapter-owner-p (owner)
-  "Return non-nil when OWNER identifies a generated skill adapter."
-  (and (consp owner) (eq (car owner) 'skill-adapter)))
-
 (defun magent-command-refresh-skill-adapters (&optional scope)
   "Rebuild compatibility commands for effective skills in SCOPE.
 Global adapters and each visited project scope are cached independently so
 live sessions can resolve commands without switching the active overlay."
   (require 'magent-skills)
   (let ((target-scope (magent-command--canonical-scope scope))
-        (magent-command--suppress-registry-hooks t))
-    (setq magent-command--registry
-          (cl-remove-if
-           (lambda (spec)
-             (and
-              (magent-command--skill-adapter-owner-p
-               (magent-command-spec-owner spec))
-              (equal target-scope
-                     (magent-command--canonical-scope
-                      (magent-command-spec-source-scope spec)))))
-           magent-command--registry))
+        (magent-command--suppress-registry-hooks t)
+        registrations)
+    (dolist (registration
+             (gethash target-scope
+                      magent-command--skill-adapter-registrations))
+      (magent-command-unregister registration))
+    (remhash target-scope magent-command--skill-adapter-registrations)
     (dolist (name (magent-skills-command-names))
       ;; Give every generated turn builder its own lexical skill-name binding.
       (let ((skill-name name))
@@ -355,28 +329,30 @@ live sessions can resolve commands without switching the active overlay."
                             (magent-command--canonical-scope
                              (magent-skill-source-scope skill)))))
           (condition-case err
-              (magent-command-register
-               skill-name
-               :description (magent-skill-description skill)
-               :turn
-               (lambda (invocation)
-                 (magent-command-turn-spec-create
-                  :prompt prompt
-                  :skills
-                  (magent-skills-dedupe-names
-                   (append
-                    (magent-runtime-session-pending-skills
-                     (magent-command-invocation-runtime-session invocation))
-                    (list skill-name)))))
-               :owner (list 'skill-adapter
-                            (or (magent-skill-file-path skill) skill-name))
-               :source-layer (magent-command--skill-source-layer skill)
-               :source-scope (magent-skill-source-scope skill)
-               :requires-project (magent-skill-requires-project skill)
-               :required-tools (magent-skill-tools skill))
+              (push
+               (magent-command-register
+                skill-name
+                :description (magent-skill-description skill)
+                :turn
+                (lambda (invocation)
+                  (magent-command-turn-spec-create
+                   :prompt prompt
+                   :skills
+                   (magent-skills-dedupe-names
+                    (append
+                     (magent-runtime-session-pending-skills
+                      (magent-command-invocation-runtime-session invocation))
+                     (list skill-name)))))
+                :source-layer (magent-command--skill-source-layer skill)
+                :source-scope (magent-skill-source-scope skill)
+                :requires-project (magent-skill-requires-project skill)
+                :required-tools (magent-skill-tools skill))
+               registrations)
             (error
              (magent-log "WARN skipped skill command adapter %S: %s"
-                         skill-name (error-message-string err))))))))
+                         skill-name (error-message-string err)))))))
+    (puthash target-scope (nreverse registrations)
+             magent-command--skill-adapter-registrations))
   (magent-command--registry-changed)
   (magent-command-list (or scope 'global)))
 

--- a/test/magent-command-builtin-test.el
+++ b/test/magent-command-builtin-test.el
@@ -16,8 +16,6 @@
     (magent-command-test-register)
     (let ((command (magent-command-get "test")))
       (should command)
-      (should (eq (magent-command-spec-owner command)
-                  'magent-command-test))
       (should (eq (magent-command-spec-source-layer command) 'builtin))
       (should (equal (magent-command-spec-required-tools command)
                      '(read_file grep bash emacs_eval))))))

--- a/test/magent-live-test.el
+++ b/test/magent-live-test.el
@@ -788,8 +788,7 @@ return that path."
            :turn
            (magent-command-turn-spec-create
             :prompt "Inspect the attached live buffer."
-            :buffers (list context-buffer))
-           :owner 'magent-live-test)
+            :buffers (list context-buffer)))
           (cl-letf (((symbol-function 'magent-runtime-submit)
                      (lambda (session prompt &rest args)
                        (setq submitted (list session prompt args))

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -4015,13 +4015,16 @@
   (require 'magent-command)
   (let ((magent-command--registry nil)
         (turn (magent-command-turn-spec-create :prompt "Demo")))
-    (should-error (magent-command-register "missing" :owner 'test))
+    (should-error (magent-command-register "missing"))
     (should-error
      (magent-command-register
-      "ambiguous" :turn turn :handler #'ignore :owner 'test))
-    (should (magent-command-register "turn" :turn turn :owner 'test))
+      "ambiguous" :turn turn :handler #'ignore))
+    (should (magent-command-register "turn" :turn turn))
     (should
-     (magent-command-register "handler" :handler #'ignore :owner 'test))))
+     (magent-command-register "handler" :handler #'ignore))
+    (should-error
+     (magent-command-register
+      "retired-owner" :handler #'ignore :owner 'retired))))
 
 (ert-deftest magent-test-command-registry-resolves-layered-overrides ()
   "Test command precedence and exact registration removal."
@@ -4030,16 +4033,16 @@
         (magent-command--sequence 0))
     (let ((builtin (magent-command-register
                     "demo" :description "builtin" :handler #'ignore
-                    :owner 'builtin :source-layer 'builtin))
+                    :source-layer 'builtin))
           (package (magent-command-register
                     "demo" :description "package" :handler #'ignore
-                    :owner 'package :source-layer 'package))
+                    :source-layer 'package))
           (user (magent-command-register
                  "demo" :description "user" :handler #'ignore
-                 :owner 'user :source-layer 'user))
+                 :source-layer 'user))
           (project (magent-command-register
                     "demo" :description "project" :handler #'ignore
-                    :owner 'project :source-layer 'project)))
+                    :source-layer 'project)))
       (should (eq (magent-command-get "demo") project))
       (should (magent-command-unregister project))
       (should (eq (magent-command-get "demo") user))
@@ -4047,6 +4050,55 @@
       (should (eq (magent-command-get "demo") package))
       (should (magent-command-unregister package))
       (should (eq (magent-command-get "demo") builtin)))))
+
+(ert-deftest magent-test-command-register-replaces-one-layer-scope-slot ()
+  "Test one name/layer/scope slot retains only its newest registration."
+  (require 'magent-command)
+  (let ((magent-command--registry nil)
+        (magent-command--sequence 0))
+    (let ((old (magent-command-register
+                "demo" :description "old" :handler #'ignore
+                :source-layer 'project :source-scope "/tmp/project-a"))
+          new other-scope)
+      (setq new
+            (magent-command-register
+             "demo" :description "new" :handler #'ignore
+             :source-layer 'project :source-scope "/tmp/project-a"))
+      (setq other-scope
+            (magent-command-register
+             "demo" :description "other" :handler #'ignore
+             :source-layer 'project :source-scope "/tmp/project-b"))
+      (should (= (length magent-command--registry) 2))
+      (should (eq (magent-command-get "demo" "/tmp/project-a") new))
+      (should (eq (magent-command-get "demo" "/tmp/project-b") other-scope))
+      (should-not (magent-command-unregister old))
+      (should (magent-command-unregister new))
+      (should-not (magent-command-get "demo" "/tmp/project-a")))))
+
+(ert-deftest magent-test-command-remove-source-is-layer-and-scope-bounded ()
+  "Test source removal preserves registrations outside its layer and scope."
+  (require 'magent-command)
+  (let ((magent-command--registry nil))
+    (let ((global (magent-command-register
+                   "global" :handler #'ignore :source-layer 'user))
+          (project-b
+           (magent-command-register
+            "project-b" :handler #'ignore :source-layer 'project
+            :source-scope "/tmp/project-b")))
+      (magent-command-register
+       "project-a" :handler #'ignore :source-layer 'project
+       :source-scope "/tmp/project-a")
+      (should (= (magent-command-remove-source
+                  'project "/tmp/project-a")
+                 1))
+      (should (eq (magent-command-get "global") global))
+      (should (eq (magent-command-get "project-b" "/tmp/project-b")
+                  project-b))
+      (should-not (magent-command-get "project-a" "/tmp/project-a"))
+      (should (= (magent-command-remove-source 'project) 1))
+      (should (eq (magent-command-get "global") global))
+      (should (= (magent-command-remove-source 'user 'global) 1))
+      (should-not (magent-command-get "global")))))
 
 (ert-deftest magent-test-command-registry-change-hook-tracks-mutations ()
   "Test frontend discovery hooks run for register and unregister."
@@ -4057,7 +4109,7 @@
     (add-hook 'magent-command-registry-changed-hook
               (lambda () (cl-incf changes)))
     (let ((registration
-           (magent-command-register "demo" :handler #'ignore :owner 'test)))
+           (magent-command-register "demo" :handler #'ignore)))
       (should (= changes 1))
       (should (magent-command-unregister registration))
       (should (= changes 2)))))
@@ -4068,14 +4120,14 @@
   (let ((magent-command--registry nil))
     (let ((core (let ((magent-command--allow-core-registration t))
                   (magent-command-register
-                   "compact" :handler #'ignore :owner 'core
+                   "compact" :handler #'ignore
                    :source-layer 'core))))
       (magent-command-register
-       "compact" :handler #'ignore :owner 'project :source-layer 'project)
+       "compact" :handler #'ignore :source-layer 'project)
       (should (eq (magent-command-get "compact") core))
       (should-error
        (magent-command-register
-        "reserved" :handler #'ignore :owner 'package :source-layer 'core)
+        "reserved" :handler #'ignore :source-layer 'core)
        :type 'error)
       (should-error (magent-command-unregister core) :type 'error)
       (should-error (magent-command-remove-source 'core) :type 'error))))
@@ -4085,9 +4137,11 @@
   (require 'magent-command)
   (require 'magent-skills)
   (let ((magent-command--registry nil)
+        (magent-command--skill-adapter-registrations
+         (make-hash-table :test #'equal))
         (magent-skills--registry nil))
     (let ((builtin (magent-command-register
-                    "fix" :handler #'ignore :owner 'builtin
+                    "fix" :handler #'ignore
                     :source-layer 'builtin)))
       (magent-skills-register
        (magent-skill-create
@@ -4108,6 +4162,8 @@
   (require 'magent-skills)
   (let ((magent-skills--registry nil)
         (magent-command--registry nil)
+        (magent-command--skill-adapter-registrations
+         (make-hash-table :test #'equal))
         (magent-command--sequence 0)
         (magent-command-registry-changed-hook nil))
     (magent-skills-register
@@ -4147,6 +4203,8 @@
   (require 'magent-command)
   (require 'magent-skills)
   (let ((magent-command--registry nil)
+        (magent-command--skill-adapter-registrations
+         (make-hash-table :test #'equal))
         (magent-skills--registry nil))
     (dolist (name '("valid-skill" "not/a/slash-name"))
       (magent-skills-register
@@ -4160,11 +4218,40 @@
      (cl-find "not/a/slash-name" magent-command--registry
               :key #'magent-command-spec-name :test #'equal))))
 
+(ert-deftest magent-test-command-skill-refresh-unregisters-only-its-tokens ()
+  "Test skill refresh preserves unrelated registrations in the same source."
+  (require 'magent-command)
+  (require 'magent-skills)
+  (let ((magent-command--registry nil)
+        (magent-command--skill-adapter-registrations
+         (make-hash-table :test #'equal))
+        (magent-skills--registry nil))
+    (let ((native
+           (magent-command-register
+            "native" :handler #'ignore :source-layer 'user)))
+      (magent-skills-register
+       (magent-skill-create
+        :name "adapter" :type 'instruction :default-prompt "Run it"
+        :source-layer 'user))
+      (magent-command-refresh-skill-adapters)
+      (should (eq (magent-command-get "native") native))
+      (should (magent-command-get "adapter"))
+      (should (= (length
+                  (gethash nil
+                           magent-command--skill-adapter-registrations))
+                 1))
+      (setq magent-skills--registry nil)
+      (magent-command-refresh-skill-adapters)
+      (should (eq (magent-command-get "native") native))
+      (should-not (magent-command-get "adapter")))))
+
 (ert-deftest magent-test-command-skill-adapters-capture-distinct-skill-names ()
   "Test generated adapter closures activate their own original skills."
   (require 'magent-command)
   (require 'magent-skills)
   (let ((magent-command--registry nil)
+        (magent-command--skill-adapter-registrations
+         (make-hash-table :test #'equal))
         (magent-skills--registry nil)
         (runtime-session (magent-runtime-session-create :id "session-1")))
     (dolist (name '("alpha" "beta"))
@@ -4206,7 +4293,7 @@
         :prompt "Base prompt"
         :skills '("review")
         :agent 'review-agent))
-     :owner 'test :source-layer 'package)
+     :source-layer 'package)
     (cl-letf (((symbol-function 'magent-runtime-session-available-tool-names)
                (lambda (_session &optional agent)
                  (setq preflight-agent agent)
@@ -4260,7 +4347,7 @@
         :prompt (format "Review target: %s"
                         (magent-command-invocation-argument invocation))
         :append-argument-p nil))
-     :owner 'test :source-layer 'package)
+     :source-layer 'package)
     (cl-letf (((symbol-function 'magent-runtime-submit)
                (lambda (_session prompt &rest args)
                  (setq submitted-prompt prompt)
@@ -4282,7 +4369,7 @@
     (magent-command-register
      "demo" :description "Demo"
      :turn (lambda (_invocation) "invalid")
-     :owner 'test :source-layer 'package)
+     :source-layer 'package)
     (cl-letf (((symbol-function 'magent-runtime-submit)
                (lambda (&rest _args) (setq submitted t))))
       (magent-command-invoke
@@ -4478,8 +4565,7 @@
      :handler (lambda (value)
                 (setq invocation value)
                 (magent-command-progress value "phase one")
-                (magent-command-defer value))
-     :owner 'test)
+                (magent-command-defer value)))
     (magent-command-invoke
      "async" runtime-session
      :observer (lambda (event) (push event events))
@@ -4503,8 +4589,7 @@
      "workflow"
      :handler (lambda (value)
                 (setq invocation value)
-                (magent-command-defer value))
-     :owner 'test)
+                (magent-command-defer value)))
     (magent-command-invoke "workflow" runtime-session)
     (cl-letf (((symbol-function 'magent-runtime-submit)
                (lambda (_session prompt &rest args)
@@ -4563,8 +4648,7 @@
      "workflow"
      :handler (lambda (value)
                 (setq invocation value)
-                (magent-command-defer value))
-     :owner 'test)
+                (magent-command-defer value)))
     (magent-command-invoke
      "workflow" runtime-session
      :on-complete (lambda (status result)
@@ -4603,7 +4687,7 @@
         (magent-command--active-invocations (make-hash-table :test #'eq))
         (runtime-session (magent-runtime-session-create :id "session-1"))
         completion)
-    (magent-command-register "broken" :handler #'ignore :owner 'test)
+    (magent-command-register "broken" :handler #'ignore)
     (magent-command-invoke
      "broken" runtime-session
      :on-complete (lambda (status result)
@@ -4638,12 +4722,11 @@
           (push 'custom-cleanup order)))
        (magent-command-defer value)
        (magent-command-submit
-        value "queued work"
-        :on-complete
+       value "queued work"
+       :on-complete
         (lambda (status result)
           (magent-command-finish value status result)))
-       (error "handler exploded"))
-     :owner 'test)
+       (error "handler exploded")))
     (cl-letf (((symbol-function 'magent-runtime-submit)
                (lambda (_session _prompt &rest args)
                  (setq submission-callback (plist-get args :on-complete))
@@ -4689,7 +4772,6 @@
     (magent-command-register
      "project-only"
      :handler (lambda (_invocation) (setq handler-ran t))
-     :owner 'test
      :requires-project t)
     (magent-command-invoke
      "project-only" global-session
@@ -4703,7 +4785,6 @@
     (magent-command-register
      "needs-tools"
      :handler (lambda (_invocation) (setq handler-ran t))
-     :owner 'test
      :required-tools '(read_file bash))
     (cl-letf (((symbol-function
                 'magent-runtime-session-available-tool-names)
@@ -4732,8 +4813,7 @@
        (setq invocation value)
        (magent-command-set-cancel-function
         value (lambda () (cl-incf cleanup)))
-       (magent-command-defer value))
-     :owner 'test)
+       (magent-command-defer value)))
     (cl-letf (((symbol-function 'magent-runtime-cancel)
                (lambda (session) (setq runtime-cancel session))))
       (magent-command-invoke
@@ -4758,8 +4838,7 @@
      "wait"
      :handler (lambda (value)
                 (setq invocation value)
-                (magent-command-defer value))
-     :owner 'test)
+                (magent-command-defer value)))
     (magent-command-invoke "wait" runtime-session)
     (cl-letf (((symbol-function 'magent-runtime-cancel)
                (lambda (_session)
@@ -10505,7 +10584,9 @@
   (require 'magent-acp)
   (require 'magent-command-controls)
   (let ((magent-skills--registry nil)
-        (magent-command--registry nil))
+        (magent-command--registry nil)
+        (magent-command--skill-adapter-registrations
+         (make-hash-table :test #'equal)))
     (magent-command-controls-register)
     (magent-skills-register
      (magent-skill-create
@@ -10580,11 +10661,11 @@
                     :id "session-b" :scope "/tmp/project-b")))
     (let ((command-a
            (magent-command-register
-            "project-command" :handler #'ignore :owner 'project-a
+            "project-command" :handler #'ignore
             :source-layer 'project :source-scope "/tmp/project-a"))
           (command-b
            (magent-command-register
-            "project-command" :handler #'ignore :owner 'project-b
+            "project-command" :handler #'ignore
             :source-layer 'project :source-scope "/tmp/project-b")))
       (should (eq (plist-get (magent-acp--slash-command
                               "/project-command" project-a)
@@ -10601,7 +10682,7 @@
   (let ((magent-command--registry nil))
     (let ((magent-command--allow-core-registration t))
       (magent-command-register
-       "clear" :handler #'ignore :owner 'magent-command-controls
+       "clear" :handler #'ignore
        :source-layer 'core))
     (magent-command-controls-register)
     (let ((compact (magent-acp--slash-command
@@ -10673,12 +10754,12 @@
            :id "session-b" :scope "/tmp/project-b"))
          notifications)
     (magent-command-register
-     "global-command" :handler #'ignore :owner 'global)
+     "global-command" :handler #'ignore)
     (magent-command-register
-     "project-a-command" :handler #'ignore :owner 'project-a
+     "project-a-command" :handler #'ignore
      :source-layer 'project :source-scope "/tmp/project-a")
     (magent-command-register
-     "project-b-command" :handler #'ignore :owner 'project-b
+     "project-b-command" :handler #'ignore
      :source-layer 'project :source-scope "/tmp/project-b")
     (puthash "session-a" "/tmp/project-a" bindings)
     (puthash "session-b" "/tmp/project-b" bindings)
@@ -10863,6 +10944,8 @@
   (require 'magent-acp)
   (let ((magent-command--registry nil)
         (magent-command--active-invocations (make-hash-table :test #'eq))
+        (magent-command--skill-adapter-registrations
+         (make-hash-table :test #'equal))
         (magent-skills--registry nil)
         (runtime-session (magent-runtime-session-create
                           :id "session-1"
@@ -10921,7 +11004,7 @@
      :turn
      (magent-command-turn-spec-create
       :prompt "Review the attached context.")
-     :owner 'test :source-layer 'package)
+     :source-layer 'package)
     (cl-letf (((symbol-function 'magent-acp--runtime-session-by-id)
                (lambda (session-id)
                  (and (equal session-id "session-1") runtime-session)))
@@ -10985,8 +11068,7 @@
          :turn
          (magent-command-turn-spec-create
           :prompt "Inspect resources."
-          :buffers (list context-buffer))
-         :owner 'test)
+          :buffers (list context-buffer)))
         (cl-letf (((symbol-function 'magent-acp--runtime-session-by-id)
                    (lambda (_session-id) runtime-session))
                   ((symbol-function 'magent-runtime-submit)
@@ -11855,7 +11937,7 @@
   (require 'magent-agent-shell)
   (let ((magent-command--registry nil)
         sent)
-    (magent-command-register "demo" :handler #'ignore :owner 'test)
+    (magent-command-register "demo" :handler #'ignore)
     (cl-letf (((symbol-function 'magent--ensure-initialized) #'ignore)
               ((symbol-function 'magent-agent-shell--prepare-skill-context)
                #'ignore)
@@ -11878,10 +11960,10 @@
           :id "session-a" :scope "/tmp/project-a"))
         offered sent)
     (magent-command-register
-     "project-a-command" :handler #'ignore :owner 'project-a
+     "project-a-command" :handler #'ignore
      :source-layer 'project :source-scope "/tmp/project-a")
     (magent-command-register
-     "project-b-command" :handler #'ignore :owner 'project-b
+     "project-b-command" :handler #'ignore
      :source-layer 'project :source-scope "/tmp/project-b")
     (cl-letf (((symbol-function 'magent--ensure-initialized) #'ignore)
               ((symbol-function 'magent-runtime-ensure-initialized) #'ignore)


### PR DESCRIPTION
## Summary

- remove the owner keyword from magent-command-register and the owner slot from magent-command-spec
- define one replaceable registry slot by command name, source layer, and canonical source scope
- retain exact registration tokens for generated skill adapters so refreshes only unregister their own definitions
- scope source removal by canonical layer and scope while preserving reserved core-control rebuilding
- update builtins, tests, live fixtures, and English/Chinese documentation

## Breaking change

Third-party command registrations must remove the owner keyword. Re-registering the same name, layer, and canonical scope now replaces that slot directly; removing the replacement does not restore an older same-slot definition.

## Verification

- make compile: 48 files compiled without warnings
- make test-unit: 539/539 passed
- isolated Emacs daemon live smoke: 2/2 passed
- no Magent log, warning, or backtrace buffers were produced