### PR TITLE
fix(runtime): defer session activation when scope lease is held

### DIFF
--- a/lisp/magent-runtime-api.el
+++ b/lisp/magent-runtime-api.el
@@ -55,20 +55,27 @@
   "Return SESSION's stable id."
   (magent-session-get-id session))
 
-(defun magent-runtime-session-ensure-registerable (scope session)
-  "Signal when installing SESSION at SCOPE would violate a queue lease."
+(defun magent-runtime-api--scope-lease-conflict-p (scope session)
+  "Return non-nil when installing SESSION at SCOPE would steal a lease."
+  (when-let* ((active-scope (magent-runtime-queue-active-scope)))
+    (and (equal (magent-session-scope-origin scope) active-scope)
+         (not (eq (magent-runtime-queue-active-session-object) session)))))
+
+(defun magent-runtime-session-ensure-registerable
+    (scope session &optional wrapper-only)
+  "Signal when registering SESSION at SCOPE would violate a queue lease.
+When WRAPPER-ONLY is non-nil, validate only the runtime wrapper registration;
+the currently installed session is not replaced."
   (let* ((id (magent-runtime-api--session-id session))
          (existing
           (gethash (magent-runtime-api--session-key scope id)
                    magent-runtime-api--sessions))
          (existing-session
           (and existing (magent-runtime-session-magent-session existing)))
-         (installed (magent-session-get-if-present scope))
-         (active-scope (magent-runtime-queue-active-scope))
-         (active-session (magent-runtime-queue-active-session-object)))
-    (when (and active-scope
-               (equal (magent-session-scope-origin scope) active-scope)
-               (not (eq active-session session)))
+         (installed (and (not wrapper-only)
+                         (magent-session-get-if-present scope))))
+    (when (and (not wrapper-only)
+               (magent-runtime-api--scope-lease-conflict-p scope session))
       (user-error
        "Magent: cannot replace a session while its scope owns the execution lease"))
     (dolist (candidate (delq nil (list existing-session installed)))
@@ -90,7 +97,7 @@
 
 (defun magent-runtime-api--wrap-session (session scope)
   "Return runtime wrapper for Magent SESSION at SCOPE."
-  (magent-runtime-session-ensure-registerable scope session)
+  (magent-runtime-session-ensure-registerable scope session t)
   (let* ((id (magent-runtime-api--session-id session))
          (key (magent-runtime-api--session-key scope id))
          (existing (gethash key magent-runtime-api--sessions)))
@@ -121,11 +128,16 @@
        target-scope (magent-session-create)))))
 
 (defun magent-runtime-session-new (&optional scope)
-  "Create and activate a new runtime session for SCOPE."
+  "Create a new runtime session for SCOPE.
+Activate it immediately unless another session from the same scope owns the
+execution lease.  In that case, keep the new session detached until its first
+queued submission starts."
   (magent-runtime-ensure-initialized)
   (let* ((target-scope (or scope (magent-session-current-scope)))
          (session (magent-session-create)))
-    (magent-runtime-session-register target-scope session)))
+    (if (magent-runtime-api--scope-lease-conflict-p target-scope session)
+        (magent-runtime-api--wrap-session session target-scope)
+      (magent-runtime-session-register target-scope session))))
 
 (defun magent-runtime-session-from-id (session-id &optional scope)
   "Return runtime SESSION-ID, optionally restricted to exact SCOPE."

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -14532,6 +14532,58 @@
     (should (eq (magent-session-get-if-present scope) first))
     (should-not (magent-runtime-session-from-id "replacement" scope))))
 
+(ert-deftest magent-test-acp-session-new-defers-install-under-scope-lease ()
+  "ACP can create a fresh same-scope session while another turn executes."
+  (require 'magent-acp)
+  (let* ((magent--initialized t)
+         (magent-runtime-api--sessions (make-hash-table :test #'equal))
+         (magent-acp--client-session-scopes
+          (make-hash-table :test #'eq :weakness 'key))
+         (magent-runtime-queue--active nil)
+         (magent-runtime-queue--pending nil)
+         (magent-runtime-queue--arbiter-active nil)
+         (magent-runtime-queue--arbiter-pending nil)
+         (magent-session--scoped-sessions (make-hash-table :test #'equal))
+         (scope "/same")
+         (first (magent-session-create :id "first"))
+         (active-runtime
+          (magent-runtime-session-create
+           :id "first" :scope scope :magent-session first))
+         (submission
+          (magent-runtime-submission-create
+           :id "leased" :scope scope :session active-runtime))
+         (client '((:notification-handlers . nil)
+                   (:request-handlers . nil)))
+         response failure)
+    (magent-session-install scope first)
+    (puthash (list scope "first") active-runtime
+             magent-runtime-api--sessions)
+    (magent-runtime-queue-submit submission #'ignore)
+    (cl-letf (((symbol-function 'magent-session-scope-from-directory)
+               (lambda (_cwd) scope))
+              ((symbol-function 'magent-runtime-prepare-command-context)
+               #'ignore)
+              ((symbol-function 'magent-agent-registry-primary-agents)
+               (lambda () nil))
+              ((symbol-function 'magent-acp--available-commands)
+               (lambda (&optional _runtime-session) [])))
+      (magent-acp--handle-request
+       client
+       '((:method . "session/new") (:params . ((cwd . "/same"))))
+       (lambda (value) (setq response value))
+       (lambda (err &optional _raw) (setq failure err))))
+    (should-not failure)
+    (let* ((fresh-runtime
+            (magent-runtime-session-from-id
+             (map-elt response 'sessionId) scope))
+           (fresh (magent-runtime-session-magent-session fresh-runtime)))
+      (should (magent-runtime-session-p fresh-runtime))
+      (should-not (eq fresh first))
+      (should (eq (magent-session-get-if-present scope) first))
+      (should (eq (magent-runtime-session-from-id
+                   (magent-session-id fresh) scope)
+                  fresh-runtime)))))
+
 (ert-deftest magent-test-runtime-current-does-not-create-under-scope-lease ()
   "Missing scoped state stays missing when another exact session owns it."
   (require 'magent-runtime-api)


### PR DESCRIPTION
## Summary

ACP `session/new` requests would error when a same-scope session owned the execution lease, because `magent-runtime-session-new` unconditionally called `magent-runtime-session-register` — which rejects replacing an installed session under an active lease. This broke the common pattern of opening a new agent-shell buffer while another turn was in progress on the same project.

The fix extracts the lease-conflict check into `magent-runtime-api--scope-lease-conflict-p`, adds a `wrapper-only` parameter to `ensure-registerable` so the runtime wrapper path can proceed without the session-replacement guard, and updates `magent-runtime-session-new` to defer full activation when the scope lease is held. In that case the new session is wrapped but kept detached; it becomes active when its own first submission acquires the queue lease.

A new integration test verifies that `session/new` succeeds under an active scope lease, returns a valid distinct runtime session, and leaves the original installed session untouched.