### PR TITLE
refactor(commands)!: unify command workflows under a generator-backed DSL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,8 @@ magent.el (package entry point and lazy runtime bootstrap)
   ├─ magent-runtime-queue.el     (UI-neutral global turn queue and session-scoped cancellation)
   ├─ magent-runtime-api.el       (UI/backend-facing runtime session and prompt API)
   ├─ magent-project-instructions.el (bounded scoped AGENTS.md discovery and prompt injection)
-  ├─ magent-command.el           (public layered command registry and invocation lifecycle)
+  ├─ magent-command-workflow.el  (generator Workflow DSL and managed Step runtime)
+  ├─ magent-command.el           (public layered command registry and Invocation lifecycle)
   ├─ magent-command-builtins.el  (built-in slash-command registration aggregator)
   ├─ magent-command-*.el         (built-in command handlers and prompt workflows)
   ├─ magent-command-session.el   (isolated command persistence, viewer, and cancellation)
@@ -146,7 +147,7 @@ magent.el (package entry point and lazy runtime bootstrap)
 
 2. **Runtime** (`magent-runtime.el`): Owns the ordered initialization pipeline for agents, skills, slash commands, and capabilities. Static bundled definitions load once; project-local overlays under `.magent/` are activated and unloaded as session scope changes.
 
-3. **Commands** (`magent-command.el`, `magent-command-builtins.el`, `magent-command-*.el`): Elisp-native commands are explicit user actions registered through `magent-command-register`. `:exposure` selects slash, interactive, or both entry surfaces; `:session-policy` selects the current conversation or an isolated durable command session. A registration owns exactly one native declarative `:turn` or one advanced `:handler`; advanced trusted extensions can own asynchronous, cancellable, multi-step lifecycles. Definitions resolve by `core > project > user > package > builtin`, and core names are reserved. ACP resolves slash discovery and dispatch against each runtime session's exact scope. Terminal results are claimed before cleanup so synchronous cancellation callbacks cannot overwrite handler failures.
+3. **Commands** (`magent-command-workflow.el`, `magent-command.el`, `magent-command-builtins.el`, `magent-command-*.el`): Elisp-native commands are explicit user actions registered through `magent-command-register`. `:exposure` selects slash, interactive, or both entry surfaces; `:session-policy` selects the current conversation or an isolated durable command session. A registration owns exactly one generator-backed `:workflow`. Trusted Elisp owns control flow while managed agent, Answer, argv process, and callback Steps provide asynchronous suspension, cancellation, and ledger activity. Elisp feature dependencies are declared with `:requires`; tool requirements are step-local, and commands have no project-workspace requirement. Definitions resolve by `core > project > user > package > builtin`, and core names are reserved. ACP resolves slash discovery and dispatch against each runtime session's exact scope. Terminal results are claimed before cleanup so synchronous cancellation callbacks cannot overwrite Step failures.
 
 4. **Isolated commands** (`magent-command-session.el`, `magent-memory.el`, `magent-doctor.el`): `/doctor` and `/memory-*` are unified command specs exposed through both agent-shell and `M-x magent-command-run-*`. They create isolated sessions under `magent-session-directory/commands`, preserve the current conversation, and can be inspected with `magent-command-list-sessions` or cancelled with `magent-command-cancel`. Memory commands respect `magent-bypass-permission`. Doctor uses trusted read-only probes, Magent-owned redaction, and one tool-free direct request outside the runtime queue. Custom probes are trusted Elisp, not sandboxed code. See `docs/DOCTOR.org`.
 
@@ -209,7 +210,7 @@ Tool-type skills can have companion `.el` files defining `magent-skill-<name>-in
 
 UI-neutral `defcustom` variables live in `magent-config.el` under `customize-group magent`. LLM provider/model/key settings are managed entirely by gptel.
 
-Key settings: `magent-default-agent` (`"build"`), `magent-enable-tools` (list of enabled tool symbols), `magent-org-roam-directory` (repository summary destination; nil falls back to `org-roam-directory`), `magent-include-reasoning` (`t`/`ignore`/`nil`), `magent-request-timeout` (120s), `magent-bash-timeout` (300s), `magent-emacs-eval-timeout` (10s), `magent-max-history` (100).
+Key settings: `magent-default-agent` (`"build"`), `magent-enable-tools` (list of enabled tool symbols), `magent-org-roam-directory` (repository summary destination; nil falls back to `org-roam-directory`), `magent-include-reasoning` (`t`/`ignore`/`nil`), `magent-request-timeout` (120s), `magent-bash-timeout` (300s), `magent-emacs-eval-timeout` (10s), `magent-command-process-timeout` (300s), `magent-command-step-output-max-chars` (24000), `magent-max-history` (100).
 
 ### Supported Frontend Commands
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,34 @@
+# Magent
+
+Magent is an Emacs-native agent runtime whose explicit commands combine
+trusted Elisp control flow with managed asynchronous agent capabilities.
+
+## Language
+
+**Command**:
+An explicitly registered user action that owns metadata and one Workflow.
+_Avoid_: Handler, prompt command
+
+**Workflow**:
+The non-blocking Elisp control program executed for a Command.
+_Avoid_: Handler lifecycle, workflow run
+
+**Command Invocation**:
+One execution of a Command and the sole owner of its runtime state.
+_Avoid_: Workflow run, command context
+
+**Step**:
+An asynchronous boundary that a Workflow yields to Magent for waiting,
+cancellation, progress, and activity recording. It is not a security or
+side-effect boundary.
+_Avoid_: Stage, task node
+
+**Answer Step**:
+A terminal agent Step that streams the final user-visible response and ends
+the Command Invocation.
+_Avoid_: Final visibility mode
+
+**Requirement**:
+An Emacs feature that must load successfully before a Command Invocation can
+start. It does not install packages or require a project workspace.
+_Avoid_: Project requirement, package dependency installer

--- a/README.org
+++ b/README.org
@@ -30,26 +30,26 @@ define the same thing:
 | Primary role           | An explicit Emacs or slash-command action                                        | Reusable instructions or a model-invokable operation                                               |
 | Definition             | Trusted Elisp registered with ~magent-command-register~                            | A ~SKILL.md~ file; a tool skill may also have a companion Elisp implementation                       |
 | Activation             | The user enters ~/name~ or runs ~M-x magent-agent-shell-run-command~                 | An instruction skill is selected or activated by a capability; a tool skill is called by the model |
-| Owns                   | Arguments, preflight, progress, cancellation, completion, and multi-step control | Model context and workflow guidance, or one named operation through ~skill_invoke~                   |
-| Project trust boundary | Native handlers are trusted installed Elisp                                      | Project instruction Markdown is data-only; companion Elisp runs only for explicitly trusted roots  |
+| Owns                   | Arguments, requirements, session policy, Steps, and multi-step control            | Model context and workflow guidance, or one named operation through ~skill_invoke~                   |
+| Project trust boundary | Command Workflows are trusted installed Elisp                                    | Project instruction Markdown is data-only; companion Elisp runs only for explicitly trusted roots  |
 
 Use ~magent-command~ when you want a stable, user-triggered entry point in
 Emacs.  Use a skill when you want reusable expertise or an operation that the
 agent can apply while handling requests.  Use both when an explicit command
-should activate reusable expertise: a command turn spec can select skills with
-~:skills~, while registration declares preflight requirements with
-~:required-tools~.
+should activate reusable expertise: an agent Step can select skills with
+~:skills~ and declare its tool preflight with ~:required-tools~.
 
 An instruction skill with ~default-prompt~ is projected into the command
 registry only as a compatibility adapter.  Invoking that adapter activates the
-original skill; it does not turn Markdown into a native command handler or give
-it trusted Elisp lifecycle authority.
+original skill; it does not turn Markdown into a Command Workflow or give it
+trusted Elisp execution authority.
 
 ~magent-command~ therefore makes slash commands first-class, explicit user
 actions.  Your init file or another trusted Elisp package can register a command
 through the public ~magent-command-register~ API without changing the agent-shell
-or ACP integration.  A standard command can submit one structured Magent turn,
-while advanced handlers can own cancellable, multi-step workflows.
+or ACP integration. Every command owns one generator-backed Elisp Workflow;
+managed agent, process, and callback Steps provide asynchronous suspension,
+cancellation, progress, and activity recording.
 
 Registered commands are advertised to agent-shell and can be invoked as slash
 input or selected with ~M-x magent-agent-shell-run-command~.  The complete
@@ -112,23 +112,33 @@ Magent directly from Git:
   (magent-agent-shell-ensure-config)
 
   ;; Register /ask-name as an Elisp-native Magent command.
+  (magent-command-defworkflow my-magent-ask-name (invocation)
+    (let ((topic
+           (string-trim
+            (or (magent-command-invocation-argument invocation) ""))))
+      (magent-command-answer
+          "Ask selected agent"
+          (if (string-empty-p topic)
+              "What is your name?"
+            (format "What is your name? Also discuss: %s" topic)))))
+
   (magent-command-register
    "ask-name"
    :description "Ask the selected Magent agent to introduce itself."
-   :turn
-   (magent-command-turn-spec-create
-    :prompt "What is your name?")
+   :session-policy 'current
+   :workflow #'my-magent-ask-name
    :source-layer 'user
-   :required-tools '(read_file grep bash emacs_eval)))
+   :requires 'subr-x))
 #+end_src
 
-The ~:required-tools~ list declares tools that must be available before the
-command can run; replace it with the command's actual requirements, or omit it
-for a tool-free command. Exactly one of ~:turn~ and ~:handler~ is required. A
-~user~ command can override an installed ~package~ or ~builtin~ command with
-the same name. Registering the same name, layer, and canonical scope again
-replaces that slot's previous definition. The core ~/compact~ name remains
-reserved.
+~:requires~ accepts one Emacs feature or a list of features. Magent calls
+~require~ during invocation preflight; it does not install packages or require
+a project workspace. Tool requirements belong to the agent Step that needs
+them. Every registration requires one ~:workflow~ and an explicit
+~:session-policy~. A ~user~ command can override an installed ~package~ or
+~builtin~ command with the same name. Registering the same name, layer, and
+canonical scope again replaces that slot's previous definition. The core
+~/compact~ name remains reserved.
 
 * Configuration
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -44,8 +44,8 @@ agents = [
 proxy = "http://127.0.0.1:10808"
 ```
 
-该代理同时用于本地构建 Emacs bundle 和 Harbor trial 容器，包括 agent 安装、
-工具联网和模型请求。loopback 地址会在容器中改写为
+该代理同时用于本地构建 Emacs bundle、Harbor task environment 的 Docker build
+和 trial 容器运行期，包括 agent 安装、工具联网和模型请求。loopback 地址会在容器中改写为
 `host.docker.internal`；宿主机代理必须监听 Docker 可访问的接口。代理值不会写入
 fingerprint，但会和 API key 一样出现在权限为 `0600` 的私有 generated job 中。
 启用代理时，agent 安装超时会从 Harbor 默认的 6 分钟放宽为 12 分钟。

--- a/benchmark/docker-compose.proxy.yaml
+++ b/benchmark/docker-compose.proxy.yaml
@@ -1,5 +1,13 @@
 services:
   main:
+    build:
+      args:
+        HTTP_PROXY: "${MAGENT_BENCHMARK_CONTAINER_PROXY}"
+        HTTPS_PROXY: "${MAGENT_BENCHMARK_CONTAINER_PROXY}"
+        http_proxy: "${MAGENT_BENCHMARK_CONTAINER_PROXY}"
+        https_proxy: "${MAGENT_BENCHMARK_CONTAINER_PROXY}"
+      extra_hosts:
+        - "host.docker.internal:host-gateway"
     environment:
       HTTP_PROXY: "${MAGENT_BENCHMARK_CONTAINER_PROXY}"
       HTTPS_PROXY: "${MAGENT_BENCHMARK_CONTAINER_PROXY}"

--- a/benchmark/tests/test_profiles.py
+++ b/benchmark/tests/test_profiles.py
@@ -157,7 +157,7 @@ def test_auto_effort_does_not_inherit_harbor_codex_high_default(
     assert job["agents"][0]["kwargs"]["reasoning_effort"] is None
 
 
-def test_job_proxy_covers_the_trial_environment_without_fingerprinting_secret(
+def test_job_proxy_covers_trial_build_and_runtime_without_fingerprinting_secret(
     tmp_path: Path,
 ) -> None:
     config, profile, suite = _config(tmp_path)
@@ -184,10 +184,18 @@ def test_job_proxy_covers_the_trial_environment_without_fingerprinting_secret(
     overlay = yaml.safe_load(
         Path(environment["extra_docker_compose"][0]).read_text()
     )
-    assert overlay["services"]["main"]["environment"] == {
+    proxy_variables = {
         name: "${MAGENT_BENCHMARK_CONTAINER_PROXY}"
         for name in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy")
     }
+    assert overlay["services"]["main"]["build"]["args"] == proxy_variables
+    assert overlay["services"]["main"]["build"]["extra_hosts"] == [
+        "host.docker.internal:host-gateway"
+    ]
+    assert overlay["services"]["main"]["environment"] == proxy_variables
+    assert overlay["services"]["main"]["extra_hosts"] == [
+        "host.docker.internal:host-gateway"
+    ]
 
 
 def test_non_loopback_proxy_uses_the_same_compose_overlay(tmp_path: Path) -> None:

--- a/docs/ARCHITECTURE.org
+++ b/docs/ARCHITECTURE.org
@@ -96,7 +96,7 @@ Legacy ~messages~ remain as the projection used for gptel prompt reuse and migra
 
 1. A user prompt enters through agent-shell as an ACP ~session/prompt~ request.
 2. ACP resolves a registered slash command against the runtime session's exact scope. Unknown slash input remains an ordinary prompt.
-3. A registered command enters ~magent-command.el~ for argument handling, preflight, and session-policy setup. A plain prompt goes directly to ~magent-runtime-api.el~; a native command turn or advanced workflow step reaches the same API through ~magent-command-submit~. A direct handler that submits no agent turn stays outside the rest of this sequence.
+3. A registered command enters ~magent-command.el~ for argument handling, feature preflight, and session-policy setup, then starts its generator-backed Workflow. Process and callback Steps run outside the agent queue. Agent and terminal Answer Steps enter ~magent-runtime-api.el~ through the command runtime adapter; a plain prompt enters the same API directly.
 4. ~magent-runtime-api.el~ records a queued turn and a completed user item.
 5. ~magent-runtime-queue.el~ starts the turn when the global execution slot is free.
 6. ~magent-agent.el~ chooses the session agent, active skills, capability instructions, and allowed tools.
@@ -131,21 +131,24 @@ Magent has three file-backed extension layers:
 Commands are a separate Elisp-native extension layer. Definitions in
 ~magent-command.el~ are explicit user actions with layered registration,
 slash/interactive exposure, current/isolated session policy, argument handling,
-project/tool preflight, progress, cancellation, and completion. A registration owns exactly one native declarative turn or one
-advanced handler. The native path delegates one turn to
-~magent-runtime-submit~; its turn spec separates prompt text, model-visible
-popwin-style buffer snapshots, and agent/skill selection while inheriting
-frontend request context from the invocation. Content blocks and canonical
-command metadata are persisted internally. Advanced trusted packages may own a
-longer async invocation without receiving ACP or queue internals. The bundled
+feature/tool preflight, progress, cancellation, and completion. Every
+registration owns one generator-backed Elisp Workflow. Ordinary Elisp provides
+control flow; managed agent, terminal Answer, argv process, and callback Steps
+provide asynchronous suspension and activity recording. Agent Steps separate
+prompt text, model-visible popwin-style buffer snapshots, tool requirements,
+and agent/skill selection while inheriting frontend request context from the
+Invocation. Content blocks and canonical command metadata are persisted
+internally. Trusted packages may own a longer asynchronous Invocation without
+receiving ACP or queue internals. The bundled
 ~/explain~, ~/fix~, ~/init~, ~/review~, ~/summarize~, and ~/test~ commands use
 this API and own their Org prompt resources rather than same-name skills.
-An invocation claims its terminal result before cleanup, so a handler failure
-cancels owned submissions without allowing synchronous cancellation callbacks
-to overwrite the failure or continue work after ACP completes.
+An Invocation claims its terminal result before cleanup, so a Step failure
+cancels owned work without allowing synchronous cancellation callbacks to
+overwrite the failure or continue work after ACP completes.
 
 For compatibility, an instruction ~SKILL.md~ with ~default-prompt~ is projected
-into the command registry. Its native turn still activates the original skill.
+into the command registry. Its generated terminal Workflow still activates the
+original skill.
 Project and user adapters override package/bundled definitions by layer, while
 the core control is reserved. Project adapters remain keyed by canonical project
 scope; ACP resolves both command discovery and dispatch against each runtime

--- a/docs/ARCHITECTURE.zh.org
+++ b/docs/ARCHITECTURE.zh.org
@@ -89,7 +89,7 @@ manifest 和 package data recipe。
 
 1. 用户 prompt 通过 agent-shell 进入 ACP ~session/prompt~ request。
 2. ACP 按 runtime session 的精确 scope 解析已注册 slash command；未知 slash input 仍作为普通 prompt。
-3. 已注册 command 进入 ~magent-command.el~ ，执行参数处理、preflight 和 session-policy 设置。普通 prompt 直接进入 ~magent-runtime-api.el~ ；native command turn 或高级 workflow step 通过 ~magent-command-submit~ 到达同一 API。不提交 agent turn 的 direct handler 不进入后续时序。
+3. 已注册 command 进入 ~magent-command.el~，执行参数处理、feature preflight 和 session-policy 设置，然后启动 generator-backed Workflow。Process 和 callback Step 不进入 agent queue；agent 与 terminal Answer Step 通过 command runtime adapter 进入 ~magent-runtime-api.el~，普通 prompt 则直接进入同一 API。
 4. ~magent-runtime-api.el~ 记录 queued turn 和 completed user item。
 5. ~magent-runtime-queue.el~ 在全局执行槽空闲时启动 turn。
 6. ~magent-agent.el~ 选择 session agent、active skills、capability instructions 和允许的工具。
@@ -123,19 +123,20 @@ Magent 有三层 file-backed 扩展：
 
 Command 是另一层 Elisp-native 扩展。 ~magent-command.el~ 中的定义表示显式
 用户动作，提供分层注册、slash/interactive exposure、current/isolated session
-policy、参数处理、project/tool preflight、progress、取消和完成
-生命周期。每个注册只能拥有一个 native declarative turn 或一个高级 handler。Native
-路径把一次 turn 交给 ~magent-runtime-submit~ ；turn spec 分离 prompt 文本、模型可见的
-popwin 风格 buffer 快照和 agent/skill 选择，并从 invocation 继承 frontend request
+policy、参数处理、feature/tool preflight、progress、取消和完成生命周期。每个
+registration 只拥有一个 generator-backed Elisp Workflow。普通 Elisp 负责控制流；
+由 Magent 管理的 agent、terminal Answer、argv process 和 callback Step 提供异步
+等待与 activity 记录。Agent Step 分离 prompt 文本、模型可见的 popwin 风格 buffer
+快照、tool requirements 和 agent/skill 选择，并从 Invocation 继承 frontend request
 context。Content blocks 和 canonical command metadata 由内部持久化。
-高级受信任 package 可以拥有更长的异步 invocation，但不会接触 ACP 或 queue
+高级受信任 package 可以拥有更长的异步 Invocation，但不会接触 ACP 或 queue
 internals。内置 ~/explain~ 、 ~/fix~ 、 ~/init~ 、 ~/review~ 、 ~/summarize~ 和 ~/test~ 都只使用该公开
 API，并拥有各自的 Org prompt resource，而不是同名 skill。
-Invocation 会先锁定 terminal result 再执行 cleanup，因此 handler 失败时会取消其
-拥有的 submission，同时避免同步取消 callback 覆盖原始失败，或在 ACP 完成后继续工作。
+Invocation 会先锁定 terminal result 再执行 cleanup，因此 Step 失败时会取消其
+拥有的工作，同时避免同步取消 callback 覆盖原始失败，或在 ACP 完成后继续工作。
 
 为保持兼容，带 ~default-prompt~ 的 instruction ~SKILL.md~ 会被投影进 command
-registry，其 native turn 调用时仍激活原 skill。Project/user adapter 按 layer 覆盖 package/bundled
+registry，其生成的 terminal Workflow 调用时仍激活原 skill。Project/user adapter 按 layer 覆盖 package/bundled
 定义；core controls 的名称保留。Project adapter 以 canonical project scope 为键
 保留；ACP 的命令发现和分派都按每个 runtime session 的精确 scope 解析，因此多个
 project session 可以安全共存。

--- a/docs/COMMANDS.org
+++ b/docs/COMMANDS.org
@@ -141,41 +141,52 @@ the same public API available to third-party packages:
   (with-current-buffer buffer
     (derived-mode-p 'diff-mode)))
 
+(magent-command-defworkflow my-magent-review (invocation)
+  "Review the current staged changes for INVOCATION."
+  (let ((changed-files
+         (magent-command-process
+             "List staged files"
+             '("git" "diff" "--cached" "--name-only"))))
+    (magent-command-answer
+        "Review staged changes"
+        (format
+         "Review the staged changes in these files:\n%s"
+         changed-files)
+      :buffers
+      '(agent-shell-mode
+        (magit-status-mode :required-p nil)
+        ("^\\*Warnings\\*" :regexp t
+         :required-p nil :project-only-p nil)
+        (my-magent-review-buffer-p :predicate t :required-p nil))
+      :skills '("code-review")
+      :agent 'build
+      :append-argument-p t
+      :required-tools '(read_file grep bash))))
+
 (magent-command-register
  "my-review"
  :description "Run my package-specific review workflow."
  :title "My package review"
  :exposure '(slash)
  :session-policy 'current
- :turn
- (lambda (_invocation)
-   (magent-command-turn-spec-create
-    :prompt "Review the attached Emacs buffers using my package policy."
-    :buffers
-    '(agent-shell-mode
-      (magit-status-mode :required-p nil)
-      ("^\\*Warnings\\*" :regexp t
-       :required-p nil :project-only-p nil)
-      (my-magent-review-buffer-p :predicate t :required-p nil))
-    :skills '("code-review")
-    :agent 'build
-    :append-argument-p t))
+ :workflow #'my-magent-review
  :source-layer 'project
  :source-scope "/path/to/project"
- :requires-project t
- :required-tools '(read_file grep bash))
+ :requires 'diff-mode)
 #+end_src
 
-Every registration must provide exactly one of ~:turn~ and ~:handler~. A
-~:turn~ value is either one static ~magent-command-turn-spec~ or a builder
-function that receives the invocation and returns one. The example uses every
-registration field that can accompany ~:turn~: ~:description~, ~:title~,
-~:exposure~, ~:session-policy~,
-~:source-layer~, ~:source-scope~, ~:requires-project~, and
-~:required-tools~. The turn spec uses all of its fields: ~:prompt~,
-~:buffers~, ~:skills~, ~:agent~, and ~:append-argument-p~. Use ~:handler~
-instead only when trusted Elisp must own a custom lifecycle; it cannot be
-combined with ~:turn~.
+Every registration provides exactly one ~:workflow~ function and an explicit
+~:session-policy~. The Workflow is an Elisp generator defined with
+~magent-command-defworkflow~. Ordinary Elisp owns branching, loops, local
+state, validation, and calls into Emacs; managed Steps are used only where the
+Workflow must suspend for asynchronous work.
+
+~:requires~ accepts one Emacs feature symbol or a list of feature symbols.
+Magent calls ~require~ for each feature during invocation preflight. A missing
+feature leaves the command discoverable but makes invocation fail before an
+isolated session is created. This option does not install a package, check for
+executables, or require a project workspace. The removed ~:requires-project~
+option has no Command equivalent.
 
 The tuple ~(NAME, SOURCE-LAYER, canonical SOURCE-SCOPE)~ is one registry
 slot. Registering that slot again replaces its previous definition and makes
@@ -218,41 +229,57 @@ content, not the resource metadata header.
 
 The model-visible user content order is the expanded command prompt, command
 buffer snapshots, then frontend attachments. ~append-argument-p~ defaults to
-non-nil and appends trailing slash text as an Additional instruction block;
-set it to nil when the builder has already consumed the argument. Project
-scope, frontend facts, and attached resource paths still belong to the command
-invocation and are inherited automatically.
+nil for an agent Step. Set it to non-nil to append trailing slash text as an
+Additional instruction block; leave it nil when the Workflow has already
+consumed ~magent-command-invocation-argument~. Project scope, frontend facts,
+and attached resource paths still belong to the Command Invocation and are
+inherited automatically.
 
 Request context is runtime metadata, not extra model input. Recognized fields
 may affect project instruction discovery, capability resolution, or runtime
-routing, but the plist is not serialized verbatim for the model. An advanced
-handler that genuinely needs step-local runtime hints may pass
-~:request-context~ to ~magent-command-submit~ or
-~magent-command-submit-step~. It may also pass model-visible
-~:resource-blocks~ and private ~:turn-metadata~ for its own ledger data.
-Standard declarative turns deliberately expose neither a generic ~:context~
-nor public ~:turn-metadata~; Magent owns their canonical command metadata. Put
+routing, but the plist is not serialized verbatim for the model. Agent and
+Answer Steps may set step-local ~:request-context~ and model-visible
+~:resource-blocks~. Magent owns canonical command metadata. Put other
 model-visible instructions and data in the prompt, ~:buffers~, or an attached
-resource instead.
+resource.
 
-An advanced handler may call ~magent-command-progress~ and
-~magent-command-submit-step~, then use ~magent-command-defer~ before returning and
-finish later with ~magent-command-complete~, ~magent-command-fail~, or
-~magent-command-finish~. Cancellation cleanup is registered with
-~magent-command-set-cancel-function~. Handlers are trusted installed Elisp;
-project-local Markdown never receives this execution authority.
+The managed Step forms are:
 
-If a handler or step callback signals after submitting runtime work, Magent
-first claims the invocation's final ~failed~ result, then runs its registered
-cleanup and cancels every owned runtime submission before publishing
-completion. A synchronous cancellation callback therefore cannot replace the
-original failure or leave background streaming and ledger writes alive.
+- ~magent-command-agent~ runs an intermediate model turn and returns its text
+  by default. It accepts ~:agent~, ~:skills~, ~:buffers~,
+  ~:append-argument-p~, ~:required-tools~, ~:request-context~,
+  ~:resource-blocks~, and ~:result~.
+- ~magent-command-answer~ accepts the same model options but is terminal. It
+  streams the final answer, ends the Invocation, and does not resume forms
+  after the Step.
+- ~magent-command-process~ runs only a non-empty argv list of strings. It
+  captures the call-site directory and process environment, and accepts
+  ~:directory~, an ~:environment~ override alist, ~:timeout~, ~:check~,
+  ~:result~, ~:record-command~, and ~:record-output~. The default result is
+  complete stdout; ~:result 'full~ returns a
+  ~magent-command-process-result~ including stderr, exit status, duration, and
+  timeout state.
+- ~magent-command-callback~ adapts an existing asynchronous Elisp API. Its
+  start function receives ~DONE~, calls ~(DONE STATUS VALUE)~ exactly once with
+  ~completed~, ~failed~, or ~cancelled~, and may return a zero-argument
+  cancellation function.
 
-A step callback still owns the completed runtime turn's FIFO lease. It can
-submit the next step immediately; no unrelated backend turn can advance in
-between. Each submitted turn records both the expanded model prompt and the
-original slash input, command name, argument, and invocation id in ledger
-metadata.
+~magent-command-process-timeout~ is the default process deadline (300 seconds).
+~magent-command-step-output-max-chars~ bounds process and formatted callback
+output persisted in the activity ledger (24000 characters); the value returned
+to Workflow Elisp remains untruncated.
+
+A Workflow that reaches its end returns either a user-visible string or nil.
+Failed process, agent, and callback Steps signal typed
+~magent-command-*-error~ conditions inside the generator, so ordinary
+~condition-case~ can recover. Cancellation is terminal and does not resume the
+Workflow. ~magent-command-progress~ remains available for notification-only
+updates; Step start/finish activity is recorded automatically.
+
+Agent and Answer Steps use the runtime FIFO. Process and callback Steps are
+owned and cancellable by their Invocation but do not consume the global agent
+execution slot, so different Invocations may overlap those external waits.
+Project-local Markdown never receives trusted Workflow execution authority.
 
 ~M-x magent-agent-shell-run-skill-command~ selects and runs any command-like
 instruction skill through the compatibility adapter.

--- a/docs/COMMANDS.zh.org
+++ b/docs/COMMANDS.zh.org
@@ -130,39 +130,50 @@ org-roam capture 约定 ~YYYY-MM-DDtHHMM.org~。后续运行通过 file-level
   (with-current-buffer buffer
     (derived-mode-p 'diff-mode)))
 
+(magent-command-defworkflow my-magent-review (invocation)
+  "Review INVOCATION 对应的 staged changes。"
+  (let ((changed-files
+         (magent-command-process
+             "List staged files"
+             '("git" "diff" "--cached" "--name-only"))))
+    (magent-command-answer
+        "Review staged changes"
+        (format
+         "Review the staged changes in these files:\n%s"
+         changed-files)
+      :buffers
+      '(agent-shell-mode
+        (magit-status-mode :required-p nil)
+        ("^\\*Warnings\\*" :regexp t
+         :required-p nil :project-only-p nil)
+        (my-magent-review-buffer-p :predicate t :required-p nil))
+      :skills '("code-review")
+      :agent 'build
+      :append-argument-p t
+      :required-tools '(read_file grep bash))))
+
 (magent-command-register
  "my-review"
  :description "运行包自定义的 review workflow。"
  :title "包自定义 review"
  :exposure '(slash)
  :session-policy 'current
- :turn
- (lambda (_invocation)
-   (magent-command-turn-spec-create
-    :prompt "Review the attached Emacs buffers using my package policy."
-    :buffers
-    '(agent-shell-mode
-      (magit-status-mode :required-p nil)
-      ("^\\*Warnings\\*" :regexp t
-       :required-p nil :project-only-p nil)
-      (my-magent-review-buffer-p :predicate t :required-p nil))
-    :skills '("code-review")
-    :agent 'build
-    :append-argument-p t))
+ :workflow #'my-magent-review
  :source-layer 'project
  :source-scope "/path/to/project"
- :requires-project t
- :required-tools '(read_file grep bash))
+ :requires 'diff-mode)
 #+end_src
 
-每个 registration 必须且只能提供 ~:turn~ 和 ~:handler~ 之一。~:turn~ 可以是静态
-~magent-command-turn-spec~，也可以是接收 invocation 并返回 turn spec 的 builder。
-上例使用了可与 ~:turn~ 搭配的 registration 字段：~:description~、~:title~、
-~:exposure~、~:session-policy~、
-~:source-layer~、~:source-scope~、~:requires-project~ 和
-~:required-tools~；也使用了 turn spec 的全部字段：~:prompt~、~:buffers~、
-~:skills~、~:agent~ 和 ~:append-argument-p~。只有受信任 Elisp 需要自主管理
-生命周期时才改用 ~:handler~，它不能和 ~:turn~ 同时出现。
+每个 registration 必须提供且只提供一个 ~:workflow~ function，并显式指定
+~:session-policy~。Workflow 是由 ~magent-command-defworkflow~ 定义的 Elisp
+generator。分支、循环、局部状态、校验以及对 Emacs 的普通调用都直接使用 Elisp；
+只有真正需要等待异步结果的地方才使用由 Magent 管理的 Step。
+
+~:requires~ 接收一个 Emacs feature symbol 或 feature symbol list。Magent 在
+Invocation preflight 中逐个调用 ~require~。缺少 feature 时 command 仍可被发现，但
+会在创建 isolated session 之前失败。这个选项不会安装 package、检查 executable，
+也不会要求调用者位于 project workspace。已经移除的 ~:requires-project~ 不再有
+Command 对应项。
 
 ~(NAME, SOURCE-LAYER, canonical SOURCE-SCOPE)~ 这个三元组对应唯一的 registry
 slot。再次注册同一 slot 会替换旧定义，并使旧 registration token 失效；撤销新
@@ -198,33 +209,47 @@ turn 持久化并用于后续 ledger replay；之后修改 live buffer 不会改
 resource metadata header。
 
 模型可见 user content 的顺序是：展开后的 command prompt、command buffer
-snapshots、frontend attachments。~append-argument-p~ 默认非 nil，会把 slash command
-后的文本追加成 Additional instruction block；builder 已经消费 argument 时应设为
-nil。项目 scope、frontend facts 和附件路径仍属于 command invocation，并自动继承。
+snapshots、frontend attachments。Agent Step 的 ~append-argument-p~ 默认为 nil；
+设为非 nil 时会把 slash command 后的文本追加成 Additional instruction block。
+Workflow 已经读取 ~magent-command-invocation-argument~ 时应保持 nil。项目 scope、
+frontend facts 和附件路径仍属于 Command Invocation，并自动继承。
 
 Request context 是 runtime metadata，不是额外的模型输入。已识别字段可以影响项目
 instructions 查找、capability resolution 或 runtime routing，但该 plist 不会原样发送
-给模型。高级 handler 确实需要 step-local runtime hints 时，可以给
-~magent-command-submit~ 或 ~magent-command-submit-step~ 传
-~:request-context~；也可以传模型可见的 ~:resource-blocks~，以及仅供自身 ledger
-使用的 ~:turn-metadata~。标准 declarative turn 刻意不暴露通用 ~:context~ 或公开
-~:turn-metadata~，canonical command metadata 由 Magent 管理。模型需要直接看到的
-指令和数据应放入 prompt、~:buffers~ 或附件 resource。
+给模型。Agent 和 Answer Step 可以设置 step-local ~:request-context~ 与模型可见的
+~:resource-blocks~。Canonical command metadata 由 Magent 管理；其他需要让模型看到
+的指令和数据应放入 prompt、~:buffers~ 或附件 resource。
 
-高级 handler 可以调用 ~magent-command-progress~ 和 ~magent-command-submit-step~，
-返回前用 ~magent-command-defer~ 声明异步所有权，之后通过
-~magent-command-complete~、~magent-command-fail~ 或 ~magent-command-finish~
-结束。取消清理由 ~magent-command-set-cancel-function~ 注册。Handler 属于受信任的
-已安装 Elisp；项目本地 Markdown 不会获得该执行权限。
+由 Magent 管理的 Step forms 包括：
 
-如果 handler 或 step callback 在提交 runtime 工作后抛错，Magent 会先锁定 invocation
-最终的 ~failed~ 结果，再执行已注册 cleanup 并取消它拥有的所有 runtime submission，
-最后才发布完成通知。因此，同步触发的取消 callback 不会覆盖原始失败，也不会遗留
-继续 streaming 或写 ledger 的后台任务。
+- ~magent-command-agent~ 执行中间 model turn，默认返回文本。它支持 ~:agent~、
+  ~:skills~、~:buffers~、~:append-argument-p~、~:required-tools~、
+  ~:request-context~、~:resource-blocks~ 和 ~:result~。
+- ~magent-command-answer~ 支持相同的 model 选项，但它是 terminal Step：流式输出
+  最终回答并结束 Invocation，之后的 forms 不会继续执行。
+- ~magent-command-process~ 只运行由非空 string 组成的 argv list。它会捕获调用点
+  的 directory 和 process environment，并支持 ~:directory~、~:environment~
+  override alist、~:timeout~、~:check~、~:result~、~:record-command~ 与
+  ~:record-output~。默认结果是完整 stdout；~:result 'full~ 返回包含 stderr、
+  exit status、duration 和 timeout state 的 ~magent-command-process-result~。
+- ~magent-command-callback~ 用来适配已有的异步 Elisp API。Start function 接收
+  ~DONE~，必须用 ~completed~、~failed~ 或 ~cancelled~ 调用
+  ~(DONE STATUS VALUE)~ 一次，并可返回一个无参数 cancel function。
 
-Step callback 执行时仍持有已完成 runtime turn 的 FIFO lease，因此可以直接提交
-下一步，期间不会插入其他 backend turn。每个提交的 turn 会在 ledger 中同时保存
-展开后的模型 prompt，以及原始 slash input、command name、argument 和 invocation id。
+~magent-command-process-timeout~ 是 process 的默认 deadline（300 秒）。
+~magent-command-step-output-max-chars~ 限制持久化到 activity ledger 的 process
+与格式化 callback output（默认 24000 characters）；返回给 Workflow Elisp 的值
+不会被截断。
+
+Workflow 正常走到结尾时只能返回用户可见 string 或 nil。Process、agent 和 callback
+Step 失败时会在 generator 内抛出对应的 typed ~magent-command-*-error~，因此可用普通
+~condition-case~ 恢复。取消是 terminal 状态，不会恢复 Workflow。
+~magent-command-progress~ 仍可发送仅通知用途的进度；每个 Step 的开始和结束会自动
+写入 activity ledger。
+
+Agent 和 Answer Step 使用 runtime FIFO。Process 和 callback Step 仍由 Invocation
+拥有并可取消，但不占用全局 agent execution slot，因此不同 Invocation 的外部等待
+可以重叠。项目本地 Markdown 不会获得受信任 Workflow 的执行权限。
 
 ~M-x magent-agent-shell-run-skill-command~ 可以通过受支持的 agent-shell frontend
 经兼容 adapter 选择并运行任意 command-like instruction skill。

--- a/docs/adr/0001-unify-command-workflows.md
+++ b/docs/adr/0001-unify-command-workflows.md
@@ -1,0 +1,50 @@
+# Use one Elisp Workflow model for commands
+
+- Status: Accepted
+- Date: 2026-07-23
+
+## Context
+
+Commands previously split extensions between declarative turns and imperative
+handlers. That duplicated completion and cancellation contracts, while complex
+handlers rebuilt sequencing, process ownership, progress, and cleanup by hand.
+A declarative step graph would add another control-flow language even though
+trusted Elisp already supplies branching, loops, validation, local state, and
+direct integration with Emacs objects.
+
+## Decision
+
+Every Command registration owns one generator-backed Elisp Workflow and an
+explicit session policy. A Command Invocation is the sole runtime lifecycle
+owner.
+
+Workflow Elisp remains ordinary, brief, and non-blocking. It yields managed
+Steps only at asynchronous boundaries:
+
+- Agent Steps run intermediate model turns.
+- Answer Steps run one terminal streaming model turn.
+- Process Steps run a string argv list without a shell-command DSL.
+- Callback Steps adapt existing asynchronous Elisp APIs.
+
+Process and callback Steps may overlap between Invocations. Agent and Answer
+Steps use the existing runtime FIFO. Every Step receives start/finish activity
+recording and Invocation-owned cancellation.
+
+A Workflow that reaches its end returns a user-visible string or nil. Process,
+agent, and callback failures signal typed, recoverable conditions inside the
+generator. Cancellation is terminal and never resumes Workflow Elisp.
+
+Command registration uses `:requires` for Emacs feature symbols loaded during
+invocation preflight. Tool requirements belong to the agent Step that uses
+them. Commands have no project-workspace requirement.
+
+## Consequences
+
+This is a breaking change. `:turn`, `:handler`, `:requires-project`, and the
+public handler lifecycle functions are removed without compatibility wrappers.
+Built-in commands, skill adapters, isolated maintenance commands, live tests,
+and third-party examples must use the Workflow API.
+
+The extension surface is smaller and lifecycle behavior is uniform. Extension
+authors can express complex orchestration in Elisp without manually owning
+process sentinels, runtime submission callbacks, or terminal cleanup.

--- a/lisp/magent-command-controls.el
+++ b/lisp/magent-command-controls.el
@@ -8,19 +8,23 @@
 (require 'magent-command)
 (require 'magent-runtime-api)
 
-(defun magent-command-controls--compact (invocation)
+(magent-command-defworkflow magent-command-controls--compact (invocation)
   "Compact the session belonging to INVOCATION."
-  (magent-command-defer invocation)
-  (magent-runtime-session-compact
-   (magent-command-invocation-runtime-session invocation)
-   :instruction (magent-command-invocation-argument invocation)
-   :observer (magent-command-invocation-observer invocation)
-   :approval-provider
-   (magent-command-invocation-approval-provider invocation)
-   :turn-metadata (magent-command-turn-metadata invocation)
-   :on-complete
-   (lambda (status result)
-     (magent-command-finish invocation status result))))
+  (let ((result
+         (magent-command-callback
+             "Compact conversation"
+             (lambda (done)
+               (magent-runtime-session-compact
+                (magent-command-invocation-runtime-session invocation)
+                :instruction (magent-command-invocation-argument invocation)
+                :approval-provider
+                (magent-command-invocation-approval-provider invocation)
+                :turn-metadata (magent-command-turn-metadata invocation)
+                :on-complete done)
+               (lambda ()
+                 (magent-runtime-cancel
+                  (magent-command-invocation-runtime-session invocation)))))))
+    (magent-agent-result-content-string result)))
 
 (defun magent-command-controls-register ()
   "Register the reserved Magent session control command."
@@ -28,7 +32,8 @@
     (magent-command-register
      "compact"
      :description "Summarize and compact the current conversation context."
-     :handler #'magent-command-controls--compact
+     :session-policy 'current
+     :workflow #'magent-command-controls--compact
      :source-layer 'core)))
 
 (provide 'magent-command-controls)

--- a/lisp/magent-command-explain.el
+++ b/lisp/magent-command-explain.el
@@ -8,16 +8,22 @@
 (require 'magent-command)
 (require 'magent-prompt)
 
+(magent-command-defworkflow magent-command-explain--workflow (_invocation)
+  "Run the bundled explanation Workflow."
+  (magent-command-answer
+      "Explain"
+      (magent-prompt-read "commands/explain.org")
+    :append-argument-p t
+    :required-tools '(read_file grep bash emacs_eval)))
+
 (defun magent-command-explain-register ()
   "Register the bundled /explain command."
   (magent-command-register
    "explain"
    :description "Explain the current code, diff, buffer, error, or project context."
-   :turn (lambda (_invocation)
-           (magent-command-turn-spec-create
-            :prompt (magent-prompt-read "commands/explain.org")))
-   :source-layer 'builtin
-   :required-tools '(read_file grep bash emacs_eval)))
+   :session-policy 'current
+   :workflow #'magent-command-explain--workflow
+   :source-layer 'builtin))
 
 (provide 'magent-command-explain)
 ;;; magent-command-explain.el ends here

--- a/lisp/magent-command-fix.el
+++ b/lisp/magent-command-fix.el
@@ -8,16 +8,22 @@
 (require 'magent-command)
 (require 'magent-prompt)
 
+(magent-command-defworkflow magent-command-fix--workflow (_invocation)
+  "Run the bundled fix Workflow."
+  (magent-command-answer
+      "Fix"
+      (magent-prompt-read "commands/fix.org")
+    :append-argument-p t
+    :required-tools '(read_file write_file edit_file grep bash emacs_eval)))
+
 (defun magent-command-fix-register ()
   "Register the bundled /fix command."
   (magent-command-register
    "fix"
    :description "Diagnose and fix the current bug, failure, or regression."
-   :turn (lambda (_invocation)
-           (magent-command-turn-spec-create
-            :prompt (magent-prompt-read "commands/fix.org")))
-   :source-layer 'builtin
-   :required-tools '(read_file write_file edit_file grep bash emacs_eval)))
+   :session-policy 'current
+   :workflow #'magent-command-fix--workflow
+   :source-layer 'builtin))
 
 (provide 'magent-command-fix)
 ;;; magent-command-fix.el ends here

--- a/lisp/magent-command-init.el
+++ b/lisp/magent-command-init.el
@@ -8,16 +8,22 @@
 (require 'magent-command)
 (require 'magent-prompt)
 
+(magent-command-defworkflow magent-command-init--workflow (_invocation)
+  "Run the bundled initialization Workflow."
+  (magent-command-answer
+      "Initialize project instructions"
+      (magent-prompt-read "commands/init.org")
+    :append-argument-p t
+    :required-tools '(read_file write_file edit_file grep glob bash)))
+
 (defun magent-command-init-register ()
   "Register the bundled /init command."
   (magent-command-register
    "init"
    :description "Initialize or refresh project instructions for Magent."
-   :turn (lambda (_invocation)
-           (magent-command-turn-spec-create
-            :prompt (magent-prompt-read "commands/init.org")))
-   :source-layer 'builtin
-   :required-tools '(read_file write_file edit_file grep glob bash)))
+   :session-policy 'current
+   :workflow #'magent-command-init--workflow
+   :source-layer 'builtin))
 
 (provide 'magent-command-init)
 ;;; magent-command-init.el ends here

--- a/lisp/magent-command-review.el
+++ b/lisp/magent-command-review.el
@@ -8,16 +8,22 @@
 (require 'magent-command)
 (require 'magent-prompt)
 
+(magent-command-defworkflow magent-command-review--workflow (_invocation)
+  "Run the bundled review Workflow."
+  (magent-command-answer
+      "Review"
+      (magent-prompt-read "commands/review.org")
+    :append-argument-p t
+    :required-tools '(read_file grep bash)))
+
 (defun magent-command-review-register ()
   "Register the bundled /review command."
   (magent-command-register
    "review"
    :description "Review the current changes for defects, risks, and missing tests."
-   :turn (lambda (_invocation)
-           (magent-command-turn-spec-create
-            :prompt (magent-prompt-read "commands/review.org")))
-   :source-layer 'builtin
-   :required-tools '(read_file grep bash)))
+   :session-policy 'current
+   :workflow #'magent-command-review--workflow
+   :source-layer 'builtin))
 
 (provide 'magent-command-review)
 ;;; magent-command-review.el ends here

--- a/lisp/magent-command-session.el
+++ b/lisp/magent-command-session.el
@@ -123,6 +123,18 @@
                    (magent-thread-item-error item)
                    "")
                "\n\n"))
+    ('workflow-step
+       (insert (format "%s Workflow Step: %s [%s]\n"
+                       prefix
+                       (or (magent-thread-item-name item) "step")
+                       (magent-command-session--format-value
+                        (magent-thread-item-status item))))
+       (when-let* ((input (magent-thread-item-input item)))
+         (insert "Input: " (magent-command-session--format-value input) "\n"))
+       (when-let* ((output (or (magent-thread-item-output item)
+                               (magent-thread-item-error item))))
+         (insert output "\n"))
+       (insert "\n"))
     (_
        (insert (format "%s %s [%s]\n%s\n\n"
                        prefix
@@ -290,18 +302,108 @@
                              (magent-command-spec-name
                               (magent-command-invocation-spec invocation))
                              :command-invocation-id
-                             (magent-command-invocation-id invocation)))))
+                             (magent-command-invocation-id invocation)
+                             :workflow-control t))))
            (magent-thread-start-turn thread (magent-thread-turn-id turn))
-           (magent-thread-record-user-message-if-needed
-            thread (magent-thread-turn-id turn) input nil
-            (list :source 'magent-command
-                  :command-invocation-id
-                  (magent-command-invocation-id invocation)))
            (setf (magent-command-invocation-turn-id invocation)
                  (magent-thread-turn-id turn))
            (magent-session-refresh-projections session)
            (magent-command-session--save invocation)
            (magent-thread-turn-id turn))))))
+
+(defun magent-command-session-start-step (invocation step)
+  "Record STEP start for INVOCATION and return its item id."
+  (magent-command-session--with-current-session
+   invocation
+   (lambda ()
+     (let* ((session (magent-command-invocation-session invocation))
+            (thread (magent-session-thread-ledger session))
+            (turn-id
+             (magent-command-session--ensure-turn
+              invocation
+              (magent-command-spec-title
+               (magent-command-invocation-spec invocation))))
+            (item
+             (magent-thread-start-item
+              thread turn-id 'workflow-step
+              :name (magent-command-step-name step)
+              :input (magent-command-workflow-step-activity-input step)
+              :metadata
+              (list :source 'magent-command
+                    :command-invocation-id
+                    (magent-command-invocation-id invocation)
+                    :step-type (magent-command-step-type step)))))
+       (magent-session-refresh-projections session)
+       (magent-command-session--save invocation)
+       (magent-thread-item-id item)))))
+
+(defun magent-command-session--step-error-string (value)
+  "Return durable error text for failed Step VALUE."
+  (cond
+   ((magent-agent-result-p value)
+    (magent-agent-result-content-string value))
+   ((and (consp value) (symbolp (car value)))
+    (error-message-string value))
+   (t (format "%s" value))))
+
+(defun magent-command-session-finish-step
+    (invocation step item-id status value)
+  "Record STEP ITEM-ID terminal STATUS and VALUE for INVOCATION."
+  (when item-id
+    (magent-command-session--with-current-session
+     invocation
+     (lambda ()
+       (let* ((session (magent-command-invocation-session invocation))
+              (thread (magent-session-thread-ledger session))
+              (item
+               (cl-find item-id (magent-thread-all-items thread)
+                        :key #'magent-thread-item-id :test #'equal))
+              (output
+               (magent-command-workflow-step-activity-output
+                step status value))
+              (metadata
+               (and item
+                    (append
+                     (magent-thread-item-metadata item)
+                     (when-let* ((submission-id
+                                  (magent-command-invocation-current-submission-id
+                                   invocation)))
+                       (list :submission-id submission-id))))))
+         (when item
+           (pcase status
+             ('completed
+              (magent-thread-complete-item
+               thread item :output output :metadata metadata))
+             ('cancelled
+              (magent-thread-cancel-item
+               thread item (magent-command-session--step-error-string value)))
+             (_
+              (magent-thread-fail-item
+               thread item (magent-command-session--step-error-string value)
+               :output output :metadata metadata)))
+           (setf (magent-command-invocation-current-submission-id invocation)
+                 nil)
+           (magent-session-refresh-projections session)
+           (magent-command-session--save invocation)))))))
+
+(defun magent-command-session-finalize-workflow-turn
+    (invocation status result)
+  "Finalize INVOCATION's control turn with STATUS and RESULT."
+  (when-let* ((turn-id (magent-command-invocation-turn-id invocation)))
+    (magent-command-session--with-current-session
+     invocation
+     (lambda ()
+       (let* ((session (magent-command-invocation-session invocation))
+              (thread (magent-session-thread-ledger session))
+              (turn (magent-thread-find-turn thread turn-id))
+              (message (magent-agent-result-content-string result)))
+         (unless (or (null turn) (magent-thread-terminal-turn-p turn))
+           (pcase status
+             ('completed (magent-thread-complete-turn thread turn-id))
+             ('cancelled (magent-thread-interrupt-turn thread turn-id message))
+             (_ (magent-thread-fail-turn thread turn-id message)))
+           (magent-session-refresh-projections session)
+           (magent-command-session--save invocation)))))))
 
 (defun magent-command-session-record-tool
     (invocation name args result &optional metadata)
@@ -389,8 +491,7 @@ When CANCELLABLE-ONLY is non-nil, omit invocations without owned work."
      (lambda (_id invocation)
        (when (and (eq (magent-command-invocation-status invocation) 'active)
                   (or (not cancellable-only)
-                      (magent-command-invocation-cancel-function invocation)
-                      (magent-command-invocation-submission-ids invocation)))
+                      (magent-command-invocation-current-step invocation)))
          (push invocation invocations)))
      magent-command-session--active-invocations)
     (sort invocations

--- a/lisp/magent-command-summarize.el
+++ b/lisp/magent-command-summarize.el
@@ -8,17 +8,22 @@
 (require 'magent-command)
 (require 'magent-prompt)
 
+(magent-command-defworkflow magent-command-summarize--workflow (_invocation)
+  "Run the bundled repository summary Workflow."
+  (magent-command-answer
+      "Summarize repository"
+      (magent-prompt-read "commands/summarize.org")
+    :append-argument-p t
+    :required-tools '(read_file grep glob bash write_repo_summary)))
+
 (defun magent-command-summarize-register ()
   "Register the bundled /summarize command."
   (magent-command-register
    "summarize"
    :description "Summarize the current Git project into one canonical Org note."
-   :turn (lambda (_invocation)
-           (magent-command-turn-spec-create
-            :prompt (magent-prompt-read "commands/summarize.org")))
-   :source-layer 'builtin
-   :requires-project t
-   :required-tools '(read_file grep glob bash write_repo_summary)))
+   :session-policy 'current
+   :workflow #'magent-command-summarize--workflow
+   :source-layer 'builtin))
 
 (provide 'magent-command-summarize)
 ;;; magent-command-summarize.el ends here

--- a/lisp/magent-command-test.el
+++ b/lisp/magent-command-test.el
@@ -8,16 +8,22 @@
 (require 'magent-command)
 (require 'magent-prompt)
 
+(magent-command-defworkflow magent-command-test--workflow (_invocation)
+  "Run the bundled test Workflow."
+  (magent-command-answer
+      "Run tests"
+      (magent-prompt-read "commands/test.org")
+    :append-argument-p t
+    :required-tools '(read_file grep bash emacs_eval)))
+
 (defun magent-command-test-register ()
   "Register the bundled /test command."
   (magent-command-register
    "test"
    :description "Run and interpret the relevant project tests."
-   :turn (lambda (_invocation)
-           (magent-command-turn-spec-create
-            :prompt (magent-prompt-read "commands/test.org")))
-   :source-layer 'builtin
-   :required-tools '(read_file grep bash emacs_eval)))
+   :session-policy 'current
+   :workflow #'magent-command-test--workflow
+   :source-layer 'builtin))
 
 (provide 'magent-command-test)
 ;;; magent-command-test.el ends here

--- a/lisp/magent-command-workflow.el
+++ b/lisp/magent-command-workflow.el
@@ -1,0 +1,672 @@
+;;; magent-command-workflow.el --- Sequential command Workflows  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Jamie Cui
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;; Assisted-by: Codex:GPT-5.6
+
+;;; Commentary:
+
+;; Generator-backed Workflow DSL for `magent-command'.  Trusted Elisp owns
+;; control flow; yielded Steps are the asynchronous waiting, cancellation,
+;; progress, and activity-recording boundary.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'generator)
+(require 'subr-x)
+(require 'magent-config)
+(require 'magent-log)
+(require 'magent-protocol)
+
+(declare-function magent-command--finish-answer "magent-command")
+(declare-function magent-command--finish-cancelled "magent-command")
+(declare-function magent-command--finish-completed "magent-command")
+(declare-function magent-command--finish-failed "magent-command")
+(declare-function magent-command--start-agent-step "magent-command")
+(declare-function magent-command--workflow-step-finish "magent-command")
+(declare-function magent-command--workflow-step-start "magent-command")
+(define-error 'magent-command-step-error "Magent command Step failed")
+(define-error 'magent-command-process-error "Magent command process Step failed"
+  'magent-command-step-error)
+(define-error 'magent-command-agent-error "Magent command agent Step failed"
+  'magent-command-step-error)
+(define-error 'magent-command-callback-error "Magent command callback Step failed"
+  'magent-command-step-error)
+
+(cl-defstruct (magent-command-invocation
+               (:constructor magent-command-invocation-create)
+               (:copier nil))
+  "Runtime state for one Magent command Invocation."
+  id
+  spec
+  control-session
+  runtime-session
+  session
+  scope
+  origin-buffer
+  origin-directory
+  origin-scope
+  parent-session
+  parent-scope
+  parent-session-id
+  options
+  turn-id
+  response-recorded-p
+  interactive-p
+  raw-input
+  argument
+  request-context
+  resource-blocks
+  observer
+  approval-provider
+  completion-function
+  submission-adapter
+  iterator
+  current-step
+  current-step-id
+  current-submission-id
+  (generation 0)
+  step-cancel-function
+  (status 'active)
+  result)
+
+(cl-defstruct (magent-command-step
+               (:constructor magent-command-step-create)
+               (:copier nil))
+  "One asynchronous boundary yielded by a command Workflow."
+  type
+  name
+  options
+  terminal-p)
+
+(cl-defstruct (magent-command-step-outcome
+               (:constructor magent-command-step-outcome-create)
+               (:copier nil))
+  "Value resumed into a Workflow after one Step finishes."
+  status
+  value
+  condition)
+
+(cl-defstruct (magent-command-process-result
+               (:constructor magent-command-process-result-create)
+               (:copier nil))
+  "Complete result from one command process Step."
+  name
+  command
+  directory
+  exit-status
+  stdout
+  stderr
+  duration-ms
+  timed-out-p)
+
+(defmacro magent-command-defworkflow (name arglist &rest body)
+  "Define NAME as a sequential command Workflow accepting ARGLIST."
+  (declare (indent defun)
+           (doc-string 3)
+           (debug (&define name lambda-list lambda-doc &rest sexp)))
+  `(iter-defun ,name ,arglist ,@body))
+
+(defun magent-command--normalize-step-name (name)
+  "Return NAME as a non-empty Step label."
+  (unless (and (stringp name) (not (string-empty-p (string-trim name))))
+    (error "Magent command Step requires a non-empty name: %S" name))
+  name)
+
+(defun magent-command--validate-result-mode (mode)
+  "Return validated Step result MODE."
+  (unless (memq mode '(value full))
+    (error "Invalid Magent command Step result mode: %S" mode))
+  mode)
+
+(cl-defun magent-command--make-process-step
+    (name command &key directory environment
+          (timeout magent-command-process-timeout)
+          (check t) (result 'value)
+          (record-command t) (record-output t))
+  "Create a process Step named NAME for argv COMMAND."
+  (magent-command--normalize-step-name name)
+  (unless (and (proper-list-p command) command
+               (cl-every #'stringp command))
+    (error "Magent command process requires non-empty string argv: %S"
+           command))
+  (unless (or (null timeout) (and (numberp timeout) (>= timeout 0)))
+    (error "Invalid Magent command process timeout: %S" timeout))
+  (unless (or (null environment)
+              (and (proper-list-p environment)
+                   (cl-every
+                    (lambda (entry)
+                      (and (consp entry)
+                           (stringp (car entry))
+                           (or (null (cdr entry)) (stringp (cdr entry)))))
+                    environment)))
+    (error "Expected environment alist, got: %S" environment))
+  (magent-command--validate-result-mode result)
+  (magent-command-step-create
+   :type 'process
+   :name name
+   :options
+   (list :command (copy-sequence command)
+         :directory (file-name-as-directory
+                     (expand-file-name (or directory default-directory)))
+         :process-environment (copy-sequence process-environment)
+         :environment (copy-tree environment)
+         :timeout timeout
+         :check (and check t)
+         :result result
+         :record-command (and record-command t)
+         :record-output (and record-output t))))
+
+(defmacro magent-command-process (name command &rest options)
+  "Run argv COMMAND as process Step NAME and return its selected result."
+  (declare (indent 2))
+  `(magent-command--unwrap-step-outcome
+    (iter-yield
+     (magent-command--make-process-step ,name ,command ,@options))))
+
+(cl-defun magent-command--make-agent-step
+    (name prompt &key agent skills buffers append-argument-p required-tools
+          (result 'value) request-context resource-blocks terminal-p)
+  "Create an agent or terminal Answer Step named NAME for PROMPT."
+  (magent-command--normalize-step-name name)
+  (unless (stringp prompt)
+    (error "Magent command agent Step requires a string prompt: %S" prompt))
+  (unless (or (null agent) (symbolp agent) (stringp agent))
+    (error "Expected Magent command agent name, got: %S" agent))
+  (unless (or (null skills) (proper-list-p skills))
+    (error "Expected Magent command skill list, got: %S" skills))
+  (unless (or (null buffers) (proper-list-p buffers))
+    (error "Expected Magent command buffer configuration list, got: %S"
+           buffers))
+  (unless (memq append-argument-p '(nil t))
+    (error "Expected append-argument-p boolean, got: %S"
+           append-argument-p))
+  (unless (or (null required-tools) (proper-list-p required-tools))
+    (error "Expected required tool list, got: %S" required-tools))
+  (magent-command--validate-result-mode result)
+  (magent-command-step-create
+   :type (if terminal-p 'answer 'agent)
+   :name name
+   :terminal-p terminal-p
+   :options
+   (list :prompt prompt
+         :agent agent
+         :skills skills
+         :buffers buffers
+         :append-argument-p (and append-argument-p t)
+         :required-tools required-tools
+         :result (if terminal-p 'full result)
+         :request-context request-context
+         :resource-blocks resource-blocks)))
+
+(defmacro magent-command-agent (name prompt &rest options)
+  "Run PROMPT as intermediate agent Step NAME and return its result."
+  (declare (indent 2))
+  `(magent-command--unwrap-step-outcome
+    (iter-yield
+     (magent-command--make-agent-step ,name ,prompt ,@options))))
+
+(defmacro magent-command-answer (name prompt &rest options)
+  "Run PROMPT as terminal Answer Step NAME.
+The Invocation ends when the Step finishes; forms after this call do not run."
+  (declare (indent 2))
+  `(iter-yield
+    (magent-command--make-agent-step
+     ,name ,prompt ,@options :terminal-p t)))
+
+(cl-defun magent-command--make-callback-step
+    (name start &key activity-input activity-formatter)
+  "Create callback Step NAME using START."
+  (magent-command--normalize-step-name name)
+  (unless (functionp start)
+    (error "Magent command callback Step requires START function: %S" start))
+  (unless (or (null activity-formatter) (functionp activity-formatter))
+    (error "Expected callback activity formatter, got: %S"
+           activity-formatter))
+  (magent-command-step-create
+   :type 'callback
+   :name name
+   :options (list :start start
+                  :activity-input activity-input
+                  :activity-formatter activity-formatter)))
+
+(defmacro magent-command-callback (name start &rest options)
+  "Wait for callback Step NAME started by START and return its value.
+START receives one DONE function, called as (DONE STATUS VALUE), and returns
+an optional zero-argument cancellation function."
+  (declare (indent 2))
+  `(magent-command--unwrap-step-outcome
+    (iter-yield
+     (magent-command--make-callback-step ,name ,start ,@options))))
+
+(defun magent-command--unwrap-step-outcome (outcome)
+  "Return completed OUTCOME value or signal its typed failure."
+  (unless (magent-command-step-outcome-p outcome)
+    (error "Workflow resumed with invalid Step outcome: %S" outcome))
+  (pcase (magent-command-step-outcome-status outcome)
+    ('completed (magent-command-step-outcome-value outcome))
+    ('failed
+     (let ((condition (magent-command-step-outcome-condition outcome)))
+       (if (and (consp condition) (symbolp (car condition)))
+           (signal (car condition) (cdr condition))
+         (signal 'magent-command-step-error
+                 (list (format "%s" condition))))))
+    (_
+     (error "Workflow received non-resumable Step status: %S"
+            (magent-command-step-outcome-status outcome)))))
+
+(defun magent-command--step-option (step key)
+  "Return STEP option KEY."
+  (plist-get (magent-command-step-options step) key))
+
+(defun magent-command-workflow-step-activity-input (step)
+  "Return safe default activity input for STEP."
+  (pcase (magent-command-step-type step)
+    ('process
+     (append
+      (when (magent-command--step-option step :record-command)
+        (list :command (magent-command--step-option step :command)))
+      (list :directory (magent-command--step-option step :directory))
+      (when-let* ((environment
+                   (magent-command--step-option step :environment)))
+        (list :environment-keys (mapcar #'car environment)))))
+    ('callback (magent-command--step-option step :activity-input))
+    ((or 'agent 'answer)
+     (list :agent (magent-command--step-option step :agent)
+           :terminal (eq (magent-command-step-type step) 'answer)))
+    (_ nil)))
+
+(defun magent-command-workflow--bounded-output (text)
+  "Return TEXT bounded for durable Step activity."
+  (let ((value (or text ""))
+        (limit magent-command-step-output-max-chars))
+    (if (or (null limit) (<= (length value) limit))
+        value
+      (concat
+       (format "[... truncated %d leading characters ...]\n"
+               (- (length value) limit))
+       (substring value (- (length value) limit))))))
+
+(defun magent-command-workflow-step-activity-output (step status value)
+  "Return durable activity output for STEP STATUS and VALUE."
+  (pcase (magent-command-step-type step)
+    ('process
+     (when (and (magent-command--step-option step :record-output)
+                (magent-command-process-result-p value))
+       (magent-command-workflow--bounded-output
+        (string-join
+         (delq nil
+               (list
+                (and (not (string-empty-p
+                           (magent-command-process-result-stdout value)))
+                     (concat "stdout:\n"
+                             (magent-command-process-result-stdout value)))
+                (and (not (string-empty-p
+                           (magent-command-process-result-stderr value)))
+                     (concat "stderr:\n"
+                             (magent-command-process-result-stderr value)))))
+         "\n"))))
+    ('callback
+     (when-let* ((formatter
+                  (magent-command--step-option step :activity-formatter)))
+       (condition-case err
+           (let ((formatted (funcall formatter status value)))
+             (and formatted
+                  (magent-command-workflow--bounded-output
+                   (if (stringp formatted)
+                       formatted
+                     (format "%s" formatted)))))
+         (error
+          (magent-log "WARN command callback activity formatter failed: %s"
+                      (error-message-string err))
+          nil))))
+    (_ nil)))
+
+(defun magent-command-workflow--process-environment (step)
+  "Return process environment captured by STEP with overrides applied."
+  (let ((process-environment
+         (copy-sequence
+          (magent-command--step-option step :process-environment))))
+    (dolist (entry (magent-command--step-option step :environment))
+      (setenv (car entry) (cdr entry)))
+    process-environment))
+
+(defun magent-command-workflow--buffer-text (buffer)
+  "Return BUFFER text, or an empty string if BUFFER is dead."
+  (if (buffer-live-p buffer)
+      (with-current-buffer buffer
+        (buffer-substring-no-properties (point-min) (point-max)))
+    ""))
+
+(defun magent-command-workflow--start-process (step done)
+  "Start process STEP and call DONE once.  Return its cancel function."
+  (let* ((stdout (generate-new-buffer " *magent-command-stdout*"))
+         (stderr (generate-new-buffer " *magent-command-stderr*"))
+         (command (magent-command--step-option step :command))
+         (directory (magent-command--step-option step :directory))
+         (timeout (magent-command--step-option step :timeout))
+         (check (magent-command--step-option step :check))
+         (started-at (float-time))
+         (finished-p nil)
+         process stderr-process timer)
+    (cl-labels
+        ((cleanup
+          ()
+          (when timer
+            (cancel-timer timer)
+            (setq timer nil))
+          (when (and (processp stderr-process)
+                     (process-live-p stderr-process))
+            (delete-process stderr-process))
+          (when (buffer-live-p stdout) (kill-buffer stdout))
+          (when (buffer-live-p stderr) (kill-buffer stderr)))
+         (finish
+          (timed-out-p)
+          (unless finished-p
+            (setq finished-p t)
+            (let* ((exit-status
+                    (if timed-out-p
+                        124
+                      (if (processp process)
+                          (process-exit-status process)
+                        1)))
+                   (result
+                    (magent-command-process-result-create
+                     :name (magent-command-step-name step)
+                     :command command
+                     :directory directory
+                     :exit-status exit-status
+                     :stdout (magent-command-workflow--buffer-text stdout)
+                     :stderr (magent-command-workflow--buffer-text stderr)
+                     :duration-ms
+                     (truncate (* 1000 (- (float-time) started-at)))
+                     :timed-out-p timed-out-p)))
+              (cleanup)
+              (funcall done
+                       (if (or (and (not timed-out-p) (zerop exit-status))
+                               (not check))
+                           'completed
+                         'failed)
+                       result))))
+         (sentinel
+          (child _event)
+          (when (and (eq child process)
+                     (memq (process-status child) '(exit signal)))
+            (finish nil))))
+      (condition-case err
+          (let ((default-directory directory)
+                (process-environment
+                 (magent-command-workflow--process-environment step)))
+            (setq stderr-process
+                  (make-pipe-process
+                   :name "magent-command-process-stderr"
+                   :buffer stderr
+                   :coding 'utf-8-unix
+                   :noquery t
+                   :sentinel #'ignore))
+            (setq process
+                  (make-process
+                   :name "magent-command-process"
+                   :buffer stdout
+                   :stderr stderr-process
+                   :command command
+                   :connection-type 'pipe
+                   :coding 'utf-8-unix
+                   :noquery t
+                   :sentinel #'ignore))
+            (set-process-sentinel process #'sentinel)
+            (when (and timeout (> timeout 0))
+              (setq timer
+                    (run-at-time
+                     timeout nil
+                     (lambda ()
+                       (when (and (processp process)
+                                  (process-live-p process))
+                         ;; Claim timeout before deletion can synchronously
+                         ;; run the process sentinel.
+                         (set-process-sentinel process #'ignore)
+                         (delete-process process))
+                       (finish t)))))
+            (when (memq (process-status process) '(exit signal))
+              (sentinel process "finished\n")))
+        (error
+         (cleanup)
+         (signal (car err) (cdr err))))
+      (lambda ()
+        (unless finished-p
+          (setq finished-p t)
+          (when (and (processp process) (process-live-p process))
+            (delete-process process))
+          (cleanup))))))
+
+(defun magent-command-workflow--step-condition (step value)
+  "Return typed condition data for failed STEP VALUE."
+  (pcase (magent-command-step-type step)
+    ('process
+     (if (magent-command-process-result-p value)
+         (let* ((result value)
+                (detail
+                 (if (magent-command-process-result-timed-out-p result)
+                     "timed out"
+                   (format
+                    "exited with status %s"
+                    (magent-command-process-result-exit-status result))))
+                (output
+                 (string-trim
+                  (concat (magent-command-process-result-stderr result)
+                          "\n"
+                          (magent-command-process-result-stdout result)))))
+           (list 'magent-command-process-error
+                 (format "%s %s%s"
+                         (magent-command-step-name step)
+                         detail
+                         (if (string-empty-p output)
+                             ""
+                           (concat ": " output)))
+                 result))
+       (list 'magent-command-process-error
+             (if (and (consp value) (symbolp (car value))
+                      (get (car value) 'error-conditions))
+                 (error-message-string value)
+               (format "%s" value))
+             value)))
+    ((or 'agent 'answer)
+     (list 'magent-command-agent-error
+           (cond
+            ((magent-agent-result-p value)
+             (magent-agent-result-content-string value))
+            ((and (consp value) (symbolp (car value))
+                  (get (car value) 'error-conditions))
+             (error-message-string value))
+            (t (format "%s" value)))
+           value))
+    ('callback
+     (list 'magent-command-callback-error
+           (if (and (consp value) (symbolp (car value))
+                    (get (car value) 'error-conditions))
+               (error-message-string value)
+             (format "%s" value))
+           value))
+    (_ (list 'magent-command-step-error (format "%s" value) value))))
+
+(defun magent-command-workflow--selected-value (step value)
+  "Return convenience or full VALUE selected by STEP."
+  (if (eq (magent-command--step-option step :result) 'full)
+      value
+    (pcase (magent-command-step-type step)
+      ('process
+       (if (magent-command-process-result-p value)
+           (magent-command-process-result-stdout value)
+         value))
+      ('agent
+       (if (magent-agent-result-p value)
+           (magent-agent-result-content-string value)
+         value))
+      (_ value))))
+
+(defun magent-command-workflow--active-p (invocation generation)
+  "Return non-nil when INVOCATION still owns GENERATION."
+  (and (eq (magent-command-invocation-status invocation) 'active)
+       (= generation (magent-command-invocation-generation invocation))))
+
+(defun magent-command-workflow--close-iterator (invocation)
+  "Close INVOCATION iterator, logging cleanup errors."
+  (when-let* ((iterator (magent-command-invocation-iterator invocation)))
+    (setf (magent-command-invocation-iterator invocation) nil)
+    (condition-case err
+        (iter-close iterator)
+      (error
+       (magent-log "ERROR command Workflow iterator cleanup failed: %s"
+                   (error-message-string err))))))
+
+(defun magent-command-workflow--finish-step
+    (invocation generation status value)
+  "Finish INVOCATION Step GENERATION with STATUS and VALUE."
+  (when (magent-command-workflow--active-p invocation generation)
+    (let ((step (magent-command-invocation-current-step invocation))
+          (item-id (magent-command-invocation-current-step-id invocation)))
+      (setf (magent-command-invocation-current-step invocation) nil
+            (magent-command-invocation-current-step-id invocation) nil
+            (magent-command-invocation-step-cancel-function invocation) nil)
+      (magent-command--workflow-step-finish
+       invocation step item-id status value)
+      (if (magent-command-step-terminal-p step)
+          (progn
+            (magent-command-workflow--close-iterator invocation)
+            (pcase status
+              ('completed (magent-command--finish-answer invocation value))
+              ('cancelled
+               (magent-command--finish-cancelled invocation value))
+              (_ (magent-command--finish-failed
+                  invocation
+                  (magent-command-workflow--step-condition step value)))))
+        (pcase status
+          ('cancelled
+           (magent-command--finish-cancelled invocation value))
+          ((or 'completed 'failed)
+           (magent-command-workflow--resume
+            invocation
+            (magent-command-step-outcome-create
+             :status status
+             :value (if (eq status 'completed)
+                        (magent-command-workflow--selected-value step value)
+                      value)
+             :condition (and (eq status 'failed)
+                             (magent-command-workflow--step-condition
+                              step value)))))
+          (_
+           (magent-command--finish-failed
+            invocation (format "Invalid command Step status: %S" status))))))))
+
+(defun magent-command-workflow--start-step (invocation step)
+  "Start STEP for INVOCATION with synchronous-callback protection."
+  (unless (magent-command-step-p step)
+    (error "Workflow yielded invalid Step: %S" step))
+  (let* ((generation (1+ (magent-command-invocation-generation invocation)))
+         (item-id (magent-command--workflow-step-start invocation step))
+         (starter-returned-p nil)
+         pending
+         cancel)
+    (setf (magent-command-invocation-generation invocation) generation
+          (magent-command-invocation-current-step invocation) step
+          (magent-command-invocation-current-step-id invocation) item-id)
+    (cl-labels
+        ((done
+          (status value)
+          (unless (memq status '(completed failed cancelled))
+            (let ((invalid status))
+              (setq status 'failed
+                    value
+                    (format "Invalid callback Step status: %S" invalid))))
+          (if starter-returned-p
+              (magent-command-workflow--finish-step
+               invocation generation status value)
+            (unless pending
+              (setq pending (cons status value))))))
+      (condition-case err
+          (setq cancel
+                (pcase (magent-command-step-type step)
+                  ('process
+                   (magent-command-workflow--start-process step #'done))
+                  ((or 'agent 'answer)
+                   (magent-command--start-agent-step invocation step #'done))
+                  ('callback
+                   (funcall (magent-command--step-option step :start) #'done))
+                  (_ (error "Unknown command Step type: %S"
+                            (magent-command-step-type step)))))
+        (error
+         (setq pending (cons 'failed err))))
+      (unless (or (null cancel) (functionp cancel))
+        (setq pending
+              (cons 'failed
+                    (format "Step %s returned invalid cancel function: %S"
+                            (magent-command-step-name step) cancel))
+              cancel nil))
+      (setq starter-returned-p t)
+      (when (magent-command-workflow--active-p invocation generation)
+        (setf (magent-command-invocation-step-cancel-function invocation)
+              cancel))
+      (when pending
+        (magent-command-workflow--finish-step
+         invocation generation (car pending) (cdr pending))))))
+
+(defun magent-command-workflow--resume
+    (invocation &optional outcome initial-p)
+  "Resume INVOCATION iterator with OUTCOME, or start it when INITIAL-P."
+  (when (eq (magent-command-invocation-status invocation) 'active)
+    (condition-case condition
+        (let ((step
+               (if initial-p
+                   (iter-next
+                    (magent-command-invocation-iterator invocation))
+                 (iter-next
+                  (magent-command-invocation-iterator invocation) outcome))))
+          (magent-command-workflow--start-step invocation step))
+      (iter-end-of-sequence
+       (let ((result (cdr condition)))
+         (setf (magent-command-invocation-iterator invocation) nil)
+         (if (or (null result) (stringp result))
+             (magent-command--finish-completed invocation result)
+           (magent-command--finish-failed
+            invocation
+            (format "Workflow returned invalid result: %S" result)))))
+      (quit
+       (magent-command--finish-cancelled invocation "Command cancelled"))
+      (error
+       (magent-command--finish-failed invocation condition)))))
+
+(defun magent-command-workflow-start (invocation workflow)
+  "Start WORKFLOW for INVOCATION and return INVOCATION."
+  (unless (functionp workflow)
+    (error "Expected command Workflow function, got: %S" workflow))
+  (let ((iterator (funcall workflow invocation)))
+    (unless (functionp iterator)
+      (error "Command Workflow did not return an iterator: %S" iterator))
+    (setf (magent-command-invocation-iterator invocation) iterator
+          (magent-command-invocation-generation invocation) 0)
+    (magent-command-workflow--resume invocation nil t))
+  invocation)
+
+(defun magent-command-workflow-cleanup (invocation reason)
+  "Cancel INVOCATION's current Step and close its iterator for REASON."
+  (when-let* ((step (magent-command-invocation-current-step invocation)))
+    (magent-command--workflow-step-finish
+     invocation step
+     (magent-command-invocation-current-step-id invocation)
+     'cancelled reason))
+  (setf (magent-command-invocation-current-step invocation) nil
+        (magent-command-invocation-current-step-id invocation) nil)
+  (when-let* ((cancel
+              (magent-command-invocation-step-cancel-function invocation)))
+    (setf (magent-command-invocation-step-cancel-function invocation) nil)
+    (condition-case err
+        (funcall cancel)
+      (error
+       (magent-log "ERROR command Step cancellation failed: %s"
+                   (error-message-string err)))))
+  (magent-command-workflow--close-iterator invocation)
+  invocation)
+
+(provide 'magent-command-workflow)
+;;; magent-command-workflow.el ends here

--- a/lisp/magent-command.el
+++ b/lisp/magent-command.el
@@ -17,6 +17,7 @@
 (require 'subr-x)
 (require 'url-util)
 (require 'magent-config)
+(require 'magent-command-workflow)
 (require 'magent-log)
 (require 'magent-prompt)
 (require 'magent-protocol)
@@ -25,11 +26,14 @@
 (declare-function magent-command-builtins-register "magent-command-builtins")
 (declare-function magent-command-session-cancel "magent-command-session")
 (declare-function magent-command-session-finalize "magent-command-session")
+(declare-function magent-command-session-finalize-workflow-turn
+                  "magent-command-session")
 (declare-function magent-command-session-initialize "magent-command-session")
 (declare-function magent-command-session-read-active-id "magent-command-session")
 (declare-function magent-command-session-record-message "magent-command-session")
-(declare-function magent-command-session-record-tool "magent-command-session")
+(declare-function magent-command-session-finish-step "magent-command-session")
 (declare-function magent-command-session-untrack "magent-command-session")
+(declare-function magent-command-session-start-step "magent-command-session")
 (declare-function magent-runtime-active-project-scope "magent-runtime")
 (declare-function magent-runtime-command-scope "magent-runtime")
 (declare-function magent-runtime-ensure-initialized "magent-runtime")
@@ -44,7 +48,6 @@
 (declare-function magent-runtime-session-scope "magent-runtime-api" t t)
 (declare-function magent-runtime-submit "magent-runtime-api")
 (declare-function magent-skill-description "magent-skills" t t)
-(declare-function magent-skill-requires-project "magent-skills" t t)
 (declare-function magent-skill-source-layer "magent-skills" t t)
 (declare-function magent-skill-source-scope "magent-skills" t t)
 (declare-function magent-skill-tools "magent-skills" t t)
@@ -62,63 +65,12 @@
   title
   exposure
   session-policy
-  turn
-  handler
+  workflow
   source-layer
   source-scope
-  requires-project
-  required-tools
+  requires
   registration-id
   sequence)
-
-(cl-defstruct (magent-command-turn-spec
-               (:constructor magent-command-turn-spec-create)
-               (:copier nil))
-  "Declarative model input and options for one standard command turn.
-PROMPT is user-role model input.  BUFFERS is a popwin-style list of buffer
-patterns whose invocation-time snapshots are attached as model-visible user
-resources.  The invocation owns frontend request context, including project
-scope and attached resource paths.  SKILLS and AGENT select runtime behavior,
-and APPEND-ARGUMENT-P controls slash argument expansion."
-  prompt
-  buffers
-  skills
-  agent
-  (append-argument-p t))
-
-(cl-defstruct (magent-command-invocation
-               (:constructor magent-command-invocation-create)
-               (:copier nil))
-  "Runtime state for one Magent command invocation."
-  id
-  spec
-  control-session
-  runtime-session
-  session
-  scope
-  origin-buffer
-  origin-directory
-  origin-scope
-  parent-session
-  parent-scope
-  parent-session-id
-  options
-  turn-id
-  response-recorded-p
-  interactive-p
-  raw-input
-  argument
-  request-context
-  resource-blocks
-  observer
-  approval-provider
-  completion-function
-  submission-adapter
-  cancel-function
-  submission-ids
-  (status 'active)
-  deferred-p
-  result)
 
 (defvar magent-command--registry nil
   "Layered list of registered `magent-command-spec' objects.")
@@ -222,34 +174,31 @@ When SCOPE is nil, use the currently active project overlay."
     (delete-dups (copy-sequence value))))
 
 (cl-defun magent-command-register
-    (name &key description title exposure (session-policy 'current)
-          turn handler (source-layer 'package) source-scope requires-project
-          required-tools)
+    (name &key description title exposure session-policy workflow
+          (source-layer 'package) source-scope requires)
   "Register Magent command NAME and return its registration token.
 
-Exactly one of TURN and HANDLER must be provided.  TURN is a
-`magent-command-turn-spec' or a function receiving one
-`magent-command-invocation' and returning a turn spec.  HANDLER receives the
-invocation directly and must complete it synchronously or call
-`magent-command-defer' before returning.  SOURCE-LAYER is one of `builtin',
-`package', `user', `project', or reserved `core'.  NAME, SOURCE-LAYER, and
-SOURCE-SCOPE identify one replaceable registration slot.  REQUIRES-PROJECT and
-REQUIRED-TOOLS are checked before model work or HANDLER execution.  EXPOSURE
-is a non-empty list containing `slash', `interactive', or both.
-SESSION-POLICY is `current' or `isolated'."
-  (unless (xor turn handler)
-    (error "Magent command %S requires exactly one of :turn or :handler" name))
-  (when (and turn
-             (not (or (magent-command-turn-spec-p turn)
-                      (functionp turn))))
-    (error "Expected Magent command turn spec or builder, got: %S" turn))
-  (when (magent-command-turn-spec-p turn)
-    (magent-command--validate-turn-spec turn))
-  (when (and handler (not (functionp handler)))
-    (error "Expected Magent command handler function, got: %S" handler))
+WORKFLOW must be a generator Workflow function receiving one
+`magent-command-invocation'.  SOURCE-LAYER is one of `builtin', `package',
+`user', `project', or reserved `core'.  NAME, SOURCE-LAYER, and SOURCE-SCOPE
+identify one replaceable registration slot.  REQUIRES is a feature symbol or
+list of feature symbols loaded with `require' before the Workflow or an
+isolated session starts.  EXPOSURE is a non-empty list containing `slash',
+`interactive', or both.  SESSION-POLICY must be explicitly `current' or
+`isolated'."
+  (unless (functionp workflow)
+    (error "Magent command %S requires a :workflow function" name))
   (unless (memq session-policy magent-command--session-policies)
     (error "Invalid Magent command session policy: %S" session-policy))
-  (let* ((key (magent-command--normalize-name name))
+  (let* ((normalized-requires
+          (cond
+           ((null requires) nil)
+           ((symbolp requires) (list requires))
+           ((and (proper-list-p requires) (cl-every #'symbolp requires))
+            (delete-dups (copy-sequence requires)))
+           (t (error "Expected :requires feature symbol or list, got: %S"
+                     requires))))
+         (key (magent-command--normalize-name name))
          (layer (or source-layer 'package))
          (_rank (magent-command--layer-rank layer))
          (registration-scope
@@ -260,15 +209,10 @@ SESSION-POLICY is `current' or `isolated'."
                 :title (or title (and (stringp description) description) key)
                 :exposure (magent-command--normalize-exposure exposure)
                 :session-policy session-policy
-                :turn turn
-                :handler handler
+                :workflow workflow
                 :source-layer layer
                 :source-scope registration-scope
-                :requires-project requires-project
-                :required-tools
-                (mapcar (lambda (tool)
-                          (if (symbolp tool) tool (intern tool)))
-                        required-tools)
+                :requires normalized-requires
                 :registration-id (magent-protocol-generate-id "command")
                 :sequence (cl-incf magent-command--sequence))))
     (when (and (eq layer 'core)
@@ -375,6 +319,21 @@ currently active project overlay."
     ('user 'user)
     (_ 'package)))
 
+(defun magent-command--make-skill-workflow (skill-name prompt required-tools)
+  "Return a terminal Workflow adapter for SKILL-NAME and PROMPT."
+  (iter-lambda (invocation)
+    (magent-command-answer
+        "Answer"
+        prompt
+      :skills
+      (magent-skills-dedupe-names
+       (append
+        (magent-runtime-session-pending-skills
+         (magent-command-invocation-runtime-session invocation))
+        (list skill-name)))
+      :required-tools required-tools
+      :append-argument-p t)))
+
 (defun magent-command-refresh-skill-adapters (&optional scope)
   "Rebuild compatibility commands for effective skills in SCOPE.
 Global adapters and each visited project scope are cached independently so
@@ -389,7 +348,6 @@ live sessions can resolve commands without switching the active overlay."
       (magent-command-unregister registration))
     (remhash target-scope magent-command--skill-adapter-registrations)
     (dolist (name (magent-skills-command-names))
-      ;; Give every generated turn builder its own lexical skill-name binding.
       (let ((skill-name name))
         (when-let* ((skill (magent-skills-get skill-name))
                     (prompt (magent-skills-default-prompt skill-name))
@@ -402,20 +360,12 @@ live sessions can resolve commands without switching the active overlay."
                (magent-command-register
                 skill-name
                 :description (magent-skill-description skill)
-                :turn
-                (lambda (invocation)
-                  (magent-command-turn-spec-create
-                   :prompt prompt
-                   :skills
-                   (magent-skills-dedupe-names
-                    (append
-                     (magent-runtime-session-pending-skills
-                      (magent-command-invocation-runtime-session invocation))
-                     (list skill-name)))))
+                :session-policy 'current
+                :workflow
+                (magent-command--make-skill-workflow
+                 skill-name prompt (magent-skill-tools skill))
                 :source-layer (magent-command--skill-source-layer skill)
-                :source-scope (magent-skill-source-scope skill)
-                :requires-project (magent-skill-requires-project skill)
-                :required-tools (magent-skill-tools skill))
+                :source-scope (magent-skill-source-scope skill))
                registrations)
             (error
              (magent-log "WARN skipped skill command adapter %S: %s"
@@ -468,23 +418,10 @@ The next load of SCOPE replaces its cached adapters from current skill data."
   "Report progress MESSAGE for active command INVOCATION."
   (unless (eq (magent-command-invocation-status invocation) 'active)
     (error "Magent command invocation is no longer active"))
-  (when (eq (magent-command-spec-session-policy
-             (magent-command-invocation-spec invocation))
-            'isolated)
-    (magent-command-record-tool
-     invocation "progress" nil message (list :progress t)))
   (magent-command--notify invocation 'command-progress :text message)
   invocation)
 
-(defun magent-command-record-tool
-    (invocation name args result &optional metadata)
-  "Record a tool-like workflow step in INVOCATION's command session."
-  (unless (magent-command-invocation-session invocation)
-    (error "Magent command invocation has no session"))
-  (require 'magent-command-session)
-  (magent-command-session-record-tool invocation name args result metadata))
-
-(defun magent-command-record-message
+(defun magent-command--record-message
     (invocation role content &optional phase metadata)
   "Record ROLE message CONTENT in INVOCATION's command session."
   (unless (magent-command-invocation-session invocation)
@@ -493,29 +430,16 @@ The next load of SCOPE replaces its cached adapters from current skill data."
   (magent-command-session-record-message
    invocation role content phase metadata))
 
-(defun magent-command-respond (invocation content &optional metadata)
+(defun magent-command--respond (invocation content &optional metadata)
   "Record assistant CONTENT and send it to INVOCATION's frontend observer."
   (unless (eq (magent-command-invocation-status invocation) 'active)
     (error "Magent command invocation is no longer active"))
-  (magent-command-record-message
-   invocation 'assistant content nil
-   (append metadata (list :source 'magent-command-final)))
+  (when (magent-command-invocation-session invocation)
+    (magent-command--record-message
+     invocation 'assistant content nil
+     (append metadata (list :source 'magent-command-final))))
   (setf (magent-command-invocation-response-recorded-p invocation) t)
   (magent-command--notify invocation 'assistant-delta :text content)
-  invocation)
-
-(defun magent-command-set-cancel-function (invocation function)
-  "Set additional cancellation FUNCTION for INVOCATION."
-  (unless (or (null function) (functionp function))
-    (error "Expected a cancellation function, got: %S" function))
-  (setf (magent-command-invocation-cancel-function invocation) function)
-  invocation)
-
-(defun magent-command-defer (invocation)
-  "Mark INVOCATION as asynchronously owned by its handler."
-  (unless (eq (magent-command-invocation-status invocation) 'active)
-    (error "Cannot defer a completed Magent command invocation"))
-  (setf (magent-command-invocation-deferred-p invocation) t)
   invocation)
 
 (defun magent-command--claim-finish (invocation status result)
@@ -552,6 +476,17 @@ The next load of SCOPE replaces its cached adapters from current skill data."
            (magent-command-session-untrack invocation))
          (magent-log "ERROR command session finalization failed: %s"
                      (error-message-string err)))))
+    (unless (eq (magent-command-spec-session-policy
+                 (magent-command-invocation-spec invocation))
+                'isolated)
+      (condition-case err
+          (progn
+            (require 'magent-command-session)
+            (magent-command-session-finalize-workflow-turn
+             invocation status result))
+        (error
+         (magent-log "ERROR command Workflow turn finalization failed: %s"
+                     (error-message-string err)))))
     ;; A stale callback must not clear a newer invocation installed for the
     ;; same control session after live reload or extension-managed recovery.
     (when (and control-session
@@ -572,70 +507,63 @@ The next load of SCOPE replaces its cached adapters from current skill data."
                      (error-message-string err)))))
     t))
 
-(defun magent-command-finish (invocation status result)
-  "Finish INVOCATION once with STATUS and RESULT.
-STATUS must be `completed', `failed', or `cancelled'.
-RESULT must be a `magent-agent-result'."
-  (when (magent-command--claim-finish invocation status result)
-    (magent-command--publish-finish invocation)))
-
-(defun magent-command-complete (invocation &optional result)
-  "Complete INVOCATION successfully with RESULT."
-  (magent-command-finish
-   invocation 'completed
-   (if (magent-agent-result-p result)
-       result
-     (magent-agent-result-completed (or result "")))))
-
 (defun magent-command--failure-result (error)
   "Return normalized command failure result for ERROR."
   (if (magent-agent-result-p error)
       error
-    (magent-agent-result-failed error (list :status 'command-error))))
+    (magent-agent-result-failed
+     (if (and (consp error) (symbolp (car error)))
+         (error-message-string error)
+       error)
+     (list :status 'command-error))))
 
-(defun magent-command-fail (invocation error)
-  "Fail INVOCATION with ERROR."
-  (magent-command-finish
-   invocation 'failed (magent-command--failure-result error)))
+(defun magent-command--finish-completed (invocation value)
+  "Complete INVOCATION with Workflow return VALUE."
+  (let ((content (or value "")))
+    (when (and (stringp value) (not (string-empty-p value)))
+      (magent-command--respond invocation value))
+    (when (magent-command--claim-finish
+           invocation 'completed (magent-agent-result-completed content))
+      (magent-command--publish-finish invocation))))
 
-(defun magent-command--cleanup-owned-work (invocation &optional force-runtime)
-  "Cancel work owned by INVOCATION without publishing terminal state.
-Run runtime cancellation when FORCE-RUNTIME is non-nil or the invocation has
-recorded submissions.  Cleanup errors are logged and never hide the original
-terminal result."
-  (let ((cancel (magent-command-invocation-cancel-function invocation))
-        (submission-ids
-         (magent-command-invocation-submission-ids invocation)))
-    ;; Clear ownership first so synchronous cancellation callbacks cannot run
-    ;; either cleanup path more than once.
-    (setf (magent-command-invocation-cancel-function invocation) nil
-          (magent-command-invocation-submission-ids invocation) nil)
-    (when cancel
-      (condition-case err
-          (funcall cancel)
-        ((error quit)
-         (magent-log "ERROR command cancellation cleanup failed: %s"
-                     (error-message-string err)))))
-    (when (or force-runtime submission-ids)
-      (condition-case err
-          (magent-runtime-cancel
-           (magent-command-invocation-runtime-session invocation))
-        ((error quit)
-         (magent-log "ERROR command runtime cancellation failed: %s"
-                     (error-message-string err))))))
-  invocation)
-
-(defun magent-command--finish-with-cleanup
-    (invocation status result &optional force-runtime)
-  "Claim INVOCATION STATUS, clean up owned work, then publish RESULT."
-  (when (magent-command--claim-finish invocation status result)
-    (magent-command--cleanup-owned-work invocation force-runtime)
+(defun magent-command--finish-answer (invocation result)
+  "Finish terminal Answer Step for INVOCATION with agent RESULT."
+  (unless (magent-agent-result-p result)
+    (setq result (magent-agent-result-completed (format "%s" result))))
+  (when (magent-command--claim-finish
+         invocation (magent-agent-result-status result) result)
     (magent-command--publish-finish invocation)))
 
-(defun magent-command--fail-with-cleanup (invocation error)
-  "Fail INVOCATION with ERROR after cancelling work it already submitted."
-  (magent-command--finish-with-cleanup
-   invocation 'failed (magent-command--failure-result error)))
+(defun magent-command--finish-failed (invocation error)
+  "Fail INVOCATION once with ERROR and cancel remaining Workflow state."
+  (let ((result (magent-command--failure-result error)))
+    (when (magent-command--claim-finish invocation 'failed result)
+      (magent-command-workflow-cleanup invocation result)
+      (magent-command--publish-finish invocation))))
+
+(defun magent-command--finish-cancelled (invocation reason)
+  "Cancel INVOCATION once with REASON."
+  (let ((result
+         (if (and (magent-agent-result-p reason)
+                  (eq (magent-agent-result-status reason) 'cancelled))
+             reason
+           (magent-agent-result-cancelled
+            (or reason "Command cancelled") (list :reason 'cancelled)))))
+    (when (magent-command--claim-finish invocation 'cancelled result)
+      (magent-command-workflow-cleanup invocation result)
+      (magent-command--publish-finish invocation))))
+
+(defun magent-command--workflow-step-start (invocation step)
+  "Record STEP start for INVOCATION and return its ledger item id."
+  (require 'magent-command-session)
+  (magent-command-session-start-step invocation step))
+
+(defun magent-command--workflow-step-finish
+    (invocation step item-id status value)
+  "Record STEP terminal STATUS and VALUE for INVOCATION ITEM-ID."
+  (require 'magent-command-session)
+  (magent-command-session-finish-step
+   invocation step item-id status value))
 
 ;;;###autoload
 (defun magent-command-cancel (&optional invocation-or-session-id reason)
@@ -645,13 +573,7 @@ REASON may be a string or a `magent-agent-result' for direct invocations."
   (interactive)
   (cond
    ((magent-command-invocation-p invocation-or-session-id)
-    (magent-command--finish-with-cleanup
-     invocation-or-session-id 'cancelled
-     (if (magent-agent-result-p reason)
-         reason
-       (magent-agent-result-cancelled
-        (or reason "Command cancelled") (list :reason 'cancelled)))
-     t))
+    (magent-command--finish-cancelled invocation-or-session-id reason))
    (t
     (require 'magent-command-session)
     (let ((session-id (or invocation-or-session-id
@@ -672,26 +594,38 @@ REASON may be a string or a `magent-agent-result' for direct invocations."
                 always (keywordp key))))
 
 (defun magent-command--validate-invocation (invocation)
-  "Validate request context and project requirements for INVOCATION."
-  (let* ((spec (magent-command-invocation-spec invocation))
-         (origin (magent-command-invocation-origin-scope invocation)))
-    (unless (magent-command--plist-p
-             (magent-command-invocation-request-context invocation))
-      (error "Expected Magent command invocation request context plist, got: %S"
-             (magent-command-invocation-request-context invocation)))
-    (unless (magent-command--plist-p
-             (magent-command-invocation-options invocation))
-      (error "Expected Magent command invocation options plist, got: %S"
-             (magent-command-invocation-options invocation)))
-    (when (and (magent-command-spec-requires-project spec)
-               (not (stringp origin)))
-      (user-error "Command /%s requires a project workspace"
-                  (magent-command-spec-name spec)))))
+  "Validate request data carried by INVOCATION."
+  (unless (magent-command--plist-p
+           (magent-command-invocation-request-context invocation))
+    (error "Expected Magent command invocation request context plist, got: %S"
+           (magent-command-invocation-request-context invocation)))
+  (unless (magent-command--plist-p
+           (magent-command-invocation-options invocation))
+    (error "Expected Magent command invocation options plist, got: %S"
+           (magent-command-invocation-options invocation))))
 
-(defun magent-command--validate-required-tools (invocation &optional agent)
-  "Validate INVOCATION's required tools for optional turn AGENT."
+(defun magent-command--load-requirements (spec)
+  "Load Elisp feature requirements declared by command SPEC."
+  (dolist (feature (magent-command-spec-requires spec))
+    (let ((loaded
+           (condition-case err
+               (require feature nil t)
+             (error
+              (error "Command /%s failed to require `%s': %s"
+                     (magent-command-spec-name spec) feature
+                     (error-message-string err))))))
+      (unless loaded
+        (user-error "Command /%s requires unavailable feature `%s'"
+                    (magent-command-spec-name spec) feature)))))
+
+(defun magent-command--validate-agent-step-tools (invocation step)
+  "Validate tool requirements of agent STEP for INVOCATION."
   (let* ((spec (magent-command-invocation-spec invocation))
-         (required (magent-command-spec-required-tools spec))
+         (required
+          (mapcar (lambda (tool)
+                    (if (symbolp tool) tool (intern tool)))
+                  (or (magent-command--step-option step :required-tools) nil)))
+         (agent (magent-command--step-option step :agent))
          (runtime-session
           (magent-command-invocation-runtime-session invocation))
          (available
@@ -701,12 +635,13 @@ REASON may be a string or a `magent-agent-result' for direct invocations."
          (missing (and required
                        (cl-set-difference required available))))
     (when missing
-      (user-error "Command /%s requires unavailable tools: %s"
+      (user-error "Command /%s Step %S requires unavailable tools: %s"
                   (magent-command-spec-name spec)
+                  (magent-command-step-name step)
                   (mapconcat #'symbol-name missing ", ")))))
 
-(defun magent-command-turn-metadata (invocation)
-  "Return canonical ledger metadata for command INVOCATION."
+(defun magent-command-turn-metadata (invocation &optional step)
+  "Return canonical ledger metadata for command INVOCATION and STEP."
   (list :source 'magent-command
         :command
         (magent-command-spec-name
@@ -716,26 +651,40 @@ REASON may be a string or a `magent-agent-result' for direct invocations."
         :command-argument
         (magent-command-invocation-argument invocation)
         :command-input
-        (magent-command-invocation-raw-input invocation)))
+        (magent-command-invocation-raw-input invocation)
+        :workflow-step-id
+        (and step (magent-command-invocation-current-step-id invocation))
+        :workflow-step-name
+        (and step (magent-command-step-name step))
+        :workflow-step-type
+        (and step (magent-command-step-type step))))
 
-(cl-defun magent-command-submit
-    (invocation prompt &key skills agent request-context turn-metadata
-                resource-blocks on-complete)
-  "Submit one agent PROMPT owned by command INVOCATION.
-REQUEST-CONTEXT supplies optional request-only runtime hints for an advanced
-handler.  It is not serialized as model input and takes precedence over the
-frontend context captured by INVOCATION.  Standard declarative turns inherit
-the invocation context without adding command-local hints.  RESOURCE-BLOCKS
-are additional model-visible user resources inserted before frontend
-attachments.  TURN-METADATA remains available to advanced handlers only.
-ON-COMPLETE receives the normal runtime STATUS and RESULT."
+(defun magent-command--forward-answer-event (invocation event)
+  "Forward terminal Answer EVENT and track visible response state."
+  (when (eq (plist-get event :type) 'assistant-delta)
+    (setf (magent-command-invocation-response-recorded-p invocation) t))
+  (when-let* ((observer (magent-command-invocation-observer invocation)))
+    (funcall observer event)))
+
+(defun magent-command--start-agent-step (invocation step done)
+  "Start agent STEP for INVOCATION and call DONE on completion."
   (unless (eq (magent-command-invocation-status invocation) 'active)
-    (error "Cannot submit from a completed Magent command invocation"))
-  (unless (magent-command--plist-p request-context)
-    (error "Expected Magent command request context plist, got: %S"
-           request-context))
-  (let* ((adapter (magent-command-invocation-submission-adapter invocation))
-         (additional-resources (append resource-blocks nil))
+    (error "Cannot start a Step for a completed command invocation"))
+  (magent-command--validate-agent-step-tools invocation step)
+  (let* ((prompt (magent-command--step-prompt step invocation))
+         (agent (magent-command--step-option step :agent))
+         (skills (magent-command--step-option step :skills))
+         (request-context
+          (magent-command--step-option step :request-context))
+         (_context-valid
+          (unless (magent-command--plist-p request-context)
+            (error "Expected Magent command request context plist, got: %S"
+                   request-context)))
+         (buffers (magent-command--resolve-step-buffers step invocation))
+         (additional-resources
+          (append (magent-command--buffer-resource-blocks buffers)
+                  (magent-command--step-option step :resource-blocks)
+                  nil))
          (frontend-resources
           (append (magent-command-invocation-resource-blocks invocation) nil))
          (default-blocks
@@ -743,62 +692,45 @@ ON-COMPLETE receives the normal runtime STATUS and RESULT."
                (vconcat
                 (cons `((type . "text") (text . ,prompt))
                       (append additional-resources frontend-resources)))))
+         (adapter (magent-command-invocation-submission-adapter invocation))
          (adapted
           (if adapter
               (funcall adapter prompt additional-resources)
             (list :prompt prompt :content-blocks default-blocks)))
          (effective-prompt (or (plist-get adapted :prompt) prompt))
          (content-blocks (plist-get adapted :content-blocks))
-         (effective-request-context
-          (append request-context
-                  (magent-command-invocation-request-context invocation)))
+         (terminal-p (eq (magent-command-step-type step) 'answer))
          (metadata
           (append
-           (magent-command-turn-metadata invocation)
-           turn-metadata
+           (magent-command-turn-metadata invocation step)
+           (unless terminal-p (list :workflow-activity t))
            (and content-blocks (list :content-blocks content-blocks))))
-         (submission-id
+         submission-id)
+    (setq submission-id
           (magent-runtime-submit
            (magent-command-invocation-runtime-session invocation)
            effective-prompt
            :skills skills
            :agent agent
-           :context effective-request-context
+           :context
+           (append request-context
+                   (magent-command-invocation-request-context invocation))
            :turn-metadata metadata
-           :observer (magent-command-invocation-observer invocation)
+           :observer
+           (and terminal-p
+                (lambda (event)
+                  (magent-command--forward-answer-event invocation event)))
            :approval-provider
            (magent-command-invocation-approval-provider invocation)
-           :on-complete (or on-complete #'ignore))))
-    (push submission-id
-          (magent-command-invocation-submission-ids invocation))
-    submission-id))
-
-(cl-defun magent-command-submit-step
-    (invocation prompt callback &key skills agent request-context turn-metadata
-                resource-blocks)
-  "Submit one workflow PROMPT step for INVOCATION, then call CALLBACK.
-CALLBACK receives runtime STATUS and RESULT while the completed step still
-owns the global FIFO lease.  It may therefore call this function again to
-queue the next step without another backend advancing between the two steps.
-REQUEST-CONTEXT has the same request-only semantics as in
-`magent-command-submit'.  RESOURCE-BLOCKS has the same model-visible
-semantics."
-  (unless (functionp callback)
-    (error "Expected a Magent command step callback, got: %S" callback))
-  (magent-command-submit
-   invocation prompt
-   :skills skills
-   :agent agent
-   :request-context request-context
-   :turn-metadata turn-metadata
-   :resource-blocks resource-blocks
-   :on-complete
-   (lambda (status result)
-     (condition-case err
-         (funcall callback status result)
-       (error
-        (magent-command--fail-with-cleanup
-         invocation (error-message-string err)))))))
+           :on-complete done))
+    (when (and (eq (magent-command-invocation-status invocation) 'active)
+               (eq step (magent-command-invocation-current-step invocation)))
+      (setf (magent-command-invocation-current-submission-id invocation)
+            submission-id))
+    (lambda ()
+      (when (magent-command-invocation-runtime-session invocation)
+        (magent-runtime-cancel
+         (magent-command-invocation-runtime-session invocation))))))
 
 (defun magent-command--normalize-buffer-config (entry)
   "Return normalized popwin-style command buffer configuration ENTRY."
@@ -864,40 +796,6 @@ semantics."
             :required-p required-p
             :project-only-p project-only-p))))
 
-(defun magent-command--validate-turn-spec (turn)
-  "Validate declarative command TURN and return it."
-  (unless (magent-command-turn-spec-p turn)
-    (error "Expected Magent command turn spec, got: %S" turn))
-  (unless (and (stringp (magent-command-turn-spec-prompt turn))
-               (not (string-blank-p
-                     (magent-command-turn-spec-prompt turn))))
-    (error "Magent command turn prompt is empty"))
-  (unless (proper-list-p (magent-command-turn-spec-buffers turn))
-    (error "Expected Magent command buffer configuration list, got: %S"
-           (magent-command-turn-spec-buffers turn)))
-  (mapc #'magent-command--normalize-buffer-config
-        (magent-command-turn-spec-buffers turn))
-  (unless (or (null (magent-command-turn-spec-skills turn))
-              (proper-list-p (magent-command-turn-spec-skills turn)))
-    (error "Expected Magent command skill list, got: %S"
-           (magent-command-turn-spec-skills turn)))
-  (unless (or (null (magent-command-turn-spec-agent turn))
-              (stringp (magent-command-turn-spec-agent turn))
-              (symbolp (magent-command-turn-spec-agent turn)))
-    (error "Expected Magent command agent name, got: %S"
-           (magent-command-turn-spec-agent turn)))
-  (unless (memq (magent-command-turn-spec-append-argument-p turn) '(nil t))
-    (error "Expected Magent command append-argument-p boolean, got: %S"
-           (magent-command-turn-spec-append-argument-p turn)))
-  turn)
-
-(defun magent-command--resolve-turn-spec (turn-or-builder invocation)
-  "Resolve TURN-OR-BUILDER for INVOCATION to a validated turn spec."
-  (magent-command--validate-turn-spec
-   (if (functionp turn-or-builder)
-       (funcall turn-or-builder invocation)
-     turn-or-builder)))
-
 (defun magent-command--path-in-project-p (path root base-directory)
   "Return non-nil when PATH under BASE-DIRECTORY belongs to ROOT."
   (when (and (stringp path) (stringp root))
@@ -958,11 +856,14 @@ semantics."
          candidates)
       candidates)))
 
-(defun magent-command--resolve-turn-buffers (turn invocation)
-  "Resolve and deduplicate TURN buffer patterns for INVOCATION."
-  (let ((seen (make-hash-table :test #'eq))
+(defun magent-command--resolve-step-buffers (step invocation)
+  "Resolve and deduplicate STEP buffer patterns for INVOCATION."
+  (let ((entries (magent-command--step-option step :buffers))
+        (seen (make-hash-table :test #'eq))
         buffers)
-    (dolist (entry (magent-command-turn-spec-buffers turn))
+    (unless (or (null entries) (proper-list-p entries))
+      (error "Expected Step buffer configuration list, got: %S" entries))
+    (dolist (entry entries)
       (let* ((config (magent-command--normalize-buffer-config entry))
              (matches (magent-command--matching-buffers config invocation)))
         (when (null matches)
@@ -1067,11 +968,13 @@ SOURCE-START is the absolute position corresponding to the start of TEXT."
           (setq remaining (max 0 (- remaining used))))))
     (nreverse blocks)))
 
-(defun magent-command--turn-prompt (turn invocation)
-  "Return TURN's prompt expanded for INVOCATION."
-  (let ((base (magent-command-turn-spec-prompt turn))
+(defun magent-command--step-prompt (step invocation)
+  "Return STEP prompt expanded for INVOCATION."
+  (let ((base (magent-command--step-option step :prompt))
         (argument (magent-command-invocation-argument invocation)))
-    (if (or (not (magent-command-turn-spec-append-argument-p turn))
+    (when (string-blank-p base)
+      (error "Magent command agent Step prompt is empty"))
+    (if (or (not (magent-command--step-option step :append-argument-p))
             (string-empty-p argument))
         base
       (concat
@@ -1079,29 +982,6 @@ SOURCE-START is the absolute position corresponding to the start of TEXT."
        (magent-prompt-render
         "internal/additional-instruction.org"
         `((instruction . ,argument)))))))
-
-(defun magent-command--run-turn (invocation)
-  "Run the standard declarative turn owned by INVOCATION."
-  (let* ((spec (magent-command-invocation-spec invocation))
-         (turn (magent-command--resolve-turn-spec
-                (magent-command-spec-turn spec) invocation))
-         (agent (magent-command-turn-spec-agent turn))
-         (prompt (magent-command--turn-prompt turn invocation)))
-    (magent-command--validate-required-tools invocation agent)
-    (let* ((buffers (magent-command--resolve-turn-buffers turn invocation))
-           (resource-blocks
-            (magent-command--buffer-resource-blocks buffers)))
-      (magent-command-defer invocation)
-      (magent-command-submit
-       invocation prompt
-       :skills (magent-command-turn-spec-skills turn)
-       :agent agent
-       :resource-blocks resource-blocks
-       :on-complete
-       (lambda (status result)
-         (if (eq status 'completed)
-             (magent-command-complete invocation result)
-           (magent-command-finish invocation status result)))))))
 
 (defun magent-command--execute (invocation)
   "Validate and execute INVOCATION, returning it immediately."
@@ -1112,6 +992,9 @@ SOURCE-START is the absolute position corresponding to the start of TEXT."
       (user-error "A Magent command is already active in this session"))
     (condition-case err
         (progn
+          (magent-command--validate-invocation invocation)
+          (magent-command--load-requirements
+           (magent-command-invocation-spec invocation))
           (when (eq (magent-command-spec-session-policy
                      (magent-command-invocation-spec invocation))
                     'isolated)
@@ -1120,24 +1003,14 @@ SOURCE-START is the absolute position corresponding to the start of TEXT."
           (when control-session
             (puthash control-session invocation
                      magent-command--active-invocations))
-          (magent-command--validate-invocation invocation)
-          (if-let* ((handler
-                     (magent-command-spec-handler
-                      (magent-command-invocation-spec invocation))))
-              (progn
-                (magent-command--validate-required-tools invocation)
-                (funcall handler invocation))
-            (magent-command--run-turn invocation))
-          (when (and (eq (magent-command-invocation-status invocation) 'active)
-                     (not (magent-command-invocation-deferred-p invocation)))
-            (magent-command-fail
-             invocation
-             "Command handler returned without completing or deferring")))
+          (magent-command-workflow-start
+           invocation
+           (magent-command-spec-workflow
+            (magent-command-invocation-spec invocation))))
       (quit
-       (magent-command-cancel invocation))
+       (magent-command--finish-cancelled invocation "Command cancelled"))
       (error
-       (magent-command--fail-with-cleanup
-        invocation (error-message-string err))))
+       (magent-command--finish-failed invocation err)))
     invocation))
 
 (cl-defun magent-command--make-invocation

--- a/lisp/magent-config.el
+++ b/lisp/magent-config.el
@@ -369,6 +369,22 @@ Magent-owned truncation for command buffer context."
                  natnum)
   :group 'magent)
 
+(defcustom magent-command-process-timeout 300
+  "Default timeout in seconds for command Workflow process Steps.
+Nil disables the default timeout.  Individual Steps may override this value."
+  :type '(choice (const :tag "No timeout" nil)
+                 number)
+  :group 'magent)
+
+(defcustom magent-command-step-output-max-chars 24000
+  "Maximum process output characters persisted for one Workflow Step.
+The Workflow receives the complete process result.  Only the durable activity
+copy is bounded, retaining the tail with a truncation marker.  Nil disables
+this persistence limit."
+  :type '(choice (const :tag "Do not truncate Step output" nil)
+                 natnum)
+  :group 'magent)
+
 (defcustom magent-session-save-idle-delay 0.25
   "Idle delay in seconds before UI-triggered session saves run.
 Explicit calls to `magent-session-save' remain synchronous."

--- a/lisp/magent-doctor.el
+++ b/lisp/magent-doctor.el
@@ -77,6 +77,7 @@
   current-process
   request-handle
   request-timer
+  done
   cancelled-p)
 
 (defvar magent-doctor--registry (make-hash-table :test #'equal)
@@ -636,25 +637,16 @@ DIRECTORY defaults to STATE's project root.  Return exit and output data."
                (result `((id . ,id)
                          (status . "completed")
                          (data . ,safe))))
-          (magent-command-record-tool
-           context "doctor_probe" (list :probe id) safe
-           (list :doctor-detail t :probe-id id :probe-status 'completed))
           result)
       (magent-doctor-security-error (signal (car err) (cdr err)))
       (magent-redaction-unsafe-value
        (signal 'magent-doctor-security-error '("Probe output rejected")))
       (magent-doctor-probe-timeout
        (let ((message "Probe timed out"))
-         (magent-command-record-tool
-          context "doctor_probe" (list :probe id) message
-          (list :doctor-detail t :probe-id id :probe-status 'failed))
          `((id . ,id) (status . "failed") (error . ,message))))
       (quit (signal 'quit nil))
       (error
        (let ((message (magent-doctor--safe-error err state)))
-         (magent-command-record-tool
-          context "doctor_probe" (list :probe id) message
-          (list :doctor-detail t :probe-id id :probe-status 'failed))
          `((id . ,id) (status . "failed") (error . ,message)))))))
 
 (defun magent-doctor--collect (probes context state)
@@ -742,10 +734,13 @@ DIRECTORY defaults to STATE's project root.  Return exit and output data."
         (delete-process process)))
     (magent-doctor--cancel-request-timer state)
     (magent-doctor--abort-request state)
-    (let ((context (magent-doctor-state-context state)))
-      (when (eq (magent-command-invocation-status context) 'active)
-        (magent-command-cancel context "Doctor cancelled")))
     t))
+
+(defun magent-doctor--done (state status value)
+  "Complete Doctor STATE once with STATUS and VALUE."
+  (when-let* ((done (magent-doctor-state-done state)))
+    (setf (magent-doctor-state-done state) nil)
+    (funcall done status value)))
 
 (defun magent-doctor--request-callback (context state event)
   "Handle one tool-free doctor EVENT for CONTEXT and STATE."
@@ -760,32 +755,31 @@ DIRECTORY defaults to STATE's project root.  Return exit and output data."
        (setf (magent-doctor-state-request-handle state) nil)
        (let ((text (or (magent-llm-event-text event) "")))
          (if (string-empty-p (string-trim text))
-             (magent-command-fail
-              context "Doctor analysis returned an empty response")
+             (magent-doctor--done
+              state 'failed "Doctor analysis returned an empty response")
            (condition-case nil
                (let ((result
                       (magent-doctor--normalize-output text context state)))
-                 (magent-command-respond
-                  context result (list :source 'magent-doctor-final))
-                 (magent-command-complete
-                  context "Doctor diagnosis complete"))
+                 (magent-doctor--done state 'completed result))
              (magent-doctor-security-error
-              (magent-command-fail
-               context "Doctor response failed security validation"))))))
+              (magent-doctor--done
+               state 'failed
+               "Doctor response failed security validation"))))))
       ('error
        (magent-doctor--cancel-request-timer state)
        (setf (magent-doctor-state-request-handle state) nil)
        (condition-case nil
-           (magent-command-fail
-            context
+           (magent-doctor--done
+            state 'failed
             (format "Doctor analysis failed: %s"
                     (magent-doctor--safe-error
                      (list 'error
                            (format "%s" (magent-llm-event-message event)))
                      state)))
          (magent-doctor-security-error
-          (magent-command-fail
-           context "Doctor analysis failed with a redacted error"))))))))
+          (magent-doctor--done
+           state 'failed
+           "Doctor analysis failed with a redacted error"))))))))
 
 (defun magent-doctor--start-analysis (context state results)
   "Start one tool-free provider analysis for CONTEXT over RESULTS."
@@ -827,28 +821,26 @@ DIRECTORY defaults to STATE's project root.  Return exit and output data."
                                          context)
                                         'active)))
                      (magent-doctor--abort-request state)
-                     (magent-command-fail
-                      context "Doctor analysis timed out"))))))))))
+                     (magent-doctor--done
+                      state 'failed "Doctor analysis timed out"))))))))))
 
-(defun magent-doctor--handler (context)
-  "Run the safe probe-based Doctor pipeline for command CONTEXT."
+(defun magent-doctor--start (context done)
+  "Start the safe Doctor pipeline for CONTEXT, completing through DONE."
   (unless (member (magent-command-invocation-argument context)
                   '("" "select"))
     (user-error "Usage: /doctor [select]"))
-  (magent-command-defer context)
   (let* ((probes (magent-doctor--select-probes context))
          (state
           (magent-doctor-state-create
            :context context
+           :done done
            :project-root (magent-doctor--project-root context))))
-    (magent-command-set-cancel-function
-     context (lambda () (magent-doctor--cancel state)))
     (magent-session-set-metadata-value
      (magent-command-invocation-session context)
      'selected-probes
      (vconcat (mapcar #'magent-doctor-probe-id probes)))
     (if (not (magent-doctor--confirm context probes))
-        (magent-command-cancel context "Doctor cancelled")
+        (magent-doctor--done state 'cancelled "Doctor cancelled")
       (setf (magent-doctor-state-deadline state)
             (and (> magent-doctor-total-timeout 0)
                  (+ (float-time) magent-doctor-total-timeout)))
@@ -857,11 +849,18 @@ DIRECTORY defaults to STATE's project root.  Return exit and output data."
             (unless (magent-doctor-state-cancelled-p state)
               (magent-doctor--start-analysis context state results)))
         (magent-doctor-security-error
-         (magent-command-fail
-          context "Doctor diagnostics failed security validation"))
+         (magent-doctor--done
+          state 'failed "Doctor diagnostics failed security validation"))
         (magent-doctor-probe-timeout
-         (magent-command-fail
-          context "Doctor local collection timed out"))))))
+         (magent-doctor--done
+          state 'failed "Doctor local collection timed out"))))
+    (lambda () (magent-doctor--cancel state))))
+
+(magent-command-defworkflow magent-doctor--workflow (context)
+  "Run Doctor as one cancellable callback Step."
+  (magent-command-callback
+      "Diagnose Magent"
+      (lambda (done) (magent-doctor--start context done))))
 
 (defun magent-doctor--register-builtins ()
   "Register built-in Magent doctor probes."
@@ -933,7 +932,7 @@ With prefix argument SELECT-PROBES, review probe selection in the minibuffer."
    :title "Run Magent Doctor"
    :exposure '(slash interactive)
    :session-policy 'isolated
-   :handler #'magent-doctor--handler
+   :workflow #'magent-doctor--workflow
    :source-layer 'core))
 
 (provide 'magent-doctor)

--- a/lisp/magent-memory.el
+++ b/lisp/magent-memory.el
@@ -1096,65 +1096,38 @@ with a plan and continuation for scan-based operations."
 
 (defun magent-memory--command-confirm-provider (context operation)
   "Return confirmation function for memory OPERATION in command CONTEXT."
+  (ignore context operation)
   (lambda (plan continue)
-    (magent-command-record-tool
-     context "memory_scan_plan"
-     (if plan
-         (magent-memory-scan-plan-approval-input plan)
-       (list :operation operation))
-     (if plan
-         (magent-memory-scan-plan-details plan)
-       (concat "Deactivate and clear managed Magent Emacs profile memory. "
-               "User notes and a snapshot are kept."))
-     (list :operation operation))
     (if magent-bypass-permission
-        (progn
-          (magent-command-record-tool
-           context "memory_approval"
-           (list :operation operation)
-           "approved by magent-bypass-permission"
-           (list :operation operation
-                 :approved t
-                 :bypass t))
-          (funcall continue t))
+        (funcall continue t)
       (magent-memory--interactive-confirm
        plan
        (lambda (approved)
-         (magent-command-record-tool
-          context "memory_approval"
-          (list :operation operation)
-          (if approved "approved" "cancelled")
-          (list :operation operation
-                :approved approved))
          (funcall continue approved))))))
 
 (defun magent-memory--command-runner (operation)
-  "Return a command runner for memory OPERATION."
-  (lambda (context)
+  "Return a command Workflow for memory OPERATION."
+  (iter-lambda (context)
     (unless (string-empty-p (magent-command-invocation-argument context))
       (user-error "Command /memory-%s does not accept arguments" operation))
-    (magent-command-defer context)
-    (let ((state
-           (magent-memory-run
-            operation
-            :confirm-fn
-            (magent-memory--command-confirm-provider context operation)
-            :notify-fn (lambda (message)
-                         (message "%s" message)
-                         (magent-command-progress context message))
-            :on-complete
-            (lambda (status message)
-              (pcase status
-                ('completed (magent-command-complete context message))
-                ('cancelled (magent-command-cancel context message))
-                (_ (magent-command-fail context message))))
-            :open-after-write (memq operation '(init refresh)))))
-      (magent-command-set-cancel-function
-       context
-       (lambda ()
-         (magent-memory-cancel-operation
-          state "Magent memory command cancelled.")))
-      state)))
+    (magent-command-callback
+        (format "%s memory" (capitalize (symbol-name operation)))
+        (lambda (done)
+          (let ((state
+                 (magent-memory-run
+                  operation
+                  :confirm-fn
+                  (magent-memory--command-confirm-provider context operation)
+                  :notify-fn
+                  (lambda (message)
+                    (message "%s" message)
+                    (magent-command-progress context message))
+                  :on-complete done
+                  :open-after-write (memq operation '(init refresh)))))
+            (lambda ()
+              (magent-memory-cancel-operation
+               state "Magent memory command cancelled."))))
+      :activity-input (list :operation operation))))
 
 (defun magent-memory--load-text ()
   "Return active memory file text, or nil."
@@ -1356,7 +1329,7 @@ with a plan and continuation for scan-based operations."
      :title (nth 2 definition)
      :exposure '(slash interactive)
      :session-policy 'isolated
-     :handler (nth 3 definition)
+     :workflow (nth 3 definition)
      :source-layer 'core)))
 
 (provide 'magent-memory)

--- a/lisp/magent-session.el
+++ b/lisp/magent-session.el
@@ -1378,11 +1378,19 @@ Returns a condensed version of the conversation."
 
 (defun magent-session--turn-include-p (turn current-turn-id)
   "Return non-nil when TURN should be included in prompt generation."
-  (let ((status (magent-thread-turn-status turn)))
-    (or (eq status 'completed)
-        (and current-turn-id
-             (equal (magent-thread-turn-id turn) current-turn-id)
-             (memq status '(queued in-progress))))))
+  (let* ((status (magent-thread-turn-status turn))
+         (metadata (magent-thread-turn-metadata turn))
+         (workflow-control
+          (magent-session--metadata-value metadata :workflow-control))
+         (workflow-activity
+          (magent-session--metadata-value metadata :workflow-activity))
+         (current-p
+          (and current-turn-id
+               (equal (magent-thread-turn-id turn) current-turn-id))))
+    (and (not workflow-control)
+         (or (not workflow-activity) current-p)
+         (or (eq status 'completed)
+             (and current-p (memq status '(queued in-progress)))))))
 
 (defun magent-session--compaction-turn-p (turn)
   "Return non-nil when TURN is a reusable completed compaction boundary."

--- a/lisp/magent.el
+++ b/lisp/magent.el
@@ -89,6 +89,7 @@
 (require 'magent-agent-job)
 (require 'magent-llm)
 (require 'magent-llm-gptel)
+(require 'magent-command-workflow)
 (require 'magent-command-session)
 (require 'magent-memory)
 (require 'magent-doctor)

--- a/source-files.txt
+++ b/source-files.txt
@@ -14,6 +14,7 @@ lisp/magent-agent-job.el
 lisp/magent-llm.el
 lisp/magent-llm-gptel.el
 lisp/magent-session.el
+lisp/magent-command-workflow.el
 lisp/magent-command.el
 lisp/magent-memory.el
 lisp/magent-agent-loop.el

--- a/test/magent-command-builtin-test.el
+++ b/test/magent-command-builtin-test.el
@@ -17,8 +17,8 @@
     (let ((command (magent-command-get "test")))
       (should command)
       (should (eq (magent-command-spec-source-layer command) 'builtin))
-      (should (equal (magent-command-spec-required-tools command)
-                     '(read_file grep bash emacs_eval))))))
+      (should (functionp (magent-command-spec-workflow command)))
+      (should (eq (magent-command-spec-session-policy command) 'current)))))
 
 (provide 'magent-command-builtin-test)
 ;;; magent-command-builtin-test.el ends here

--- a/test/magent-live-test.el
+++ b/test/magent-live-test.el
@@ -762,8 +762,8 @@ return that path."
           (should (string-match-p "\\`[0-9]+\\'"
                                   (plist-get tool-content :result))))))))
 
-(ert-deftest magent-live-test-command-turn-snapshots-live-buffer ()
-  "Run a native command turn with one immutable live-buffer resource."
+(ert-deftest magent-live-test-command-answer-snapshots-live-buffer ()
+  "Run a terminal Answer Step with one immutable live-buffer resource."
   :tags '(:magent-live-smoke)
   (require 'magent)
   (magent-live-test--with-isolated-runtime
@@ -784,11 +784,14 @@ return that path."
         (let ((context-buffer (current-buffer)))
           (magent-command-register
            "live-buffer-context"
-           :description "Exercise native command buffer context."
-           :turn
-           (magent-command-turn-spec-create
-            :prompt "Inspect the attached live buffer."
-            :buffers (list context-buffer)))
+           :description "Exercise command Answer buffer context."
+           :session-policy 'current
+           :workflow
+           (iter-lambda (_invocation)
+             (magent-command-answer
+                 "Inspect live buffer"
+                 "Inspect the attached live buffer."
+               :buffers (list context-buffer))))
           (cl-letf (((symbol-function 'magent-runtime-submit)
                      (lambda (session prompt &rest args)
                        (setq submitted (list session prompt args))

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -126,6 +126,19 @@
   '("doctor" "memory-clear" "memory-init" "memory-refresh")
   "Magent-owned isolated workflows exposed as slash commands.")
 
+(magent-command-defworkflow magent-test--empty-command-workflow (_invocation)
+  "Return immediately for registry and frontend discovery tests."
+  nil)
+
+(defmacro magent-test--without-command-step-ledger (&rest body)
+  "Run BODY while replacing durable command Step recording with stubs."
+  (declare (indent 0))
+  `(cl-letf (((symbol-function 'magent-command--workflow-step-start)
+              (lambda (&rest _) "workflow-step-test"))
+             ((symbol-function 'magent-command--workflow-step-finish)
+              #'ignore))
+     ,@body))
+
 (defun magent-test--load-builtin-skills-only ()
   "Load bundled skill files into the caller's test skill registry."
   (require 'magent-skills)
@@ -2129,8 +2142,7 @@
                                 "memory init progress")
                        (funcall (plist-get args :on-complete)
                                 'completed
-                                (magent-agent-result-completed
-                                 "memory init complete")))))
+                                "memory init complete"))))
             (magent-command-run-memory-init))
           (let* ((files (magent-session-list-command-files "memory-init"))
                  (meta (magent-session--read-file-metadata-cached (car files)))
@@ -2157,7 +2169,7 @@
                 :title "Initialize memory"
                 :exposure '(interactive)
                 :session-policy 'isolated
-                :handler #'ignore))
+                :workflow #'magent-test--empty-command-workflow))
          (invocation (magent-command-invocation-create
                       :id "invocation-memory"
                       :spec spec
@@ -2171,19 +2183,7 @@
                        (error "interactive confirmation must be bypassed"))))
             (funcall (magent-memory--command-confirm-provider invocation 'init)
                      nil (lambda (value) (setq approved value))))
-          (let* ((session (magent-command-invocation-session invocation))
-                 (thread (magent-session-thread-ledger session))
-                 (items (apply #'append
-                               (mapcar #'magent-thread-turn-items
-                                       (magent-thread-turns thread))))
-                 (approval (cl-find "memory_approval" items
-                                    :key #'magent-thread-item-name
-                                    :test #'equal)))
-            (should approved)
-            (should approval)
-            (should (string-match-p
-                     "magent-bypass-permission"
-                     (or (magent-thread-item-output approval) "")))))
+          (should approved))
       (delete-directory magent-session-directory t))))
 
 (ert-deftest magent-test-isolated-command-completion-preserves-current-session ()
@@ -2197,7 +2197,7 @@
          (magent-session--scoped-sessions (make-hash-table :test #'equal))
          (parent (magent-session-create :id "session-parent"))
          (new-current (magent-session-create :id "session-new"))
-         captured)
+         captured finish)
     (unwind-protect
         (progn
           (magent-session-install 'global parent)
@@ -2206,9 +2206,14 @@
            :title "Async test"
            :exposure '(interactive)
            :session-policy 'isolated
-           :handler (lambda (invocation)
-                      (setq captured invocation)
-                      (magent-command-defer invocation)))
+           :workflow
+           (iter-lambda (invocation)
+             (setq captured invocation)
+             (magent-command-callback
+                 "Wait"
+                 (lambda (done)
+                   (setq finish done)
+                   #'ignore))))
           (cl-letf (((symbol-function 'magent-runtime-ensure-initialized)
                      #'ignore)
                     ((symbol-function 'magent-runtime-command-scope)
@@ -2219,7 +2224,7 @@
                      #'ignore))
             (magent-command-run "async-test")
             (magent-session-install "/tmp/magent-other-project" new-current)
-            (magent-command-complete captured "Async test complete"))
+            (funcall finish 'completed "Async test complete"))
           (should (eq magent--current-session new-current))
           (should (equal magent-session--current-scope
                          "/tmp/magent-other-project"))
@@ -2235,7 +2240,7 @@
          (spec (magent-command-spec-create
                 :name "viewer-test" :title "Viewer test"
                 :exposure '(interactive) :session-policy 'isolated
-                :handler #'ignore))
+                :workflow #'magent-test--empty-command-workflow))
          (invocation (magent-command-invocation-create
                       :id "invocation-viewer" :spec spec
                       :origin-scope 'global))
@@ -2243,12 +2248,19 @@
     (unwind-protect
         (progn
           (magent-command-session-initialize invocation)
-          (magent-command-record-tool
-           invocation "doctor_probe" '(:probe "core") "bounded detail")
-          (magent-command-respond
+          (let* ((step (magent-command--make-callback-step
+                        "Collect diagnostics" #'ignore
+                        :activity-input '(:probe "core")
+                        :activity-formatter
+                        (lambda (_status value) value)))
+                 (item-id
+                  (magent-command-session-start-step invocation step)))
+            (magent-command-session-finish-step
+             invocation step item-id 'completed "bounded detail"))
+          (magent-command--respond
            invocation "* Diagnosis\n** Summary\nVisible result"
            (list :source 'magent-doctor-final))
-          (magent-command-complete invocation "Viewer complete")
+          (magent-command--finish-completed invocation nil)
           (let ((file (car (magent-session-list-command-files "viewer-test"))))
             (cl-letf (((symbol-function 'display-buffer)
                        (lambda (value &rest _) value)))
@@ -3219,32 +3231,30 @@
       (let ((command (magent-command-get name)))
         (should command)
         (should (eq (magent-command-spec-source-layer command) 'builtin))
-        (should (functionp (magent-command-spec-turn command)))
-        (should-not (magent-command-spec-handler command))
+        (should (functionp (magent-command-spec-workflow command)))
         (should-not (magent-skills-get name))))))
 
-(ert-deftest magent-test-command-register-requires-turn-handler-xor ()
-  "Test command registration requires exactly one execution strategy."
+(ert-deftest magent-test-command-register-requires-workflow-and-policy ()
+  "Test command registration requires one Workflow and explicit policy."
   (require 'magent-command)
-  (let ((magent-command--registry nil)
-        (turn (magent-command-turn-spec-create :prompt "Demo")))
+  (let ((magent-command--registry nil))
     (should-error (magent-command-register "missing"))
     (should-error
-     (magent-command-register
-      "ambiguous" :turn turn :handler #'ignore))
-    (should (magent-command-register "turn" :turn turn))
-    (should
-     (magent-command-register "handler" :handler #'ignore))
+     (magent-command-register "missing-policy"
+                              :workflow #'magent-test--empty-command-workflow))
+    (should (magent-command-register
+             "workflow" :session-policy 'current
+             :workflow #'magent-test--empty-command-workflow))
     (should-error
      (magent-command-register
-      "retired-owner" :handler #'ignore :owner 'retired))))
+      "retired-owner" :session-policy 'current :workflow #'magent-test--empty-command-workflow :owner 'retired))))
 
 (ert-deftest magent-test-command-register-validates-exposure-and-session-policy ()
   "Command exposure is orthogonal to registry identity and defaults to slash."
   (let ((magent-command--registry nil))
-    (let ((slash (magent-command-register "slash" :handler #'ignore))
+    (let ((slash (magent-command-register "slash" :session-policy 'current :workflow #'magent-test--empty-command-workflow))
           (both (magent-command-register
-                 "both" :handler #'ignore
+                 "both" :workflow #'magent-test--empty-command-workflow
                  :exposure '(slash interactive slash)
                  :session-policy 'isolated)))
       (should (equal (magent-command-spec-exposure slash) '(slash)))
@@ -3255,10 +3265,10 @@
       (should (eq (magent-command-get "both") both))
       (should-not (magent-command-get "slash" nil 'interactive)))
     (should-error
-     (magent-command-register "bad-exposure" :handler #'ignore
+     (magent-command-register "bad-exposure" :session-policy 'current :workflow #'magent-test--empty-command-workflow
                               :exposure '(menu)))
     (should-error
-     (magent-command-register "bad-policy" :handler #'ignore
+     (magent-command-register "bad-policy" :workflow #'magent-test--empty-command-workflow
                               :session-policy 'temporary))))
 
 (ert-deftest magent-test-command-registry-resolves-layered-overrides ()
@@ -3267,16 +3277,16 @@
   (let ((magent-command--registry nil)
         (magent-command--sequence 0))
     (let ((builtin (magent-command-register
-                    "demo" :description "builtin" :handler #'ignore
+                    "demo" :description "builtin" :session-policy 'current :workflow #'magent-test--empty-command-workflow
                     :source-layer 'builtin))
           (package (magent-command-register
-                    "demo" :description "package" :handler #'ignore
+                    "demo" :description "package" :session-policy 'current :workflow #'magent-test--empty-command-workflow
                     :source-layer 'package))
           (user (magent-command-register
-                 "demo" :description "user" :handler #'ignore
+                 "demo" :description "user" :session-policy 'current :workflow #'magent-test--empty-command-workflow
                  :source-layer 'user))
           (project (magent-command-register
-                    "demo" :description "project" :handler #'ignore
+                    "demo" :description "project" :session-policy 'current :workflow #'magent-test--empty-command-workflow
                     :source-layer 'project)))
       (should (eq (magent-command-get "demo") project))
       (should (magent-command-unregister project))
@@ -3292,16 +3302,16 @@
   (let ((magent-command--registry nil)
         (magent-command--sequence 0))
     (let ((old (magent-command-register
-                "demo" :description "old" :handler #'ignore
+                "demo" :description "old" :session-policy 'current :workflow #'magent-test--empty-command-workflow
                 :source-layer 'project :source-scope "/tmp/project-a"))
           new other-scope)
       (setq new
             (magent-command-register
-             "demo" :description "new" :handler #'ignore
+             "demo" :description "new" :session-policy 'current :workflow #'magent-test--empty-command-workflow
              :source-layer 'project :source-scope "/tmp/project-a"))
       (setq other-scope
             (magent-command-register
-             "demo" :description "other" :handler #'ignore
+             "demo" :description "other" :session-policy 'current :workflow #'magent-test--empty-command-workflow
              :source-layer 'project :source-scope "/tmp/project-b"))
       (should (= (length magent-command--registry) 2))
       (should (eq (magent-command-get "demo" "/tmp/project-a") new))
@@ -3315,13 +3325,13 @@
   (require 'magent-command)
   (let ((magent-command--registry nil))
     (let ((global (magent-command-register
-                   "global" :handler #'ignore :source-layer 'user))
+                   "global" :session-policy 'current :workflow #'magent-test--empty-command-workflow :source-layer 'user))
           (project-b
            (magent-command-register
-            "project-b" :handler #'ignore :source-layer 'project
+            "project-b" :session-policy 'current :workflow #'magent-test--empty-command-workflow :source-layer 'project
             :source-scope "/tmp/project-b")))
       (magent-command-register
-       "project-a" :handler #'ignore :source-layer 'project
+       "project-a" :session-policy 'current :workflow #'magent-test--empty-command-workflow :source-layer 'project
        :source-scope "/tmp/project-a")
       (should (= (magent-command-remove-source
                   'project "/tmp/project-a")
@@ -3344,7 +3354,7 @@
     (add-hook 'magent-command-registry-changed-hook
               (lambda () (cl-incf changes)))
     (let ((registration
-           (magent-command-register "demo" :handler #'ignore)))
+           (magent-command-register "demo" :session-policy 'current :workflow #'magent-test--empty-command-workflow)))
       (should (= changes 1))
       (should (magent-command-unregister registration))
       (should (= changes 2)))))
@@ -3355,14 +3365,14 @@
   (let ((magent-command--registry nil))
     (let ((core (let ((magent-command--allow-core-registration t))
                   (magent-command-register
-                   "compact" :handler #'ignore
+                   "compact" :session-policy 'current :workflow #'magent-test--empty-command-workflow
                    :source-layer 'core))))
       (magent-command-register
-       "compact" :handler #'ignore :source-layer 'project)
+       "compact" :session-policy 'current :workflow #'magent-test--empty-command-workflow :source-layer 'project)
       (should (eq (magent-command-get "compact") core))
       (should-error
        (magent-command-register
-        "reserved" :handler #'ignore :source-layer 'core)
+        "reserved" :session-policy 'current :workflow #'magent-test--empty-command-workflow :source-layer 'core)
        :type 'error)
       (should-error (magent-command-unregister core) :type 'error)
       (should-error (magent-command-remove-source 'core) :type 'error))))
@@ -3376,7 +3386,7 @@
          (make-hash-table :test #'equal))
         (magent-skills--registry nil))
     (let ((builtin (magent-command-register
-                    "fix" :handler #'ignore
+                    "fix" :session-policy 'current :workflow #'magent-test--empty-command-workflow
                     :source-layer 'builtin)))
       (magent-skills-register
        (magent-skill-create
@@ -3463,7 +3473,7 @@
         (magent-skills--registry nil))
     (let ((native
            (magent-command-register
-            "native" :handler #'ignore :source-layer 'user)))
+            "native" :session-policy 'current :workflow #'magent-test--empty-command-workflow :source-layer 'user)))
       (magent-skills-register
        (magent-skill-create
         :name "adapter" :type 'instruction :default-prompt "Run it"
@@ -3501,18 +3511,20 @@
               (magent-command-invocation-create
                :id name :spec spec :runtime-session runtime-session))
              submitted-skills)
-        (cl-letf (((symbol-function 'magent-runtime-submit)
-                   (lambda (_session _prompt &rest args)
-                     (setq submitted-skills (plist-get args :skills))
-                     (funcall (plist-get args :on-complete)
-                              'completed
-                              (magent-agent-result-completed "done"))
-                     "submission-1")))
-          (magent-command--run-turn invocation))
+        (magent-test--without-command-step-ledger
+          (cl-letf (((symbol-function 'magent-runtime-submit)
+                     (lambda (_session _prompt &rest args)
+                       (setq submitted-skills (plist-get args :skills))
+                       (funcall (plist-get args :on-complete)
+                                'completed
+                                (magent-agent-result-completed "done"))
+                       "submission-1")))
+            (magent-command-workflow-start
+             invocation (magent-command-spec-workflow spec))))
         (should (equal submitted-skills (list name)))))))
 
-(ert-deftest magent-test-command-native-turn-submits-structured-turn ()
-  "Test native declarative turns own one structured runtime submission."
+(ert-deftest magent-test-command-answer-submits-structured-turn ()
+  "Test terminal Answer Steps own one structured runtime submission."
   (require 'magent-command)
   (let* ((magent-command--registry nil)
          (magent-command--active-invocations (make-hash-table :test #'eq))
@@ -3523,12 +3535,14 @@
          submitted completion preflight-agent)
     (magent-command-register
      "demo" :description "Demo"
-     :turn
-     (lambda (_invocation)
-       (magent-command-turn-spec-create
-        :prompt "Base prompt"
-        :skills '("review")
-        :agent 'review-agent))
+     :session-policy 'current
+     :workflow
+     (iter-lambda (_invocation)
+       (magent-command-answer
+           "Answer" "Base prompt"
+         :skills '("review")
+         :agent 'review-agent
+         :append-argument-p t))
      :source-layer 'package)
     (cl-letf (((symbol-function 'magent-runtime-session-available-tool-names)
                (lambda (_session &optional agent)
@@ -3568,8 +3582,8 @@
     (should (equal (magent-agent-result-content-string (cadr completion))
                    "done"))))
 
-(ert-deftest magent-test-command-turn-builder-may-consume-argument ()
-  "Test a turn builder can own argument expansion without duplicate text."
+(ert-deftest magent-test-command-workflow-may-consume-argument ()
+  "Test a Workflow can own argument expansion without duplicate text."
   (require 'magent-command)
   (let* ((magent-command--registry nil)
          (magent-command--active-invocations (make-hash-table :test #'eq))
@@ -3580,12 +3594,13 @@
          submitted-prompt)
     (magent-command-register
      "demo" :description "Demo"
-     :turn
-     (lambda (invocation)
-       (magent-command-turn-spec-create
-        :prompt (format "Review target: %s"
-                        (magent-command-invocation-argument invocation))
-        :append-argument-p nil))
+     :session-policy 'current
+     :workflow
+     (iter-lambda (invocation)
+       (magent-command-answer
+           "Answer"
+           (format "Review target: %s"
+                   (magent-command-invocation-argument invocation))))
      :source-layer 'package)
     (cl-letf (((symbol-function 'magent-runtime-submit)
                (lambda (_session prompt &rest args)
@@ -3596,8 +3611,193 @@
       (magent-command-invoke "demo" runtime-session :argument "lisp/"))
     (should (equal submitted-prompt "Review target: lisp/"))))
 
-(ert-deftest magent-test-command-turn-rejects-invalid-builder-result ()
-  "Test an invalid turn builder fails before runtime submission."
+(ert-deftest magent-test-command-process-step-returns-full-result ()
+  "Test an argv process Step resumes with its complete result."
+  (require 'magent-command)
+  (let ((program (executable-find "printf")))
+    (skip-unless program)
+    (let ((magent-command--registry nil)
+          (magent-command--active-invocations (make-hash-table :test #'eq))
+          (runtime-session (magent-runtime-session-create :id "session-1"))
+          captured
+          completion)
+      (magent-command-register
+       "process"
+       :session-policy 'current
+       :workflow
+       (iter-lambda (_invocation)
+         (setq captured
+               (magent-command-process
+                   "Print value" (list program "%s" "hello")
+                 :result 'full))
+         "process completed"))
+      (magent-test--without-command-step-ledger
+        (magent-command-invoke
+         "process" runtime-session
+         :on-complete
+         (lambda (status result) (setq completion (list status result))))
+        (let ((deadline (+ (float-time) 3)))
+          (while (and (null completion) (< (float-time) deadline))
+            (accept-process-output nil 0.02))))
+      (should (eq (car completion) 'completed))
+      (should (magent-command-process-result-p captured))
+      (should (equal (magent-command-process-result-command captured)
+                     (list program "%s" "hello")))
+      (should (zerop (magent-command-process-result-exit-status captured)))
+      (should (equal (magent-command-process-result-stdout captured) "hello"))
+      (should (string-empty-p
+               (magent-command-process-result-stderr captured)))
+      (should-not (magent-command-process-result-timed-out-p captured)))))
+
+(ert-deftest magent-test-command-process-step-failure-is-recoverable ()
+  "Test a failed process Step signals its typed condition in the Workflow."
+  (require 'magent-command)
+  (let ((program (executable-find "false")))
+    (skip-unless program)
+    (let ((magent-command--registry nil)
+          (magent-command--active-invocations (make-hash-table :test #'eq))
+          (runtime-session (magent-runtime-session-create :id "session-1"))
+          condition
+          completion)
+      (magent-command-register
+       "process-failure"
+       :session-policy 'current
+       :workflow
+       (iter-lambda (_invocation)
+         (condition-case err
+             (magent-command-process
+                 "Expected failure" (list program))
+           (magent-command-process-error
+            (setq condition err)
+            "failure recovered"))))
+      (magent-test--without-command-step-ledger
+        (magent-command-invoke
+         "process-failure" runtime-session
+         :on-complete
+         (lambda (status result) (setq completion (list status result))))
+        (let ((deadline (+ (float-time) 3)))
+          (while (and (null completion) (< (float-time) deadline))
+            (accept-process-output nil 0.02))))
+      (should (eq (car completion) 'completed))
+      (should (eq (car condition) 'magent-command-process-error))
+      (should (magent-command-process-result-p (nth 2 condition)))
+      (should (= (magent-command-process-result-exit-status
+                  (nth 2 condition))
+                 1))
+      (should (equal
+               (magent-agent-result-content-string (cadr completion))
+               "failure recovered")))))
+
+(ert-deftest magent-test-command-process-step-start-error-is-typed ()
+  "Test a process startup error remains useful and recoverable."
+  (require 'magent-command)
+  (let ((magent-command--registry nil)
+        (magent-command--active-invocations (make-hash-table :test #'eq))
+        (runtime-session (magent-runtime-session-create :id "session-1"))
+        condition
+        completion)
+    (magent-command-register
+     "process-start-error"
+     :session-policy 'current
+     :workflow
+     (iter-lambda (_invocation)
+       (condition-case err
+           (magent-command-process
+               "Missing executable"
+               '("magent-test-executable-that-does-not-exist"))
+         (magent-command-process-error
+          (setq condition err)
+          "start error recovered"))))
+    (magent-test--without-command-step-ledger
+      (magent-command-invoke
+       "process-start-error" runtime-session
+       :on-complete
+       (lambda (status result) (setq completion (list status result)))))
+    (should (eq (car completion) 'completed))
+    (should (eq (car condition) 'magent-command-process-error))
+    (should (eq (car (nth 2 condition)) 'file-missing))
+    (should (string-match-p
+             "magent-test-executable-that-does-not-exist"
+             (error-message-string condition)))
+    (should (equal
+             (magent-agent-result-content-string (cadr completion))
+             "start error recovered"))))
+
+(ert-deftest magent-test-command-process-step-timeout-is-typed ()
+  "Test process timeout kills the child and remains recoverable."
+  (require 'magent-command)
+  (let ((program (executable-find "sleep")))
+    (skip-unless program)
+    (let ((magent-command--registry nil)
+          (magent-command--active-invocations (make-hash-table :test #'eq))
+          (runtime-session (magent-runtime-session-create :id "session-1"))
+          process-result
+          completion)
+      (magent-command-register
+       "process-timeout"
+       :session-policy 'current
+       :workflow
+       (iter-lambda (_invocation)
+         (condition-case err
+             (magent-command-process
+                 "Expected timeout" (list program "1")
+               :timeout 0.01)
+           (magent-command-process-error
+            (setq process-result (nth 2 err))
+            "timeout recovered"))))
+      (magent-test--without-command-step-ledger
+        (magent-command-invoke
+         "process-timeout" runtime-session
+         :on-complete
+         (lambda (status result) (setq completion (list status result))))
+        (let ((deadline (+ (float-time) 3)))
+          (while (and (null completion) (< (float-time) deadline))
+            (accept-process-output nil 0.02))))
+      (should (eq (car completion) 'completed))
+      (should (magent-command-process-result-p process-result))
+      (should (magent-command-process-result-timed-out-p process-result))
+      (should (= (magent-command-process-result-exit-status process-result)
+                 124))
+      (should (equal
+               (magent-agent-result-content-string (cadr completion))
+               "timeout recovered")))))
+
+(ert-deftest magent-test-command-callback-step-failure-is-typed ()
+  "Test a callback failure resumes as its typed Workflow condition."
+  (require 'magent-command)
+  (let ((magent-command--registry nil)
+        (magent-command--active-invocations (make-hash-table :test #'eq))
+        (runtime-session (magent-runtime-session-create :id "session-1"))
+        condition
+        completion)
+    (magent-command-register
+     "callback-failure"
+     :session-policy 'current
+     :workflow
+     (iter-lambda (_invocation)
+       (condition-case err
+           (magent-command-callback
+               "Fail callback"
+               (lambda (_done) (error "callback exploded")))
+         (magent-command-callback-error
+          (setq condition err)
+          "callback recovered"))))
+    (magent-test--without-command-step-ledger
+      (magent-command-invoke
+       "callback-failure" runtime-session
+       :on-complete
+       (lambda (status result) (setq completion (list status result)))))
+    (should (eq (car completion) 'completed))
+    (should (eq (car condition) 'magent-command-callback-error))
+    (should (eq (car (nth 2 condition)) 'error))
+    (should (string-match-p "callback exploded"
+                            (error-message-string condition)))
+    (should (equal
+             (magent-agent-result-content-string (cadr completion))
+             "callback recovered"))))
+
+(ert-deftest magent-test-command-workflow-rejects-non-iterator-result ()
+  "Test an invalid Workflow result fails before runtime submission."
   (require 'magent-command)
   (let* ((magent-command--registry nil)
          (magent-command--active-invocations (make-hash-table :test #'eq))
@@ -3608,7 +3808,8 @@
          submitted completion)
     (magent-command-register
      "demo" :description "Demo"
-     :turn (lambda (_invocation) "invalid")
+     :session-policy 'current
+     :workflow (lambda (_invocation) "invalid")
      :source-layer 'package)
     (cl-letf (((symbol-function 'magent-runtime-submit)
                (lambda (&rest _args) (setq submitted t))))
@@ -3619,34 +3820,32 @@
     (should-not submitted)
     (should (eq (car completion) 'failed))
     (should (string-match-p
-             "Expected Magent command turn spec"
+             "did not return an iterator"
              (magent-agent-result-content-string (cadr completion))))))
 
-(ert-deftest magent-test-command-turn-validates-structured-fields ()
-  "Test malformed structured turn fields fail before submission ownership."
+(ert-deftest magent-test-command-agent-step-validates-structured-fields ()
+  "Test malformed structured Step fields fail before submission ownership."
   (require 'magent-command)
   (let ((valid-buffer (generate-new-buffer " *magent-turn-validation*")))
     (unwind-protect
         (progn
           (should-error
-           (apply #'magent-command-turn-spec-create
-                  '(:prompt "Demo" :context
-                    (:file-path "/tmp/example.el"))))
-          (should-error
-           (apply #'magent-command-turn-spec-create
-                  '(:prompt "Demo" :turn-metadata (:workflow review))))
-          (dolist (turn
-                   (list
-                    (magent-command-turn-spec-create
-                     :prompt "Demo" :skills "review")
-                    (magent-command-turn-spec-create
-                     :prompt "Demo" :append-argument-p 'yes)
-                    (magent-command-turn-spec-create
-                     :prompt "Demo" :buffers '(("[" :regexp t)))
-                    (magent-command-turn-spec-create
-                     :prompt "Demo"
-                     :buffers (list (list valid-buffer :unknown t)))))
-            (should-error (magent-command--validate-turn-spec turn))))
+           (apply #'magent-command--make-agent-step
+                  '("Demo" "Prompt" :context (:file-path "/tmp/example.el"))))
+          (dolist (buffers
+                   (list '(("[" :regexp t))
+                         (list (list valid-buffer :unknown t))))
+            (let* ((step (magent-command--make-agent-step
+                          "Demo" "Prompt" :buffers buffers))
+                   (invocation
+                    (magent-command-invocation-create
+                     :id "validation"
+                     :spec (magent-command-spec-create :name "validation")
+                     :runtime-session
+                     (magent-runtime-session-create
+                      :id "validation" :scope 'global))))
+              (should-error
+               (magent-command--resolve-step-buffers step invocation)))))
       (kill-buffer valid-buffer))))
 
 (ert-deftest magent-test-command-buffer-patterns-use-popwin-semantics ()
@@ -3675,15 +3874,15 @@
           (cl-letf (((symbol-function 'magent-test-context-buffer-p)
                      (lambda (buffer)
                        (string-match-p "two" (buffer-name buffer)))))
-            (let* ((turn
-                    (magent-command-turn-spec-create
-                     :prompt "Inspect"
+            (let* ((step
+                    (magent-command--make-agent-step
+                     "Inspect" "Inspect"
                      :buffers
                      '(magent-test-context-mode
                        ("^ \\*magent-pattern-" :regexp t)
                        (magent-test-context-buffer-p :predicate t))))
                    (matches
-                    (magent-command--resolve-turn-buffers turn invocation)))
+                    (magent-command--resolve-step-buffers step invocation)))
               (should (= (length matches) 2))
               (should (memq buffer-a matches))
               (should (memq buffer-b matches))
@@ -3717,18 +3916,18 @@
            :id "invocation-1" :spec spec :runtime-session runtime-session))
          logged)
     (should-error
-     (magent-command--resolve-turn-buffers
-      (magent-command-turn-spec-create
-       :prompt "Inspect" :buffers '("*magent-missing-required*"))
+     (magent-command--resolve-step-buffers
+      (magent-command--make-agent-step
+       "Inspect" "Inspect" :buffers '("*magent-missing-required*"))
       invocation)
      :type 'user-error)
     (cl-letf (((symbol-function 'magent-log)
                (lambda (format-string &rest args)
                  (setq logged (apply #'format format-string args)))))
       (should-not
-       (magent-command--resolve-turn-buffers
-        (magent-command-turn-spec-create
-         :prompt "Inspect"
+       (magent-command--resolve-step-buffers
+        (magent-command--make-agent-step
+         "Inspect" "Inspect"
          :buffers '(("*magent-missing-optional*" :required-p nil)))
         invocation)))
     (should (string-match-p "optional buffer pattern" logged))))
@@ -3793,80 +3992,83 @@
               (when (buffer-live-p buffer) (kill-buffer buffer)))
             (list first second)))))
 
-(ert-deftest magent-test-command-advanced-handler-defers-progresses-and-completes ()
-  "Test an asynchronous third-party handler owns invocation completion."
+(ert-deftest magent-test-command-callback-progresses-and-completes ()
+  "Test an asynchronous callback Step owns invocation completion."
   (require 'magent-command)
   (let* ((magent-command--registry nil)
          (magent-command--active-invocations (make-hash-table :test #'eq))
          (runtime-session (magent-runtime-session-create :id "session-1"))
-         invocation events completion)
+         invocation done events completion)
     (magent-command-register
      "async"
-     :handler (lambda (value)
-                (setq invocation value)
-                (magent-command-progress value "phase one")
-                (magent-command-defer value)))
-    (magent-command-invoke
-     "async" runtime-session
-     :observer (lambda (event) (push event events))
-     :on-complete
-     (lambda (status result) (setq completion (list status result))))
-    (should (eq (magent-command-invocation-status invocation) 'active))
-    (should (cl-find 'command-progress events :key (lambda (e) (plist-get e :type))))
-    (should (magent-command-complete invocation "finished"))
+     :session-policy 'current
+     :workflow
+     (iter-lambda (value)
+       (setq invocation value)
+       (magent-command-progress value "phase one")
+       (magent-command-callback
+           "Wait" (lambda (callback) (setq done callback) #'ignore))))
+    (magent-test--without-command-step-ledger
+      (magent-command-invoke
+       "async" runtime-session
+       :observer (lambda (event) (push event events))
+       :on-complete
+       (lambda (status result) (setq completion (list status result))))
+      (should (eq (magent-command-invocation-status invocation) 'active))
+      (should (cl-find 'command-progress events
+                       :key (lambda (e) (plist-get e :type))))
+      (funcall done 'completed "finished"))
     (should (eq (car completion) 'completed))
     (should (equal (magent-agent-result-content-string (cadr completion))
                    "finished"))
-    (should-not (magent-command-complete invocation "again"))))
+    (funcall done 'completed "again")
+    (should (equal (magent-agent-result-content-string (cadr completion))
+                   "finished"))))
 
-(ert-deftest magent-test-command-finish-rejects-legacy-string-results ()
-  "Command terminal callbacks require one structured result contract."
+(ert-deftest magent-test-command-workflow-rejects-non-string-return ()
+  "A Workflow may return only a string or nil."
   (require 'magent-command)
-  (let ((invocation
-         (magent-command-invocation-create
-          :id "strict-result"
-          :spec (magent-command-spec-create :name "strict-result")
-          :status 'active)))
-    (should-error
-     (magent-command-finish invocation 'completed "legacy string")
-     :type 'wrong-type-argument)
-    (should (eq (magent-command-invocation-status invocation) 'active))))
+  (let* ((spec (magent-command-spec-create :name "strict-result"))
+         (invocation
+          (magent-command-invocation-create :id "strict-result" :spec spec))
+         completion)
+    (setf (magent-command-invocation-completion-function invocation)
+          (lambda (status result) (setq completion (list status result))))
+    (magent-command-workflow-start invocation (iter-lambda (_value) 42))
+    (should (eq (car completion) 'failed))
+    (should (string-match-p
+             "invalid result: 42"
+             (magent-agent-result-content-string (cadr completion))))))
 
-(ert-deftest magent-test-command-submit-step-supports-sequential-workflows ()
-  "Test advanced handlers can submit a following step from completion."
+(ert-deftest magent-test-command-agent-steps-support-sequential-workflows ()
+  "Test a Workflow resumes into its following agent Step."
   (require 'magent-command)
   (let* ((magent-command--registry nil)
          (magent-command--active-invocations (make-hash-table :test #'eq))
          (runtime-session (magent-runtime-session-create :id "session-1"))
-         invocation
          submitted)
     (magent-command-register
      "workflow"
-     :handler (lambda (value)
-                (setq invocation value)
-                (magent-command-defer value)))
-    (magent-command-invoke "workflow" runtime-session)
-    (cl-letf (((symbol-function 'magent-runtime-submit)
-               (lambda (_session prompt &rest args)
-                 (push prompt submitted)
-                 (when (equal prompt "first")
-                   (funcall (plist-get args :on-complete)
-                            'completed
-                            (magent-agent-result-completed "first result")))
-                 prompt)))
-      (magent-command-submit-step
-       invocation "first"
-       (lambda (status _result)
-         (should (eq status 'completed))
-         (magent-command-submit-step
-          invocation "second"
-          (lambda (_next-status _next-result)
-            (magent-command-complete invocation "done"))))))
+     :session-policy 'current
+     :workflow
+     (iter-lambda (_invocation)
+       (magent-command-agent "First" "first")
+       (magent-command-answer "Second" "second")))
+    (magent-test--without-command-step-ledger
+      (cl-letf (((symbol-function 'magent-runtime-submit)
+                 (lambda (_session prompt &rest args)
+                   (push prompt submitted)
+                   (when (equal prompt "first")
+                     (funcall (plist-get args :on-complete)
+                              'completed
+                              (magent-agent-result-completed "first result")))
+                   prompt)))
+        (magent-command-invoke "workflow" runtime-session)))
     (should (equal (nreverse submitted) '("first" "second")))
-    (should (eq (magent-command-invocation-status invocation) 'active))))
+    (should (gethash runtime-session magent-command--active-invocations))))
 
-(ert-deftest magent-test-command-submit-merges-explicit-request-context ()
-  "Test advanced submissions name and merge request-only runtime hints."
+(ert-deftest magent-test-command-agent-step-merges-explicit-request-context ()
+  "Test agent Steps merge request-only runtime hints."
   (require 'magent-command)
   (let* ((runtime-session (magent-runtime-session-create :id "session-1"))
          (invocation
@@ -3881,42 +4083,41 @@
                (lambda (_session _prompt &rest args)
                  (setq submitted-context (plist-get args :context))
                  "submission-1")))
-      (magent-command-submit
-       invocation "step"
-       :request-context '(:features (workflow) :workflow-step review)))
+      (magent-command--start-agent-step
+       invocation
+       (magent-command--make-agent-step
+        "Step" "step"
+        :request-context '(:features (workflow) :workflow-step review))
+       #'ignore))
     (should (equal (plist-get submitted-context :features) '(workflow)))
     (should (eq (plist-get submitted-context :workflow-step) 'review))
     (should (equal (plist-get submitted-context :file-path)
                    "/tmp/frontend.el"))
     (should-error
-     (magent-command-submit
-      invocation "step" :context '(:features (ambiguous))))))
+     (magent-command--make-agent-step
+      "Step" "step" :context '(:features (ambiguous))))))
 
-(ert-deftest magent-test-command-submit-step-fails-closed-on-callback-error ()
-  "Test a broken advanced step callback cannot strand its invocation."
+(ert-deftest magent-test-command-workflow-fails-closed-after-callback-error ()
+  "Test Workflow code that fails after a callback cannot strand invocation."
   (require 'magent-command)
   (let* ((magent-command--registry nil)
          (magent-command--active-invocations (make-hash-table :test #'eq))
          (runtime-session (magent-runtime-session-create :id "session-1"))
-         invocation
          completion)
     (magent-command-register
      "workflow"
-     :handler (lambda (value)
-                (setq invocation value)
-                (magent-command-defer value)))
-    (magent-command-invoke
-     "workflow" runtime-session
-     :on-complete (lambda (status result)
-                    (setq completion (list status result))))
-    (cl-letf (((symbol-function 'magent-runtime-submit)
-               (lambda (_session _prompt &rest args)
-                 (funcall (plist-get args :on-complete)
-                          'completed (magent-agent-result-completed "done"))
-                 "submission-1")))
-      (magent-command-submit-step
-       invocation "step" (lambda (&rest _args) (error "broken step"))))
-    (should (eq (magent-command-invocation-status invocation) 'failed))
+     :session-policy 'current
+     :workflow
+     (iter-lambda (_invocation)
+       (magent-command-callback
+           "Callback"
+           (lambda (done) (funcall done 'completed "done") nil))
+       (error "broken step")))
+    (magent-test--without-command-step-ledger
+      (magent-command-invoke
+       "workflow" runtime-session
+       :on-complete (lambda (status result)
+                      (setq completion (list status result)))))
     (should (eq (car completion) 'failed))
     (should (string-match-p
              "broken step"
@@ -3933,176 +4134,158 @@
          (current (magent-command-invocation-create
                    :id "new" :spec spec :runtime-session runtime-session)))
     (puthash runtime-session current magent-command--active-invocations)
-    (should (magent-command-complete stale "late"))
+    (should (magent-command--finish-completed stale nil))
     (should (eq (gethash runtime-session magent-command--active-invocations)
                 current))))
 
-(ert-deftest magent-test-command-handler-must-complete-or-defer ()
-  "Test a forgotten async lifecycle fails closed."
+(ert-deftest magent-test-command-workflow-nil-return-completes ()
+  "Test an empty Workflow completes without an assistant response."
   (require 'magent-command)
   (let ((magent-command--registry nil)
         (magent-command--active-invocations (make-hash-table :test #'eq))
-        (runtime-session (magent-runtime-session-create :id "session-1"))
+        (runtime-session
+         (magent-runtime-session-create
+          :id "session-1" :scope 'global
+          :magent-session (magent-session-create)))
         completion)
-    (magent-command-register "broken" :handler #'ignore)
+    (magent-command-register "broken" :session-policy 'current :workflow #'magent-test--empty-command-workflow)
     (magent-command-invoke
      "broken" runtime-session
      :on-complete (lambda (status result)
                     (setq completion (list status result))))
-    (should (eq (car completion) 'failed))
-    (should (string-match-p
-             "without completing or deferring"
+    (should (eq (car completion) 'completed))
+    (should (string-empty-p
              (magent-agent-result-content-string (cadr completion))))))
 
-(ert-deftest magent-test-command-handler-error-cancels-owned-submission ()
-  "Test a handler error cleans up submitted work before reporting failure."
+(ert-deftest magent-test-command-callback-start-error-fails-invocation ()
+  "Test a callback starter error fails and releases its invocation."
   (require 'magent-command)
   (let ((magent-command--registry nil)
         (magent-command--active-invocations (make-hash-table :test #'eq))
         (runtime-session (magent-runtime-session-create :id "session-1"))
-        invocation
-        submission-callback
-        runtime-cancelled
         completion
         (completion-count 0)
-        (cleanup-count 0)
         order)
     (magent-command-register
-     "broken-submit"
-     :handler
-     (lambda (value)
-       (setq invocation value)
-       (magent-command-set-cancel-function
-        value
-        (lambda ()
-          (cl-incf cleanup-count)
-          (push 'custom-cleanup order)))
-       (magent-command-defer value)
-       (magent-command-submit
-       value "queued work"
-       :on-complete
-        (lambda (status result)
-          (magent-command-finish value status result)))
-       (error "handler exploded")))
-    (cl-letf (((symbol-function 'magent-runtime-submit)
-               (lambda (_session _prompt &rest args)
-                 (setq submission-callback (plist-get args :on-complete))
-                 "submission-1"))
-              ((symbol-function 'magent-runtime-cancel)
-               (lambda (session)
-                 (setq runtime-cancelled session)
-                 (push 'runtime-cancel order)
-                 (funcall submission-callback 'cancelled "runtime cancelled"))))
+     "broken-callback"
+     :session-policy 'current
+     :workflow
+     (iter-lambda (_invocation)
+       (magent-command-callback
+           "Broken" (lambda (_done) (error "starter exploded")))))
+    (magent-test--without-command-step-ledger
       (magent-command-invoke
-       "broken-submit" runtime-session
+       "broken-callback" runtime-session
        :on-complete
        (lambda (status result)
          (cl-incf completion-count)
          (setq completion (list status result))
          (push 'completion order))))
-    (should (= cleanup-count 1))
-    (should (eq runtime-cancelled runtime-session))
     (should (= completion-count 1))
     (should (eq (car completion) 'failed))
     (should (string-match-p
-             "handler exploded"
+             "starter exploded"
              (magent-agent-result-content-string (cadr completion))))
-    (should (eq (magent-command-invocation-status invocation) 'failed))
-    (should-not (magent-command-invocation-submission-ids invocation))
     (should-not (gethash runtime-session
                          magent-command--active-invocations))
-    (should (equal (nreverse order)
-                   '(custom-cleanup runtime-cancel completion)))))
+    (should (equal order '(completion)))))
 
-(ert-deftest magent-test-command-validates-project-and-tool-requirements ()
-  "Test command constraints fail before trusted handler execution."
+(ert-deftest magent-test-command-validates-elisp-and-step-tool-requirements ()
+  "Test Elisp requirements and Step tools fail before model work."
   (require 'magent-command)
   (let ((magent-command--registry nil)
         (magent-command--active-invocations (make-hash-table :test #'eq))
-        (global-session
-         (magent-runtime-session-create :id "global" :scope 'global))
+        (global-session (magent-runtime-session-create :id "global" :scope 'global))
         (project-session
          (magent-runtime-session-create :id "project" :scope "/tmp/project"))
-        handler-ran
+        workflow-ran
         global-completion
         tool-completion)
     (magent-command-register
-     "project-only"
-     :handler (lambda (_invocation) (setq handler-ran t))
-     :requires-project t)
+     "missing-feature"
+     :session-policy 'current
+     :workflow (iter-lambda (_invocation) (setq workflow-ran t))
+     :requires 'magent-test-feature-that-does-not-exist)
     (magent-command-invoke
-     "project-only" global-session
+     "missing-feature" global-session
      :on-complete (lambda (status result)
                     (setq global-completion (list status result))))
-    (should-not handler-ran)
+    (should-not workflow-ran)
     (should (eq (car global-completion) 'failed))
     (should (string-match-p
-             "requires a project workspace"
+             "requires unavailable feature"
              (magent-agent-result-content-string (cadr global-completion))))
     (magent-command-register
      "needs-tools"
-     :handler (lambda (_invocation) (setq handler-ran t))
-     :required-tools '(read_file bash))
-    (cl-letf (((symbol-function
-                'magent-runtime-session-available-tool-names)
-               (lambda (_session &optional _agent) '(read_file))))
-      (magent-command-invoke
-       "needs-tools" project-session
-       :on-complete (lambda (status result)
-                      (setq tool-completion (list status result)))))
-    (should-not handler-ran)
+     :session-policy 'current
+     :workflow
+     (iter-lambda (_invocation)
+       (magent-command-agent
+           "Needs tools" "Use tools"
+         :required-tools '(read_file bash))))
+    (magent-test--without-command-step-ledger
+      (cl-letf (((symbol-function
+                  'magent-runtime-session-available-tool-names)
+                 (lambda (_session &optional _agent) '(read_file))))
+        (magent-command-invoke
+         "needs-tools" project-session
+         :on-complete (lambda (status result)
+                        (setq tool-completion (list status result))))))
     (should (eq (car tool-completion) 'failed))
     (should (string-match-p
              "unavailable tools: bash"
              (magent-agent-result-content-string (cadr tool-completion))))))
 
-(ert-deftest magent-test-command-cancel-cleans-up-once ()
-  "Test session cancellation invokes command and runtime cleanup."
+(ert-deftest magent-test-command-cancel-cleans-up-current-step-once ()
+  "Test session cancellation invokes current Step cleanup once."
   (require 'magent-command)
   (let ((magent-command--registry nil)
         (magent-command--active-invocations (make-hash-table :test #'eq))
         (runtime-session (magent-runtime-session-create :id "session-1"))
-        invocation (cleanup 0) runtime-cancel completion)
+        invocation (cleanup 0) completion)
     (magent-command-register
      "wait"
-     :handler
-     (lambda (value)
+     :session-policy 'current
+     :workflow
+     (iter-lambda (value)
        (setq invocation value)
-       (magent-command-set-cancel-function
-        value (lambda () (cl-incf cleanup)))
-       (magent-command-defer value)))
-    (cl-letf (((symbol-function 'magent-runtime-cancel)
-               (lambda (session) (setq runtime-cancel session))))
+       (magent-command-callback
+           "Wait" (lambda (_done) (lambda () (cl-incf cleanup))))))
+    (magent-test--without-command-step-ledger
       (magent-command-invoke
        "wait" runtime-session
        :on-complete (lambda (status _result) (setq completion status)))
       (should (magent-command-cancel-session runtime-session))
       (should-not (magent-command-cancel-session runtime-session)))
     (should (= cleanup 1))
-    (should (eq runtime-cancel runtime-session))
     (should (eq completion 'cancelled))
     (should (eq (magent-command-invocation-status invocation) 'cancelled))))
 
-(ert-deftest magent-test-command-cancel-survives-reentrant-runtime-completion ()
-  "Test synchronous runtime completion still reports command cancellation."
+(ert-deftest magent-test-command-cancel-survives-reentrant-step-completion ()
+  "Test synchronous Step completion still reports command cancellation."
   (require 'magent-command)
   (let ((magent-command--registry nil)
         (magent-command--active-invocations (make-hash-table :test #'eq))
         (runtime-session (magent-runtime-session-create :id "session-1"))
-        invocation
-        (runtime-cancels 0))
+        invocation done
+        (cleanups 0))
     (magent-command-register
      "wait"
-     :handler (lambda (value)
-                (setq invocation value)
-                (magent-command-defer value)))
-    (magent-command-invoke "wait" runtime-session)
-    (cl-letf (((symbol-function 'magent-runtime-cancel)
-               (lambda (_session)
-                 (cl-incf runtime-cancels)
-                 (magent-command-finish invocation 'cancelled "runtime"))))
+     :session-policy 'current
+     :workflow
+     (iter-lambda (value)
+       (setq invocation value)
+       (magent-command-callback
+           "Wait"
+           (lambda (callback)
+             (setq done callback)
+             (lambda ()
+               (cl-incf cleanups)
+               (funcall done 'cancelled "reentrant"))))))
+    (magent-test--without-command-step-ledger
+      (magent-command-invoke "wait" runtime-session)
       (should (magent-command-cancel-session runtime-session)))
-    (should (= runtime-cancels 1))
+    (should (= cleanups 1))
     (should (eq (magent-command-invocation-status invocation) 'cancelled))))
 
 (ert-deftest magent-test-skill-reload-restores-builtin-skill ()
@@ -4692,15 +4875,26 @@
       (delete-directory tmpdir t))))
 
 (ert-deftest magent-test-bundled-summarize-command-keeps-constraints ()
-  "Test /summarize remains project-bound and tool-backed."
+  "Test /summarize is global-capable and keeps Step-local tools."
   (require 'magent-command)
   (let ((magent-command--registry nil))
     (magent-test--register-builtin-commands-only)
     (let ((command (magent-command-get "summarize")))
       (should command)
-      (should (magent-command-spec-requires-project command))
-      (should (memq 'write_repo_summary
-                    (magent-command-spec-required-tools command))))))
+      (should (eq (magent-command-spec-session-policy command) 'current))
+      (let* ((invocation
+              (magent-command-invocation-create
+               :id "summarize" :spec command :argument ""))
+             (iterator
+              (funcall (magent-command-spec-workflow command) invocation))
+             (step (iter-next iterator)))
+        (unwind-protect
+            (progn
+              (should (eq (magent-command-step-type step) 'answer))
+              (should (memq
+                       'write_repo_summary
+                       (magent-command--step-option step :required-tools))))
+          (iter-close iterator))))))
 
 (ert-deftest magent-test-skills-load-all-includes-emacs-runtime-inspection ()
   "Test builtin skill loading includes the Emacs runtime inspection workflow."
@@ -10322,11 +10516,11 @@
                     :id "session-b" :scope "/tmp/project-b")))
     (let ((command-a
            (magent-command-register
-            "project-command" :handler #'ignore
+            "project-command" :session-policy 'current :workflow #'magent-test--empty-command-workflow
             :source-layer 'project :source-scope "/tmp/project-a"))
           (command-b
            (magent-command-register
-            "project-command" :handler #'ignore
+            "project-command" :session-policy 'current :workflow #'magent-test--empty-command-workflow
             :source-layer 'project :source-scope "/tmp/project-b")))
       (should (eq (plist-get (magent-acp--slash-command
                               "/project-command" project-a)
@@ -10343,7 +10537,7 @@
   (let ((magent-command--registry nil))
     (let ((magent-command--allow-core-registration t))
       (magent-command-register
-       "clear" :handler #'ignore
+       "clear" :session-policy 'current :workflow #'magent-test--empty-command-workflow
        :source-layer 'core))
     (magent-test--register-builtin-commands-only)
     (let ((compact (magent-acp--slash-command
@@ -10415,12 +10609,12 @@
            :id "session-b" :scope "/tmp/project-b"))
          notifications)
     (magent-command-register
-     "global-command" :handler #'ignore)
+     "global-command" :session-policy 'current :workflow #'magent-test--empty-command-workflow)
     (magent-command-register
-     "project-a-command" :handler #'ignore
+     "project-a-command" :session-policy 'current :workflow #'magent-test--empty-command-workflow
      :source-layer 'project :source-scope "/tmp/project-a")
     (magent-command-register
-     "project-b-command" :handler #'ignore
+     "project-b-command" :session-policy 'current :workflow #'magent-test--empty-command-workflow
      :source-layer 'project :source-scope "/tmp/project-b")
     (puthash "session-a" "/tmp/project-a" bindings)
     (puthash "session-b" "/tmp/project-b" bindings)
@@ -10632,7 +10826,8 @@
                  (setq submitted (list session prompt args))
                  (setf (magent-runtime-session-pending-skills session) nil)
                  (funcall (plist-get args :on-complete)
-                          'completed (magent-agent-result-completed "ok")))))
+                          'completed (magent-agent-result-completed "ok"))
+                 "submission-1")))
       (magent-acp--handle-request
        '((:notification-handlers . nil)
          (:request-handlers . nil))
@@ -10650,8 +10845,8 @@
     (should-not (magent-runtime-session-pending-skills runtime-session))
     (should (equal (map-elt response 'stopReason) "end_turn"))))
 
-(ert-deftest magent-test-acp-command-turn-preserves-resource-context ()
-  "Test a structured command turn retains ACP resources and request context."
+(ert-deftest magent-test-acp-command-answer-preserves-resource-context ()
+  "Test a terminal Answer retains ACP resources and request context."
   (require 'magent-acp)
   (let ((magent-command--registry nil)
         (magent-command--active-invocations (make-hash-table :test #'eq))
@@ -10663,9 +10858,12 @@
         submitted response failure)
     (magent-command-register
      "review" :description "Review"
-     :turn
-     (magent-command-turn-spec-create
-      :prompt "Review the attached context.")
+     :session-policy 'current
+     :workflow
+     (iter-lambda (_invocation)
+       (magent-command-answer
+           "Review" "Review the attached context."
+         :append-argument-p t))
      :source-layer 'package)
     (cl-letf (((symbol-function 'magent-acp--runtime-session-by-id)
                (lambda (session-id)
@@ -10712,8 +10910,8 @@
       (should (equal (map-elt resource 'text) "resource body")))
     (should (equal (map-elt response 'stopReason) "end_turn"))))
 
-(ert-deftest magent-test-acp-command-turn-prepends-buffer-snapshots ()
-  "Test turn buffers precede frontend resources and remain immutable snapshots."
+(ert-deftest magent-test-acp-command-answer-prepends-buffer-snapshots ()
+  "Test Answer buffers precede frontend resources and stay immutable."
   (require 'magent-acp)
   (let ((magent-command--registry nil)
         (magent-command--active-invocations (make-hash-table :test #'eq))
@@ -10728,10 +10926,12 @@
       (let ((context-buffer (current-buffer)))
         (magent-command-register
          "inspect" :description "Inspect"
-         :turn
-         (magent-command-turn-spec-create
-          :prompt "Inspect resources."
-          :buffers (list context-buffer)))
+         :session-policy 'current
+         :workflow
+         (iter-lambda (_invocation)
+           (magent-command-answer
+               "Inspect" "Inspect resources."
+             :buffers (list context-buffer))))
         (cl-letf (((symbol-function 'magent-acp--runtime-session-by-id)
                    (lambda (_session-id) runtime-session))
                   ((symbol-function 'magent-runtime-submit)
@@ -10798,7 +10998,8 @@
                      (setq submitted (list session prompt args))
                      (setf (magent-runtime-session-pending-skills session) nil)
                      (funcall (plist-get args :on-complete)
-                              'completed (magent-agent-result-completed "ok"))))
+                              'completed (magent-agent-result-completed "ok"))
+                     "submission-1"))
                   ((symbol-function
                     'magent-runtime-session-available-tool-names)
                    (lambda (&rest _)
@@ -10859,9 +11060,13 @@
 (ert-deftest magent-test-acp-session-prompt-compacts-through-runtime ()
   "Test /compact invokes runtime compaction and forwards its completion."
   (require 'magent-acp)
+  (require 'magent-command-controls)
   (let ((magent-command--registry nil)
         (magent-command--active-invocations (make-hash-table :test #'eq))
-        (runtime-session (magent-runtime-session-create :id "session-1"))
+        (runtime-session
+         (magent-runtime-session-create
+          :id "session-1" :scope 'global
+          :magent-session (magent-session-create)))
         compact-args response failure)
     (magent-command-controls-register)
     (cl-letf (((symbol-function 'magent-acp--runtime-session-by-id)
@@ -11605,7 +11810,7 @@
   (require 'magent-agent-shell)
   (let ((magent-command--registry nil)
         sent)
-    (magent-command-register "demo" :handler #'ignore)
+    (magent-command-register "demo" :session-policy 'current :workflow #'magent-test--empty-command-workflow)
     (cl-letf (((symbol-function 'magent--ensure-initialized) #'ignore)
               ((symbol-function 'magent-agent-shell--prepare-skill-context)
                #'ignore)
@@ -11628,10 +11833,10 @@
           :id "session-a" :scope "/tmp/project-a"))
         offered sent)
     (magent-command-register
-     "project-a-command" :handler #'ignore
+     "project-a-command" :session-policy 'current :workflow #'magent-test--empty-command-workflow
      :source-layer 'project :source-scope "/tmp/project-a")
     (magent-command-register
-     "project-b-command" :handler #'ignore
+     "project-b-command" :session-policy 'current :workflow #'magent-test--empty-command-workflow
      :source-layer 'project :source-scope "/tmp/project-b")
     (cl-letf (((symbol-function 'magent--ensure-initialized) #'ignore)
               ((symbol-function 'magent-runtime-ensure-initialized) #'ignore)
@@ -13274,8 +13479,7 @@
                               (setq called t)
                               '((ok . t)))))
          (state (magent-doctor-state-create :deadline nil)))
-    (cl-letf (((symbol-function 'magent-command-progress) #'ignore)
-              ((symbol-function 'magent-command-record-tool) #'ignore))
+    (cl-letf (((symbol-function 'magent-command-progress) #'ignore))
       (let ((result (magent-doctor--run-probe probe nil state)))
         (should called)
         (should (equal (cdr (assq 'status result)) "completed"))))))


### PR DESCRIPTION
## Summary

- replace the separate command turn and handler lifecycles with one generator-backed Elisp Workflow model
- add managed agent, terminal Answer, argv process, and callback Steps with cancellation, typed failures, and ledger activity
- migrate built-in commands, isolated Doctor and Memory commands, and skill adapters to the Workflow API
- replace command project requirements with invocation-time Elisp feature requirements and step-local tool requirements
- make Harbor benchmark proxy settings cover both task environment image builds and trial runtime
- update architecture, bilingual command documentation, live smoke coverage, and unit tests

## Breaking changes

- remove command registration fields :turn, :handler, and :requires-project
- remove the public handler lifecycle helpers without compatibility wrappers
- require explicit :workflow and :session-policy on every command registration

## Benchmark conclusion

- a proxy configured for a benchmark job must be applied in both phases: task environment Docker builds through build args, and trial runtime through container environment variables
- loopback proxy rewriting requires host.docker.internal:host-gateway during both build and runtime; the host proxy must still listen on an interface reachable from Docker
- proxy values remain outside the benchmark fingerprint and stay in the private generated job with 0600 permissions

## Testing

- make compile
- make test-unit (547 tests)
- make test-live-smoke against an isolated Emacs daemon
- make benchmark-test (2 Emacs adapter tests and 36 Python tests)