### PR TITLE
perf: reduce redundant agent output

### DIFF
--- a/lisp/magent-config.el
+++ b/lisp/magent-config.el
@@ -353,9 +353,10 @@ failure status headers are always retained outside this limit."
   :group 'magent)
 
 (defcustom magent-tool-result-model-preview-length 10000
-  "Body prefix characters retained when a tool result is truncated.
-The final record also includes a compact truncation notice with the original
-body length.  Structured failure status headers are not part of this budget."
+  "Body characters retained when a tool result is truncated.
+Successful results keep a prefix.  Failed results keep a short prefix and a
+longer diagnostic suffix.  The final record also includes a compact truncation
+notice; structured failure status headers are not part of this budget."
   :type 'integer
   :group 'magent)
 

--- a/lisp/magent-ledger.el
+++ b/lisp/magent-ledger.el
@@ -1115,6 +1115,40 @@ number of lifecycle objects changed."
   (magent-thread--legacy-tool-value
    (magent-thread--alist-to-keyword-plist input)))
 
+(defun magent-thread--truncate-model-visible-tool-result-body
+    (body failed-p max-length)
+  "Return BODY truncated to MAX-LENGTH characters of retained content.
+When FAILED-P is non-nil, preserve a short prefix and a longer diagnostic
+suffix.  Successful output keeps its prefix as before."
+  (let* ((preview-length
+          (min (max 0
+                    (or magent-tool-result-model-preview-length max-length))
+               max-length
+               (length body)))
+         (omitted (- (length body) preview-length)))
+    (if failed-p
+        (let* ((head-length
+                (if (> preview-length 1)
+                    (max 1 (/ preview-length 4))
+                  preview-length))
+               (tail-length (- preview-length head-length))
+               (head (substring body 0 head-length))
+               (tail (and (> tail-length 0)
+                          (substring body (- tail-length)))))
+          (if tail
+              (format
+               "%s\n\n[Tool result truncated: original %d characters; kept first %d and last %d; omitted %d.]\n\n%s"
+               head (length body) head-length tail-length omitted tail)
+            (format
+             "%s\n\n[Tool result truncated: original %d characters; kept first %d; omitted %d.]"
+             head (length body) head-length omitted)))
+      (format
+       "%s\n\n[Tool result truncated: original %d characters, kept first %d, omitted %d. Narrow the command, read a smaller range, or refine the query for more detail.]"
+       (substring body 0 preview-length)
+       (length body)
+       preview-length
+       omitted))))
+
 (defun magent-thread--model-visible-tool-result (result)
   "Return RESULT bounded for model-visible tool history."
   (let* ((structured-p (magent-tool-result-p result))
@@ -1142,18 +1176,8 @@ number of lifecycle objects changed."
           (if (and (numberp max-length)
                    (> max-length 0)
                    (> (length body) max-length))
-              (let* ((preview-length
-                      (min (max 0
-                                (or magent-tool-result-model-preview-length
-                                    max-length))
-                           max-length
-                           (length body)))
-                     (truncated (- (length body) preview-length)))
-                (format "%s\n\n[Tool result truncated: original %d characters, kept first %d, omitted %d. Narrow the command, read a smaller range, or refine the query for more detail.]"
-                        (substring body 0 preview-length)
-                        (length body)
-                        preview-length
-                        truncated))
+              (magent-thread--truncate-model-visible-tool-result-body
+               body failed-p max-length)
             (if failed-p body safe-result))))
     (if failed-p
         (concat header bounded-body)

--- a/lisp/magent-tools.el
+++ b/lisp/magent-tools.el
@@ -70,6 +70,9 @@ whole so a subsequent line-based request always makes progress.")
 (defconst magent-tools--agent-wait-fallback-timeout 300
   "Fallback wait timeout in seconds when the host request timeout is disabled.")
 
+(defconst magent-tools--bash-failure-max-lines 300
+  "Maximum Bash failure output lines retained before model-side bounding.")
+
 (defun magent-tools--agent-wait-timeout (&optional timeout)
   "Return explicit child-agent TIMEOUT or the host's finite default."
   (cond
@@ -573,16 +576,38 @@ Evaluation runs in the user's context buffer when known
                 (format "Error evaluating sexp: %s"
                         (error-message-string err)))))))
 
+(defun magent-tools--bound-bash-failure-output (message)
+  "Return MESSAGE with long Bash failure output compacted by line count.
+Keep the first line for failure context and the final diagnostic lines."
+  (let* ((trimmed (string-trim-right message))
+         (lines (split-string trimmed "\n" nil))
+         (line-count (length lines))
+         (tail-count (1- magent-tools--bash-failure-max-lines)))
+    (if (<= line-count magent-tools--bash-failure-max-lines)
+        trimmed
+      (let ((omitted (- line-count 1 tail-count)))
+        (string-join
+         (append
+          (list
+           (car lines)
+           (format
+            "[Bash failure output truncated: omitted %d lines; kept first 1 and final %d.]"
+            omitted tail-count))
+          (last lines tail-count))
+         "\n")))))
+
 (defun magent-tools--bash-failure (message &optional exit-code metadata)
   "Return a structured bash failure for MESSAGE.
 EXIT-CODE is nil when no process exit status exists.  METADATA is optional."
-  (magent-tool-result-create
-   :status 'failed
-   :success nil
-   :exit-code exit-code
-   :error message
-   :output message
-   :metadata metadata))
+  (let ((bounded-message
+         (magent-tools--bound-bash-failure-output message)))
+    (magent-tool-result-create
+     :status 'failed
+     :success nil
+     :exit-code exit-code
+     :error bounded-message
+     :output bounded-message
+     :metadata metadata)))
 
 (defun magent-tools--bash-executable ()
   "Return the configured Bash executable, or nil when unavailable."

--- a/prompts/system.org
+++ b/prompts/system.org
@@ -8,7 +8,7 @@ Lead with the outcome or direct answer. Match detail to the task: simple questio
 
 Use natural prose and the minimum formatting that improves clarity. Use short lists when several findings, mappings, or steps would otherwise be difficult to scan. Avoid unnecessary preambles, repeated summaries, and generic conclusions.
 
-For longer work, provide brief progress updates at meaningful boundaries so the user knows what is being inspected, changed, or verified. After making changes, report the important result, relevant verification, and any remaining risk or blocker. Do not narrate every routine tool call.
+For longer work, keep progress updates to one short sentence at meaningful phase boundaries or when a blocker or risk changes. Between tool calls, do not restate plans, commands, or results when the next action is clear; call the next tool directly. Stop exploring once the available evidence is sufficient. After making changes, report the important result, relevant verification, and any remaining risk or blocker.
 
 Treat the user as a capable collaborator. Push back when evidence or constraints warrant it, but do so directly and constructively. If you make a mistake, acknowledge the concrete error, correct it, and continue without excessive apology or self-criticism.
 

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -5726,6 +5726,48 @@
     (should (string-match-p "failure-output"
                             (magent-tool-result-output-string result)))))
 
+(ert-deftest magent-test-tools-bash-bounds-failure-output-by-lines ()
+  "Test Bash keeps failure context and the final diagnostic lines."
+  (require 'magent-tools)
+  (skip-unless (executable-find "bash"))
+  (let* ((default-directory temporary-file-directory)
+         (magent-bash-program "bash")
+         (result
+          (magent-test--run-bash
+           "for ((i=1; i<=305; i++)); do printf 'line-%03d\\n' \"$i\"; done; exit 7"))
+         (output (magent-tool-result-output-string result)))
+    (should-not (magent-tool-result-success-p result))
+    (should (= (magent-tool-result-exit-code result) 7))
+    (should (string-prefix-p "line-001\n" output))
+    (should (string-match-p
+             (regexp-quote
+              "[Bash failure output truncated: omitted 5 lines; kept first 1 and final 299.]")
+             output))
+    (should-not (string-match-p "^line-002$" output))
+    (should-not (string-match-p "^line-006$" output))
+    (should (string-match-p "^line-007$" output))
+    (should (string-suffix-p "line-305" output))
+    (should (= 300
+               (length
+                (seq-filter
+                 (lambda (line) (string-prefix-p "line-" line))
+                 (split-string output "\n" t)))))))
+
+(ert-deftest magent-test-tools-bash-keeps-long-success-output ()
+  "Test the Bash execution layer does not compact successful output."
+  (require 'magent-tools)
+  (skip-unless (executable-find "bash"))
+  (let* ((default-directory temporary-file-directory)
+         (magent-bash-program "bash")
+         (result
+          (magent-test--run-bash
+           "for ((i=1; i<=305; i++)); do printf 'line-%03d\\n' \"$i\"; done"))
+         (output (magent-tool-result-output-string result)))
+    (should (magent-tool-result-success-p result))
+    (should (string-prefix-p "line-001\n" output))
+    (should (string-suffix-p "line-305" output))
+    (should-not (string-match-p "Bash failure output truncated" output))))
+
 (ert-deftest magent-test-tools-bash-enforces-pipefail-without-errexit ()
   "Test Bash exposes pipeline failures without forcing errexit."
   (require 'magent-tools)
@@ -5808,7 +5850,17 @@
     (let ((result (magent-test--run-bash "sleep 1" 0.02)))
       (should-not (magent-tool-result-success-p result))
       (should-not (magent-tool-result-exit-code result))
-      (should (plist-get (magent-tool-result-metadata result) :timeout)))))
+      (should (plist-get (magent-tool-result-metadata result) :timeout)))
+    (let* ((result
+            (magent-test--run-bash
+             "for ((i=1; i<=305; i++)); do printf 'line-%03d\\n' \"$i\"; done; sleep 1"
+             0.05))
+           (output (magent-tool-result-output-string result)))
+      (should-not (magent-tool-result-success-p result))
+      (should (plist-get (magent-tool-result-metadata result) :timeout))
+      (should (string-prefix-p "Command timed out. Partial output:\n" output))
+      (should (string-match-p "Bash failure output truncated" output))
+      (should (string-suffix-p "line-305" output)))))
 
 (ert-deftest magent-test-tools-bash-ignores-host-bash-env ()
   "Test host BASH_ENV cannot disable the tool's pipefail execution."
@@ -12736,28 +12788,31 @@
       (should (equal (plist-get prompt-tool :result) result)))))
 
 (ert-deftest magent-test-session-keeps-failure-header-outside-body-budget ()
-  "Test failure status remains intact with a very small body preview."
+  "Test failure status and diagnostic tail survive a small body preview."
   (require 'magent-session)
   (let* ((magent-tool-result-model-max-length 8)
-         (magent-tool-result-model-preview-length 4)
+         (magent-tool-result-model-preview-length 8)
          (thread (magent-thread-create :id "thread-truncated-failure"))
          (turn (magent-thread-create-turn thread "Run failing tool"))
          (result (magent-tool-result-create
                   :status 'failed
                   :success nil
                   :exit-code 23
-                  :output (make-string 20 ?x)))
+                  :output "ab0123456789uvwxyz"))
          (item (magent-thread-record-tool-result
                 thread (magent-thread-turn-id turn) "call-23" "bash" nil
                 result))
          (visible (magent-thread-item-output item)))
     (should (string-prefix-p
-             "[Tool result: status=failed; exit-code=23]\nxxxx\n\n"
+             "[Tool result: status=failed; exit-code=23]\nab\n\n"
              visible))
     (should (string-match-p
-             "original 20 characters, kept first 4, omitted 16"
+             "original 18 characters; kept first 2 and last 6; omitted 10"
              visible))
-    (should-not (string-match-p "xxxxx" visible))))
+    (should (string-suffix-p "uvwxyz" visible))
+    (should-not (string-match-p "0123456789" visible))
+    (should (equal "ab0123456789uvwxyz"
+                   (magent-tool-result-output result)))))
 
 (ert-deftest magent-test-thread-ledger-turn-and-item-state-machine ()
   "Test explicit thread/turn/item state transitions."


### PR DESCRIPTION
## Summary

- Cap Bash failure output at 300 lines while preserving initial context and the diagnostic tail.
- Preserve both head and tail when failed tool results exceed the model-visible character budget, while retaining existing success behavior.
- Tighten the system prompt against repeated progress narration and add regression coverage for failure, timeout, and success paths.
- In the matched 5-case smoke, Magent kept 3/5 pass@1 while mean output fell from 24.4K to 19.2K and mean cost fell from $0.0311 to $0.0214; the full paid rerun was skipped because the 10K / $0.013 gate was not met.

## Validation

- `make compile`
- `make test-unit` — 549/549
- `make test` — 549/549 plus deterministic live smoke
- 5-case Magent/OpenCode benchmark smoke — 10/10 trials completed without exceptions