### PR TITLE
feat(skills): expose instruction skills as ACP slash commands

### DIFF
--- a/README.org
+++ b/README.org
@@ -29,7 +29,7 @@ define the same thing:
 |------------------------+----------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------|
 | Primary role           | An explicit Emacs or slash-command action                                        | Reusable instructions or a model-invokable operation                                               |
 | Definition             | Trusted Elisp registered with ~magent-command-register~                            | A ~SKILL.md~ file; a tool skill may also have a companion Elisp implementation                       |
-| Activation             | The user enters ~/name~ or runs ~M-x magent-agent-shell-run-command~                 | An instruction skill is selected or activated by a capability; a tool skill is called by the model |
+| Activation             | The user enters ~/name~ or runs ~M-x magent-agent-shell-run-command~                 | The user enters ~/$name~, selects it for the next turn, or a capability activates it; a tool skill is called by the model |
 | Owns                   | Arguments, requirements, session policy, Steps, and multi-step control            | Model context and workflow guidance, or one named operation through ~skill_invoke~                   |
 | Project trust boundary | Command Workflows are trusted installed Elisp                                    | Project instruction Markdown is data-only; companion Elisp runs only for explicitly trusted roots  |
 
@@ -39,10 +39,12 @@ agent can apply while handling requests.  Use both when an explicit command
 should activate reusable expertise: an agent Step can select skills with
 ~:skills~ and declare its tool preflight with ~:required-tools~.
 
-An instruction skill with ~default-prompt~ is projected into the command
-registry only as a compatibility adapter.  Invoking that adapter activates the
-original skill; it does not turn Markdown into a Command Workflow or give it
-trusted Elisp execution authority.
+ACP advertises every visible instruction skill as ~/$name~ in agent-shell,
+without requiring ~default-prompt~. An instruction skill with ~default-prompt~
+is additionally projected into the command registry as a legacy ~/name~
+compatibility adapter. Invoking either surface activates the original skill; it
+does not turn Markdown into a Command Workflow or give it trusted Elisp
+execution authority.
 
 ~magent-command~ therefore makes slash commands first-class, explicit user
 actions.  Your init file or another trusted Elisp package can register a command
@@ -138,7 +140,7 @@ them. Every registration requires one ~:workflow~ and an explicit
 ~:session-policy~. A ~user~ command can override an installed ~package~ or
 ~builtin~ command with the same name. Registering the same name, layer, and
 canonical scope again replaces that slot's previous definition. The core
-~/compact~ name remains reserved.
+~/compact~ and ~/skills~ names remain reserved.
 
 * Configuration
 
@@ -269,19 +271,23 @@ and are consumed by the next prompt.
 
 Elisp-native slash commands are registered through the public
 ~magent-command-register~ API and can be selected with
-~M-x magent-agent-shell-run-command~. Agent-shell advertises seven bundled
+~M-x magent-agent-shell-run-command~. Agent-shell advertises twelve bundled
 commands: ~/explain~, ~/fix~, ~/init~, ~/review~, ~/summarize~, ~/test~,
-and ~/compact~. The six prompt commands own package Org resources and
+~/compact~, ~/skills~, ~/doctor~, ~/memory-init~, ~/memory-refresh~, and
+~/memory-clear~. The six prompt commands own package Org resources and
 do not activate same-name skills. ~/summarize~ writes one canonical Org note
 for the current Git project and accepts an optional path or semantic scope.
 
-Skills with ~default-prompt~ remain compatible and are projected into the same
-registry; use ~M-x magent-agent-shell-run-skill-command~ to select one directly.
-Project and user skill adapters may override package commands, while the core
-~/compact~ session control is reserved. See [[file:docs/COMMANDS.org][docs/COMMANDS.org]]
-for command behavior, the third-party Elisp API, and compatibility details.
-Project adapters are retained by canonical project scope, and agent-shell uses
-the exact session scope for both command menus and dispatch.
+Every instruction skill in the exact session scope is advertised as ~/$name~.
+~/skills~ lists those descriptors locally. Skills with ~default-prompt~ retain
+the additional legacy ~/name~ adapter; use
+~M-x magent-agent-shell-run-skill-command~ to select one directly. Project and
+user skill adapters may override package commands, while the core ~/compact~
+and ~/skills~ controls are reserved. See
+[[file:docs/COMMANDS.org][docs/COMMANDS.org]] for command behavior, the
+third-party Elisp API, and compatibility details. Project adapters and skill
+descriptors are retained by canonical project scope, and agent-shell uses the
+exact session scope for both menus and dispatch.
 
 Project-local instruction skills are data-only and load normally.  A
 tool-type project skill may also contain executable companion Elisp; Magent

--- a/docs/ARCHITECTURE.org
+++ b/docs/ARCHITECTURE.org
@@ -146,13 +146,19 @@ An Invocation claims its terminal result before cleanup, so a Step failure
 cancels owned work without allowing synchronous cancellation callbacks to
 overwrite the failure or continue work after ACP completes.
 
-For compatibility, an instruction ~SKILL.md~ with ~default-prompt~ is projected
-into the command registry. Its generated terminal Workflow still activates the
-original skill.
-Project and user adapters override package/bundled definitions by layer, while
-the core control is reserved. Project adapters remain keyed by canonical project
-scope; ACP resolves both command discovery and dispatch against each runtime
-session's exact scope, allowing multiple project sessions to coexist safely.
+~magent-skills.el~ also owns frontend-neutral, scope-aware skill descriptors.
+ACP projects every instruction descriptor as ~$name~, which agent-shell renders
+as ~/$name~, and dispatches it as an ordinary runtime turn with an explicit
+skill selection. This path does not require ~default-prompt~ or enter the
+Command Invocation lifecycle. For compatibility, an instruction ~SKILL.md~
+with ~default-prompt~ is additionally projected into the command registry as a
+legacy ~/name~ adapter; its generated terminal Workflow still activates the
+original skill. Project and user adapters override package/bundled definitions
+by layer, while core controls are reserved. Project command adapters and skill
+catalog snapshots remain keyed by canonical project scope; ACP resolves
+discovery and dispatch against each runtime session's exact scope, allowing
+multiple project sessions to coexist safely. A future frontend may consume the
+same descriptor API while presenting commands and skills as separate surfaces.
 
 ~magent-command-session.el~ supplies persistence, ledger recording, inspection,
 and cancellation for specs using ~:session-policy 'isolated~. It does not own a

--- a/docs/ARCHITECTURE.zh.org
+++ b/docs/ARCHITECTURE.zh.org
@@ -135,11 +135,17 @@ API，并拥有各自的 Org prompt resource，而不是同名 skill。
 Invocation 会先锁定 terminal result 再执行 cleanup，因此 Step 失败时会取消其
 拥有的工作，同时避免同步取消 callback 覆盖原始失败，或在 ACP 完成后继续工作。
 
-为保持兼容，带 ~default-prompt~ 的 instruction ~SKILL.md~ 会被投影进 command
-registry，其生成的 terminal Workflow 调用时仍激活原 skill。Project/user adapter 按 layer 覆盖 package/bundled
-定义；core controls 的名称保留。Project adapter 以 canonical project scope 为键
-保留；ACP 的命令发现和分派都按每个 runtime session 的精确 scope 解析，因此多个
-project session 可以安全共存。
+~magent-skills.el~ 还拥有 frontend-neutral、scope-aware 的 skill descriptors。ACP
+会把每个 instruction descriptor 投影成 ~$name~，agent-shell 将其显示为
+~/$name~，分派时则作为带显式 skill selection 的普通 runtime turn。该路径不要求
+~default-prompt~，也不进入 Command Invocation lifecycle。为保持兼容，带
+~default-prompt~ 的 instruction ~SKILL.md~ 还会额外投影进 command registry，提供
+legacy ~/name~ adapter；其生成的 terminal Workflow 调用时仍激活原 skill。
+Project/user adapter 按 layer 覆盖 package/bundled 定义；core controls 的名称保留。
+Project command adapter 与 skill catalog snapshot 都以 canonical project scope
+为键保留；ACP 的发现和分派按每个 runtime session 的精确 scope 解析，因此多个
+project session 可以安全共存。未来 frontend 可以消费同一 descriptor API，同时把
+commands 和 skills 展示为两个独立入口。
 
 ~magent-command-session.el~ 为 ~:session-policy 'isolated~ 的 spec 提供持久化、
 ledger 记录、viewer 和取消，但不再拥有第二套 registry 或 context 类型。
@@ -164,8 +170,9 @@ Instruction skill 会注入 system prompt。Tool skill 通过 ~skill_invoke~ 调
 
 - ~command~ 是由受信任 Elisp 实现、可暴露为 slash、interactive 或两者的显式 invocation。Prompt command 通常拥有
   一个 agent turn；高级 handler 可以拥有多个异步步骤。
-- ~skill~ 是可复用的模型说明或 tool-type operation。Legacy ~default-prompt~ 会投影
-  一个兼容 command，但 Markdown 不再是 Magent 原生命令入口。
+- ~skill~ 是可复用的模型说明或 tool-type operation。ACP 的 ~/$name~ 是普通 turn
+  的显式 skill selection；legacy ~default-prompt~ 只额外投影一个兼容 command，
+  Markdown 不会因此获得 trusted Workflow 权限。
 - ~capability~ 是自动激活规则：由 ~modes~ 、~features~ 、~files~ 、~keywords~ 、~disclosure~ 和 ~risk~ 等 resolver metadata 描述什么时候为当前 turn 选择一个或多个 skills。只有 context 的匹配会作为可检查的 suggestion；active disclosure 还要求当前 user prompt 命中有词边界的 keyword。
 - skill-backed capability 是 contextual capability 的常见形态：某个 ~SKILL.md~ 声明
   ~capability: true~ 后，resolver 会在当前 context 与 prompt intent 同时匹配且所需

--- a/docs/COMMANDS.org
+++ b/docs/COMMANDS.org
@@ -11,7 +11,7 @@ Magent has one command registry with two user-facing entry surfaces:
 - *Interactive commands* are ~M-x~ wrappers over specs that opt into
   interactive exposure.
 
-The bundled package provides eleven slash commands. Doctor and the three Memory
+The bundled package provides twelve slash commands. Doctor and the three Memory
 commands also expose ~M-x magent-command-run-*~ wrappers and use isolated
 durable sessions.
 
@@ -24,12 +24,16 @@ Type a slash command as the prompt in the Magent agent-shell buffer:
 /summarize src/session persistence and replay
 /fix focus on the failing session persistence test
 /compact preserve exact filenames and remaining failures
+/skills
+/$code-review focus on the queue
 #+end_example
 
 Text following a prompt command or ~/compact~ is passed as its argument. The
 six bundled prompt commands reuse the current session and agent without
 activating a same-name skill. An unknown slash command is submitted as ordinary
-prompt text rather than executed locally.
+prompt text rather than executed locally. The ~/$name~ form is reserved for an
+explicit instruction skill; an unknown or unavailable skill name fails before
+provider submission.
 
 | Command    | Purpose                                | Expected effect |
 |------------+----------------------------------------+-----------------|
@@ -40,6 +44,7 @@ prompt text rather than executed locally.
 | ~/summarize~ | Summarize the project into org-roam   | Creates or updates one canonical Org note |
 | ~/test~    | Run and interpret relevant tests        | Runs focused tests; may fix an in-scope failure when appropriate |
 | ~/compact~ | Summarize the current conversation      | Replaces older model context with a continuation summary |
+| ~/skills~  | List instruction skills in this session scope | Local, provider-free discovery |
 | ~/doctor~  | Diagnose Magent and current runtime state | Uses bounded probes and one sanitized tool-free request |
 | ~/memory-init~ | Build Emacs profile memory | Uses an isolated command session and confirmation |
 | ~/memory-refresh~ | Refresh managed profile memory | Preserves user notes in an isolated command session |
@@ -281,19 +286,30 @@ owned and cancellable by their Invocation but do not consume the global agent
 execution slot, so different Invocations may overlap those external waits.
 Project-local Markdown never receives trusted Workflow execution authority.
 
+Every instruction skill visible in the exact runtime session scope is
+advertised through ACP as ~$name~, which agent-shell renders as ~/$name~.
+Submitting ~/$name optional instruction~ preserves that text as the ordinary
+user turn and explicitly selects the skill for that turn. It does not create a
+Command Invocation and does not require ~default-prompt~. Tool-type skills are
+not projected. ~/skills~ lists the same scope-aware instruction descriptors
+locally without contacting the provider.
+
 ~M-x magent-agent-shell-run-skill-command~ selects and runs any command-like
 instruction skill through the compatibility adapter.
 
 Existing instruction skills with a ~default-prompt~ remain compatible: Magent
-projects them into the same command registry and activates the original skill
-when invoked. Project and user adapters can override installed or bundled
-commands by name; the ~/compact~ core name remains reserved.
+additionally projects them into the command registry as legacy ~/name~
+adapters, expands the predefined prompt, and activates the original skill when
+invoked. Project and user adapters can override installed or bundled commands
+by name; the ~/compact~ and ~/skills~ core names remain reserved.
 
 Project command adapters are retained under their canonical project scope.
 ~magent-command-get~, ~magent-command-list~, and ~magent-command-parse~ accept an
 optional scope, and ACP always supplies the runtime session's scope for both
-advertisement and dispatch. Concurrent sessions for different projects can
-therefore expose same-name overrides without leaking commands between menus.
+advertisement and dispatch. The skill descriptor catalog follows the same
+scope rule and retains inactive project snapshots. Concurrent sessions for
+different projects can therefore expose same-name command or skill overrides
+without leaking entries between menus.
 
 * User Skill Management
 

--- a/docs/COMMANDS.zh.org
+++ b/docs/COMMANDS.zh.org
@@ -11,7 +11,7 @@ Magent 使用同一个 command registry 提供两类用户入口：
 - *Interactive commands* 是选择了 interactive exposure 的 command spec 对应的
   ~M-x~ wrapper。
 
-当前内置包提供 11 个 slash commands。Doctor 和三个 Memory command 还提供
+当前内置包提供 12 个 slash commands。Doctor 和三个 Memory command 还提供
 ~M-x magent-command-run-*~ wrapper，并使用独立 durable session。
 
 * Slash Commands
@@ -23,11 +23,14 @@ Magent 使用同一个 command registry 提供两类用户入口：
 /summarize src/session 的持久化与 replay
 /fix 重点检查失败的 session persistence test
 /compact 保留准确的文件名和未解决的失败
+/skills
+/$code-review 重点检查 queue
 #+end_example
 
 Prompt command 或 ~/compact~ 后的文本会作为命令参数。六个内置 prompt command
 复用当前 session 和 agent，但不会激活同名 instruction skill。未知 slash command
-不会在本地执行，而是作为普通 prompt text 提交。
+不会在本地执行，而是作为普通 prompt text 提交。~/$name~ 形式专门用于显式选择
+instruction skill；skill 不存在或在当前 scope 不可用时，会在提交 provider 前失败。
 
 | 命令       | 用途                              | 预期效果 |
 |------------+-----------------------------------+----------|
@@ -38,6 +41,7 @@ Prompt command 或 ~/compact~ 后的文本会作为命令参数。六个内置 p
 | ~/summarize~ | 把项目总结到 org-roam            | 创建或更新一个 canonical Org note |
 | ~/test~    | 运行并解释相关测试                  | 运行聚焦测试；适当时可修复范围内失败 |
 | ~/compact~ | 总结当前对话                        | 用续接摘要替换较早的模型上下文 |
+| ~/skills~ | 列出当前 session scope 的 instruction skills | 本地发现，不请求 provider |
 | ~/doctor~ | 诊断 Magent 和当前 runtime | 使用有界 probes 和一次脱敏、无工具请求 |
 | ~/memory-init~ | 建立 Emacs profile memory | 在独立 command session 中确认并执行 |
 | ~/memory-refresh~ | 刷新 managed profile memory | 在独立 command session 中保留 user notes |
@@ -251,17 +255,25 @@ Agent 和 Answer Step 使用 runtime FIFO。Process 和 callback Step 仍由 Inv
 拥有并可取消，但不占用全局 agent execution slot，因此不同 Invocation 的外部等待
 可以重叠。项目本地 Markdown 不会获得受信任 Workflow 的执行权限。
 
+ACP 会把当前 runtime session 精确 scope 内可见的每个 instruction skill 发布成
+~$name~，agent-shell 将其显示为 ~/$name~。提交 ~/$name 可选说明~ 时，原始文本仍
+作为普通 user turn 保存，同时该 skill 会被显式选择到本次 turn；它不会创建 Command
+Invocation，也不要求 ~default-prompt~。Tool-type skill 不会投影。~/skills~ 使用
+相同的 scope-aware descriptor 在本地列出 instruction skills，不联系 provider。
+
 ~M-x magent-agent-shell-run-skill-command~ 可以通过受支持的 agent-shell frontend
 经兼容 adapter 选择并运行任意 command-like instruction skill。
 
 现有带 ~default-prompt~ 的 instruction skill 保持兼容：Magent 会把它投影到同一
-command registry，并在调用时激活原 skill。Project/user adapter 可以按名称覆盖
-installed 或 bundled command；~/compact~ 这个 core 名称保留。
+command registry，额外提供 legacy ~/name~ adapter；调用时展开预定义 prompt 并激活
+原 skill。Project/user adapter 可以按名称覆盖 installed 或 bundled command；
+~/compact~ 和 ~/skills~ 这两个 core 名称保留。
 
 Project command adapter 会按 canonical project scope 保留。~magent-command-get~、
 ~magent-command-list~ 和 ~magent-command-parse~ 接受可选 scope；ACP 在发布菜单和
-分派命令时都会传入对应 runtime session 的 scope。因此多个项目 session 可以同时
-使用同名覆盖，而不会把一个项目的命令泄漏到另一个项目的菜单。
+分派命令时都会传入对应 runtime session 的 scope。Skill descriptor catalog 遵循
+相同规则，并保留 inactive project snapshot。因此多个项目 session 可以同时使用
+同名 command 或 skill 覆盖，而不会把一个项目的条目泄漏到另一个项目的菜单。
 
 * 用户级 Skill 管理
 

--- a/docs/ONBOARDING.org
+++ b/docs/ONBOARDING.org
@@ -112,10 +112,12 @@ command wrappers use the adjacent command lifecycle rather than another UI.
 
 *What it does:* Prompts route through
 ~magent-agent-shell.el~ and the in-process ACP adapter. ACP sends registered
-slash commands through ~magent-command.el~ and ordinary prompts directly to
-~magent-runtime-api.el~. A prompt request remains pending until its ordinary
-turn or command invocation reaches a terminal state. See ~docs/UI_BACKENDS.org~
-for the frontend development boundary before changing this layer.
+slash commands through ~magent-command.el~, projects scope-aware instruction
+skill descriptors as ~/$name~, and submits those skill selections plus ordinary
+prompts directly to ~magent-runtime-api.el~. A prompt request remains pending
+until its ordinary turn or command invocation reaches a terminal state. See
+~docs/UI_BACKENDS.org~ for the frontend development boundary before changing
+this layer.
 
 ** Layer 7: Events
 
@@ -161,11 +163,15 @@ Two skill types:
 Instruction skills can be selected as one-shot context for the next request.
 The agent-shell frontend exposes native commands such as
 ~magent-agent-shell-toggle-skill-for-next-request~ and
-~magent-agent-shell-run-skill-command~. Skills that define ~default-prompt~ can
-also be run as compatibility command-like actions. Elisp-native slash commands
-are registered separately through ~magent-command-register~ and can be selected
-with ~magent-agent-shell-run-command~. The bundled ~/init~ command initializes
-or refreshes the project root ~AGENTS.md~ and accepts optional extra text.
+~magent-agent-shell-run-skill-command~. ACP also advertises every visible
+instruction skill as ~/$name~; this explicitly selects the skill for an
+ordinary turn and does not require ~default-prompt~. Skills that define
+~default-prompt~ additionally retain the legacy ~/name~ compatibility action.
+Elisp-native slash commands are registered separately through
+~magent-command-register~ and can be selected with
+~magent-agent-shell-run-command~. ~/skills~ lists the same descriptors without
+a provider request. The bundled ~/init~ command initializes or refreshes the
+project root ~AGENTS.md~ and accepts optional extra text.
 
 For each turn, Magent starts with the selected agent's base prompt, then adds
 project context, applicable ~AGENTS.md~ files from the project root toward
@@ -185,7 +191,8 @@ Keep the terms separate when adding or reviewing defaults:
 
 - Use a ~command~ for an explicit slash action with an Elisp entry point.
 - Use a ~skill~ for reusable instructions or tool-type operations that can be
-  selected explicitly or automatically. ~default-prompt~ is compatibility.
+  selected explicitly or automatically. ~/$name~ is the ACP projection;
+  ~default-prompt~ only adds legacy ~/name~ compatibility.
 - Use a ~capability~ when the skill should be selected automatically from live
   context or prompt text.
 - Co-locate the capability metadata in ~SKILL.md~ when the capability only
@@ -228,7 +235,7 @@ invocation lifecycle, and shared runtime behavior remains in the runtime API.
 
 Trace a request through these files in order:
 1. ~magent-agent-shell.el~ / ~magent-acp.el~ — Receive ~session/prompt~ and normalize frontend input
-2. ~magent-command.el~ — Conditionally resolve and invoke registered slash commands
+2. ~magent-command.el~ / ~magent-skills.el~ — Resolve registered slash commands or scope-aware ~/$skill~ descriptors
 3. ~magent-runtime-api.el~ / ~magent-runtime-queue.el~ / ~magent-ledger.el~ — Record, queue, and start ordinary or command-owned turns
 4. ~magent-agent.el~ — Build the prompt and select agent, skills, capabilities, and tools
 5. ~magent-llm-gptel.el~ / ~magent-agent-loop.el~ — Sample through gptel and own normalized continuation outcomes

--- a/docs/ONBOARDING.zh.org
+++ b/docs/ONBOARDING.zh.org
@@ -118,9 +118,11 @@ command lifecycle，而不是另一套 UI。
 - ~magent-file-loader.el~ ：agent/skill/capability 共享 frontmatter parser。
 
 *职责：* Prompt 走 agent-shell 和进程内 ACP adapter。ACP 把 registered slash
-command 交给 ~magent-command.el~ ，普通 prompt 则直接提交 ~magent-runtime-api.el~ 。
-Prompt request 会保持 pending，直到对应普通 turn 或 command invocation 进入 terminal
-state。修改该层前先读 ~docs/UI_BACKENDS.org~ 中的 frontend 开发边界。
+command 交给 ~magent-command.el~，把 scope-aware instruction skill descriptor
+投影为 ~/$name~，并把该 skill selection 或普通 prompt 直接提交
+~magent-runtime-api.el~。Prompt request 会保持 pending，直到对应普通 turn 或 command
+invocation 进入 terminal state。修改该层前先读 ~docs/UI_BACKENDS.org~ 中的 frontend
+开发边界。
 
 ** 第 7 层：Events
 
@@ -169,10 +171,12 @@ Skill 有两类：
 
 Instruction skills 可以作为下一次请求的一次性上下文。Agent-shell frontend 提供
 ~magent-agent-shell-toggle-skill-for-next-request~ 和
-~magent-agent-shell-run-skill-command~ 等命令。带 ~default-prompt~ 的 skills 也可作为
-兼容 command-like action 运行。Elisp-native slash command 通过
-~magent-command-register~ 单独注册，并可用 ~magent-agent-shell-run-command~ 选择。
-内置 ~/init~ 命令用于初始化或刷新项目根目录 ~AGENTS.md~。
+~magent-agent-shell-run-skill-command~ 等命令。ACP 还会把每个可见 instruction skill
+发布成 ~/$name~；这会在一次普通 turn 中显式选择 skill，不要求 ~default-prompt~。
+带 ~default-prompt~ 的 skill 额外保留 legacy ~/name~ 兼容 action。Elisp-native
+slash command 通过 ~magent-command-register~ 单独注册，并可用
+~magent-agent-shell-run-command~ 选择。~/skills~ 不请求 provider，直接列出相同的
+descriptors。内置 ~/init~ 命令用于初始化或刷新项目根目录 ~AGENTS.md~。
 
 每个 turn 都从 selected agent 的 base prompt 开始，随后加入 project context、从项目
 根到请求相关本地文件逐层适用的 ~AGENTS.md~、相关的 profile memory，以及显式选择或
@@ -189,7 +193,8 @@ Skills 加载来源：内置 ~skills/~、存在时兼容的 legacy 用户目录 
 
 - 显式 slash action 需要 Elisp 入口时，用 ~command~ 。
 - 需要可复用 instruction 或 tool-type operation，并且可以被显式或自动选择时，
-  用 ~skill~ ； ~default-prompt~ 只承担兼容作用。
+  用 ~skill~；~/$name~ 是 ACP projection，~default-prompt~ 只额外提供 legacy
+  ~/name~ 兼容。
 - 需要根据 live context 或 prompt text 自动选择某个 skill 时，用 ~capability~ 。
 - 如果 capability 只是为了激活同一个 skill，就把 metadata 和说明共址在
   ~SKILL.md~ 。只有当触发 metadata 不属于单个 skill，或属于 project overlay 时，
@@ -232,7 +237,8 @@ API。
 按顺序跟踪一次请求：
 
 1. ~magent-agent-shell.el~ / ~magent-acp.el~ ：接收 ~session/prompt~ 并规范化 frontend input。
-2. ~magent-command.el~ ：按需解析和调用 registered slash command。
+2. ~magent-command.el~ / ~magent-skills.el~ ：解析 registered slash command 或
+   scope-aware ~/$skill~ descriptor。
 3. ~magent-runtime-api.el~ / ~magent-runtime-queue.el~ / ~magent-ledger.el~ ：记录、排队并启动普通或 command-owned turn。
 4. ~magent-agent.el~ ：构造 prompt，选择 agent、skills、capabilities 和 tools。
 5. ~magent-llm-gptel.el~ / ~magent-agent-loop.el~ ：通过 gptel sampling，并负责 normalized continuation outcomes。

--- a/docs/UI_BACKENDS.org
+++ b/docs/UI_BACKENDS.org
@@ -63,6 +63,15 @@ Keep frontend-neutral behavior in ~magent-runtime-api.el~, ACP conversion in
 ~magent-acp.el~, and supported frontend behavior in ~magent-agent-shell.el~.
 Do not introduce a second interactive frontend inside the core runtime.
 
+Skill discovery is also frontend-neutral. ~magent-skills-list-descriptors~ and
+~magent-skills-resolve-descriptor~ return metadata for an exact session scope
+without exposing prompt bodies or executable handlers. ACP flattens instruction
+skills into its command list as ~$name~ because agent-shell has one slash-menu
+surface, then dispatches ~/$name~ as an ordinary
+~magent-runtime-submit :skills~ turn. A future frontend may instead present
+registered commands and skill descriptors as two separate entry surfaces; it
+must not infer skills from the command registry or require ~default-prompt~.
+
 * Current Limitations
 
 - ~agent-shell~ and ~acp~ are hard dependencies of the supported frontend.
@@ -70,8 +79,8 @@ Do not introduce a second interactive frontend inside the core runtime.
 - Cancellation is session-scoped: cancelling one ACP session cancels that
   session's active and queued submissions without removing other sessions'
   queued work.
-- Per-request instruction skill overrides, Elisp-native slash commands, and
-  compatibility skill commands are supported.
+- Per-request instruction skill overrides, scope-aware ~/$skill~ projection,
+  Elisp-native slash commands, and compatibility skill commands are supported.
   Per-request agent overrides are not currently exposed by the supported
   frontend.
 - ACP session config exposes ~Automatic capabilities~. Disabling it suppresses

--- a/docs/UI_BACKENDS.zh.org
+++ b/docs/UI_BACKENDS.zh.org
@@ -56,14 +56,22 @@ Frontend-neutral 行为放在 ~magent-runtime-api.el~ ，ACP conversion 放在
 ~magent-acp.el~ ，受支持的 frontend 行为放在 ~magent-agent-shell.el~ 。不要在 core
 runtime 内引入第二套交互 frontend。
 
+Skill discovery 同样保持 frontend-neutral。
+~magent-skills-list-descriptors~ 和 ~magent-skills-resolve-descriptor~ 会针对精确
+session scope 返回 metadata，但不暴露 prompt body 或 executable handler。因为
+agent-shell 只有一套 slash menu，ACP 会把 instruction skill 展平为 ~$name~，再把
+~/$name~ 作为普通 ~magent-runtime-submit :skills~ turn 分派。未来 frontend 可以把
+registered commands 与 skill descriptors 展示为两个独立入口；它不应从 command
+registry 反推 skills，也不应要求 ~default-prompt~。
+
 * 当前限制
 
 - 受支持的 frontend 硬依赖 ~agent-shell~ 和 ~acp~ 。
 - runtime execution 使用全局单执行队列。
 - cancellation 是 session-scoped：取消一个 ACP session 会取消该 session 的 active
   和 queued submissions，但不会移除其他 session 的 queued work。
-- 受支持的 frontend 已支持 per-request instruction skill overrides、Elisp-native
-  slash commands 和 compatibility skill commands；目前不暴露 per-request agent
-  overrides。
+- 受支持的 frontend 已支持 per-request instruction skill overrides、scope-aware
+  ~/$skill~ projection、Elisp-native slash commands 和 compatibility skill commands；
+  目前不暴露 per-request agent overrides。
 - ACP session config 暴露 ~Automatic capabilities~ ；关闭后，该 session 后续 turn 不再
   自动解析 contextual capabilities，但显式选择的 instruction skills 仍然生效。

--- a/lisp/magent-acp.el
+++ b/lisp/magent-acp.el
@@ -27,6 +27,7 @@
 (require 'magent-session)
 (require 'magent-ledger)
 (require 'magent-command)
+(require 'magent-skills)
 
 (defvar gptel-model)
 
@@ -134,14 +135,36 @@
     (description . ,(magent-acp--metadata-string
                      (magent-command-spec-description command)))))
 
+(defun magent-acp--skill-command-name-p (name)
+  "Return non-nil when NAME can be projected as an ACP skill command."
+  (and (stringp name)
+       (string-match-p "\\`[[:alnum:]_-]+\\'" name)))
+
+(defun magent-acp--skill-command-entry (descriptor)
+  "Return ACP available command entry for skill DESCRIPTOR, or nil."
+  (let ((name (magent-skill-descriptor-name descriptor)))
+    (if (magent-acp--skill-command-name-p name)
+        `((name . ,(concat "$" name))
+          (description . ,(magent-acp--metadata-string
+                           (magent-skill-descriptor-description descriptor))))
+      (magent-log "WARN skipped ACP skill command with invalid name: %S" name)
+      nil)))
+
 (defun magent-acp--available-commands (&optional runtime-session-or-scope)
-  "Return ACP slash commands for RUNTIME-SESSION-OR-SCOPE."
+  "Return ACP slash commands and skills for RUNTIME-SESSION-OR-SCOPE.
+Instruction skills are projected as `$NAME' entries.  The ACP frontend adds
+the leading slash, so agent-shell displays them as `/$NAME'."
   (let ((scope
          (if (magent-runtime-session-p runtime-session-or-scope)
              (magent-runtime-session-scope runtime-session-or-scope)
            runtime-session-or-scope)))
     (vconcat
-     (mapcar #'magent-acp--command-entry (magent-command-list scope)))))
+     (append
+      (mapcar #'magent-acp--command-entry (magent-command-list scope))
+      (delq nil
+            (mapcar
+             #'magent-acp--skill-command-entry
+             (magent-skills-list-descriptors scope 'instruction)))))))
 
 (defun magent-acp--session-response (runtime-session)
   "Return common ACP session response for RUNTIME-SESSION."
@@ -399,6 +422,38 @@ RESOURCES-BEFORE appear before the frontend resources already stored in INPUT."
             :spec (car parsed)
             :name (magent-command-spec-name (car parsed))
             :argument (cdr parsed)))))
+
+(defun magent-acp--skill-command (prompt &optional runtime-session-or-scope)
+  "Return explicit skill invocation parsed from PROMPT for session scope.
+The accepted wire form is `/$NAME' followed by an optional instruction.
+Unknown or unavailable instruction skills fail here instead of reaching the
+model as ambiguous prompt text."
+  (let* ((scope
+          (if (magent-runtime-session-p runtime-session-or-scope)
+              (magent-runtime-session-scope runtime-session-or-scope)
+            runtime-session-or-scope))
+         (trimmed (string-trim (or prompt ""))))
+    (when (string-match
+           "\\`/\\$\\([[:alnum:]_-]+\\)\\(?:[[:space:]]+\\(.*\\)\\)?\\'"
+           trimmed)
+      (let* ((name (match-string 1 trimmed))
+             (descriptor (magent-skills-resolve-descriptor name scope)))
+        (unless (and descriptor
+                     (eq (magent-skill-descriptor-type descriptor)
+                         'instruction))
+          (user-error
+           "Magent: unknown or unavailable instruction skill '$%s' in this session"
+           name))
+        (list :kind 'skill
+              :name name
+              :argument (string-trim (or (match-string 2 trimmed) ""))
+              :descriptor descriptor)))))
+
+(defun magent-acp--skill-selection (runtime-session skill-name)
+  "Return pending skills plus explicit SKILL-NAME for RUNTIME-SESSION."
+  (magent-skills-dedupe-names
+   (append (magent-runtime-session-pending-skills runtime-session)
+           (list skill-name))))
 
 (defun magent-acp--command-submission-adapter (input)
   "Return a command submission adapter preserving structured ACP INPUT."
@@ -1024,29 +1079,59 @@ switching semantics."
                    (and runtime-session
                         (magent-acp--slash-command
                          instruction-text runtime-session)))
+                  (skill-command
+                   (and runtime-session
+                        (not command)
+                        (magent-acp--skill-command
+                         instruction-text runtime-session)))
                   (resources (plist-get input :resource-blocks)))
              (unless runtime-session
                (error "Unknown session: %s" session-id))
-             (if command
-                 (magent-command-invoke
-                  (plist-get command :spec) runtime-session
-                  :raw-input instruction-text
-                  :argument (plist-get command :argument)
-                  :request-context
-                  (append (plist-get input :context)
-                          (list :capabilities-enabled
-                                (magent-runtime-session-capabilities-enabled-p
-                                 runtime-session)))
-                  :resource-blocks resources
+             (cond
+              (command
+               (magent-command-invoke
+                (plist-get command :spec) runtime-session
+                :raw-input instruction-text
+                :argument (plist-get command :argument)
+                :request-context
+                (append (plist-get input :context)
+                        (list :capabilities-enabled
+                              (magent-runtime-session-capabilities-enabled-p
+                               runtime-session)))
+                :resource-blocks resources
+                :observer (magent-acp--observer client session-id)
+                :approval-provider
+                (magent-acp--approval-provider client session-id)
+                :submission-adapter
+                (magent-acp--command-submission-adapter input)
+                :on-complete
+                (lambda (status result)
+                  (magent-acp--complete-prompt-request
+                   on-success status result))))
+              (skill-command
+               (let ((skill-name (plist-get skill-command :name)))
+                 (magent-runtime-submit
+                  runtime-session (plist-get input :display-text)
+                  :context
+                  (append
+                   (plist-get input :context)
+                   (list :capabilities-enabled
+                         (magent-runtime-session-capabilities-enabled-p
+                          runtime-session)))
+                  :skills
+                  (magent-acp--skill-selection runtime-session skill-name)
+                  :turn-metadata
+                  (list :content-blocks (plist-get input :content-blocks)
+                        :explicit-skill skill-name
+                        :skill-invocation 'acp-command)
                   :observer (magent-acp--observer client session-id)
                   :approval-provider
                   (magent-acp--approval-provider client session-id)
-                  :submission-adapter
-                  (magent-acp--command-submission-adapter input)
                   :on-complete
                   (lambda (status result)
                     (magent-acp--complete-prompt-request
-                     on-success status result)))
+                     on-success status result)))))
+              (t
                (magent-runtime-submit
                 runtime-session (plist-get input :display-text)
                 :context
@@ -1062,7 +1147,7 @@ switching semantics."
                 :on-complete
                 (lambda (status result)
                   (magent-acp--complete-prompt-request
-                   on-success status result))))))
+                   on-success status result)))))))
           (_
            (error "Unsupported ACP method: %s" method))))
     (error

--- a/lisp/magent-command-builtins.el
+++ b/lisp/magent-command-builtins.el
@@ -12,6 +12,7 @@
 (require 'magent-command-fix)
 (require 'magent-command-init)
 (require 'magent-command-review)
+(require 'magent-command-skills)
 (require 'magent-command-summarize)
 (require 'magent-command-test)
 
@@ -27,6 +28,7 @@
     (magent-command-fix-register)
     (magent-command-init-register)
     (magent-command-review-register)
+    (magent-command-skills-register)
     (magent-command-summarize-register)
     (magent-command-test-register))
   (magent-command--registry-changed))

--- a/lisp/magent-command-skills.el
+++ b/lisp/magent-command-skills.el
@@ -1,0 +1,64 @@
+;;; magent-command-skills.el --- Skill discovery command  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Jamie Cui
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;; Assisted-by: Codex:GPT-5.6
+
+;;; Commentary:
+
+;; Provider-free /skills command backed by the scope-aware Magent skill
+;; catalog.  Frontends may project the same descriptors through other
+;; interaction surfaces without coupling skills to the command registry.
+
+;;; Code:
+
+(require 'subr-x)
+(require 'magent-command)
+(require 'magent-skills)
+
+(defun magent-command-skills--description-string (value)
+  "Return skill description VALUE as display text."
+  (cond
+   ((stringp value) value)
+   ((null value) "")
+   ((listp value)
+    (string-join (mapcar (lambda (item) (format "%s" item)) value)
+                 ", "))
+   (t (format "%s" value))))
+
+(magent-command-defworkflow magent-command-skills--workflow (invocation)
+  "List instruction skills visible to INVOCATION."
+  (let ((descriptors
+         (magent-skills-list-descriptors
+          (magent-command-invocation-scope invocation)
+          'instruction)))
+    (if descriptors
+        (string-join
+         (cons
+          "Available skills:"
+          (mapcar
+           (lambda (descriptor)
+             (let ((description
+                    (magent-command-skills--description-string
+                     (magent-skill-descriptor-description descriptor))))
+               (if (string-empty-p description)
+                   (format "- %s"
+                           (magent-skill-descriptor-name descriptor))
+                 (format "- %s: %s"
+                         (magent-skill-descriptor-name descriptor)
+                         description))))
+           descriptors))
+         "\n")
+      "No skills configured.")))
+
+(defun magent-command-skills-register ()
+  "Register the reserved Magent skill discovery command."
+  (magent-command-register
+   "skills"
+   :description "List instruction skills available in this session."
+   :session-policy 'current
+   :workflow #'magent-command-skills--workflow
+   :source-layer 'core))
+
+(provide 'magent-command-skills)
+;;; magent-command-skills.el ends here

--- a/lisp/magent-runtime.el
+++ b/lisp/magent-runtime.el
@@ -60,7 +60,8 @@ wins; when all functions return nil, scope is derived from
      :unload-project magent-agent-registry-remove-project-scope
      :project-enabled magent-load-custom-agents)
     (:name skills
-     :state-variable magent-skills--registry
+     :state-variables (magent-skills--registry
+                       magent-skills--scope-catalog)
      :static-feature magent-skills
      :static magent-skills-initialize-static
      :load-project-feature magent-skills
@@ -281,12 +282,18 @@ Nil means only static definitions are loaded.")
 
 (defun magent-runtime--snapshot-overlay-state ()
   "Capture the registry state owned by every project overlay spec."
-  (cl-loop for spec in magent-runtime--overlay-specs
-           for variable = (plist-get spec :state-variable)
-           when (and variable (boundp variable))
-           collect (cons variable
-                         (magent-runtime--copy-overlay-state
-                          (symbol-value variable)))))
+  (cl-loop
+   for spec in magent-runtime--overlay-specs
+   append
+   (cl-loop
+    for variable in
+    (or (plist-get spec :state-variables)
+        (when-let* ((single (plist-get spec :state-variable)))
+          (list single)))
+    when (and variable (boundp variable))
+    collect (cons variable
+                  (magent-runtime--copy-overlay-state
+                   (symbol-value variable))))))
 
 (defun magent-runtime--restore-overlay-state (snapshot)
   "Restore project overlay registries from SNAPSHOT."

--- a/lisp/magent-skills.el
+++ b/lisp/magent-skills.el
@@ -30,6 +30,7 @@
 (require 'magent-runtime)
 
 (declare-function magent-command-refresh-skill-adapters "magent-command")
+(declare-function magent-session-scope-origin "magent-session")
 
 ;;; Built-in skill metadata
 
@@ -68,10 +69,12 @@ Markdown body: instructions for the AI...
 **instruction**: Markdown body is injected into the system prompt every request.
 Use for workflow guidance, coding standards, domain knowledge.
 Keep under 200 lines to avoid bloating the system prompt.
-Add `default-prompt` only when this Markdown skill should expose a portable
-compatibility slash command.  A trusted installed Magent extension that needs
-Elisp execution or a multi-step workflow should instead register through
-`magent-command-register`; project-local Markdown remains data-only.
+Agent-shell exposes every available instruction skill as `/$name`.
+Add `default-prompt` only when this Markdown skill should additionally expose
+the legacy `/name` compatibility adapter with a predefined prompt.  A trusted
+installed Magent extension that needs Elisp execution or a multi-step workflow
+should instead register through `magent-command-register`; project-local
+Markdown remains data-only.
 
 **tool**: Invoked explicitly via `skill_invoke` with named operations.
 Requires a companion `.el` file defining `magent-skill-<name>-invoke`.
@@ -196,12 +199,30 @@ use a skill - make it count."
   (source-layer 'builtin)
   source-scope)
 
+(cl-defstruct (magent-skill-descriptor
+               (:constructor magent-skill-descriptor-create)
+               (:copier nil))
+  "Frontend-neutral metadata for one effective Magent skill."
+  name
+  description
+  type
+  tools
+  requires-project
+  source-layer
+  source-scope
+  command-like-p)
+
 ;;; Skill registry
 
 (defvar magent-skills--registry nil
   "Layered alist of (skill-name . magent-skill) definitions.
 For duplicate names the first entry is effective; lower-layer entries are
 kept so unloading a project overlay restores the previous definition.")
+
+(defvar magent-skills--scope-catalog (make-hash-table :test #'equal)
+  "Effective skill snapshots keyed by canonical project scope.
+The nil key stores the global snapshot.  Project snapshots are retained while
+their overlays are inactive so live frontend sessions remain scope-correct.")
 
 (defun magent-skills--same-owner-p (left right)
   "Return non-nil when skills LEFT and RIGHT belong to the same layer."
@@ -218,6 +239,141 @@ kept so unloading a project overlay restores the previous definition.")
         (push (car entry) seen)
         (push entry effective)))
     (nreverse effective)))
+
+(defun magent-skills--canonical-scope (scope)
+  "Return canonical project origin for SCOPE, or nil for global scope."
+  (let ((origin (magent-session-scope-origin scope)))
+    (cond
+     ((or (null origin) (eq origin 'global)) nil)
+     ((stringp origin)
+      (condition-case nil
+          (file-truename (directory-file-name origin))
+        (error (directory-file-name (expand-file-name origin)))))
+     (t origin))))
+
+(defun magent-skills--resolution-scope (&optional scope)
+  "Return canonical catalog scope for optional SCOPE."
+  (magent-skills--canonical-scope
+   (or scope
+       (magent-runtime-active-project-scope)
+       'global)))
+
+(defun magent-skills--visible-in-scope-p (skill scope)
+  "Return non-nil when SKILL is visible in canonical SCOPE."
+  (let ((source-scope
+         (magent-skills--canonical-scope
+          (magent-skill-source-scope skill))))
+    (or (null source-scope)
+        (equal source-scope scope))))
+
+(defun magent-skills--registry-skills-for-scope (scope)
+  "Return effective registry skills visible in canonical SCOPE."
+  (let (seen skills)
+    (dolist (entry magent-skills--registry)
+      (let ((name (car entry))
+            (skill (cdr entry)))
+        (when (and (not (member name seen))
+                   (magent-skills--visible-in-scope-p skill scope))
+          (push name seen)
+          (push skill skills))))
+    (sort skills
+          (lambda (left right)
+            (string< (magent-skill-name left)
+                     (magent-skill-name right))))))
+
+(defun magent-skills--rebase-project-catalogs ()
+  "Rebase cached project catalogs on the current global snapshot."
+  (let ((global-skills
+         (copy-sequence
+          (gethash nil magent-skills--scope-catalog))))
+    (maphash
+     (lambda (scope skills)
+       (when scope
+         (let* ((project-skills
+                 (cl-remove-if-not
+                  (lambda (skill)
+                    (equal
+                     scope
+                     (magent-skills--canonical-scope
+                      (magent-skill-source-scope skill))))
+                  skills))
+                (project-names
+                 (mapcar #'magent-skill-name project-skills))
+                (rebased
+                 (append
+                  project-skills
+                  (cl-remove-if
+                   (lambda (skill)
+                     (member (magent-skill-name skill) project-names))
+                   global-skills))))
+           (puthash
+            scope
+            (sort rebased
+                  (lambda (left right)
+                    (string< (magent-skill-name left)
+                             (magent-skill-name right))))
+            magent-skills--scope-catalog))))
+     magent-skills--scope-catalog)))
+
+(defun magent-skills--record-scope-catalog (&optional scope)
+  "Record effective skills for SCOPE from the active registry."
+  (let ((key (magent-skills--resolution-scope scope)))
+    (puthash key
+             (magent-skills--registry-skills-for-scope key)
+             magent-skills--scope-catalog)
+    (when (null key)
+      (magent-skills--rebase-project-catalogs))))
+
+(defun magent-skills--descriptor (skill)
+  "Return frontend-neutral descriptor for SKILL."
+  (magent-skill-descriptor-create
+   :name (magent-skill-name skill)
+   :description (magent-skill-description skill)
+   :type (magent-skill-type skill)
+   :tools (copy-sequence (magent-skill-tools skill))
+   :requires-project (magent-skill-requires-project skill)
+   :source-layer (magent-skill-source-layer skill)
+   :source-scope (magent-skill-source-scope skill)
+   :command-like-p
+   (and (stringp (magent-skill-default-prompt skill))
+        (not (string-blank-p (magent-skill-default-prompt skill))))))
+
+(defun magent-skills-list-descriptors (&optional scope type)
+  "Return effective skill descriptors for SCOPE, optionally limited to TYPE.
+When SCOPE is nil, use the currently active project overlay.  Results are
+sorted by skill name and do not expose prompt bodies or executable handlers."
+  (let* ((key (magent-skills--resolution-scope scope))
+         (active-key
+          (magent-skills--canonical-scope
+           (or (magent-runtime-active-project-scope) 'global)))
+         (skills
+          (if (equal key active-key)
+              (magent-skills--registry-skills-for-scope key)
+            (let ((cached (gethash key magent-skills--scope-catalog
+                                   'magent-skills--missing)))
+              (if (eq cached 'magent-skills--missing)
+                  (copy-sequence
+                   (gethash nil magent-skills--scope-catalog))
+                (copy-sequence cached))))))
+    (setq skills
+          (cl-remove-if
+           (lambda (skill)
+             (and (null key)
+                  (magent-skill-requires-project skill)))
+           skills))
+    (mapcar
+     #'magent-skills--descriptor
+     (if type
+         (cl-remove-if-not
+          (lambda (skill) (eq (magent-skill-type skill) type))
+          skills)
+       skills))))
+
+(defun magent-skills-resolve-descriptor (name &optional scope)
+  "Return effective skill descriptor NAME for SCOPE, or nil."
+  (cl-find name (magent-skills-list-descriptors scope)
+           :key #'magent-skill-descriptor-name
+           :test #'equal))
 
 (defun magent-skills-get (name)
   "Get skill by NAME from registry."
@@ -286,18 +442,30 @@ Shadowed lower-layer definitions remain registered for later restoration."
                                (magent-skills--same-owner-p
                                 (cdr entry) skill)))
                         magent-skills--registry))
-    (push (cons name skill) magent-skills--registry))
+    (push (cons name skill) magent-skills--registry)
+    (magent-skills--record-scope-catalog
+     (or (magent-skill-source-scope skill) 'global)))
   skill)
 
 (defun magent-skills-unregister (name)
   "Remove skill NAME from registry."
   (setq magent-skills--registry
         (cl-remove-if (lambda (entry) (equal (car entry) name))
-                      magent-skills--registry)))
+                      magent-skills--registry))
+  (maphash
+   (lambda (scope skills)
+     (puthash scope
+              (cl-remove name skills
+                         :key #'magent-skill-name
+                         :test #'equal)
+              magent-skills--scope-catalog))
+   magent-skills--scope-catalog)
+  (magent-skills--record-scope-catalog 'global))
 
 (defun magent-skills-clear ()
   "Clear all skills from registry."
-  (setq magent-skills--registry nil))
+  (setq magent-skills--registry nil)
+  (clrhash magent-skills--scope-catalog))
 
 ;;; Skill invocation
 
@@ -586,15 +754,20 @@ Returns number of skills loaded."
 (defun magent-skills-initialize-static ()
   "Load built-in and user-global skill definitions."
   (magent-skills--register-builtin)
-  (magent-skills-load-all (magent-skills-definition-directories)))
+  (prog1
+      (magent-skills-load-all (magent-skills-definition-directories))
+    (magent-skills--record-scope-catalog 'global)))
 
 (defun magent-skills-load-project-scope (scope)
   "Load project-local skill definitions for SCOPE."
-  (if-let* ((directories
-             (magent-file-loader-project-subdir-for-scope
-              ".magent/skills" scope)))
-      (magent-skills-load-all directories)
-    0))
+  (let ((count
+         (if-let* ((directories
+                    (magent-file-loader-project-subdir-for-scope
+                     ".magent/skills" scope)))
+             (magent-skills-load-all directories)
+           0)))
+    (magent-skills--record-scope-catalog scope)
+    count))
 
 (defun magent-skills-reload ()
   "Reload all skills from files.
@@ -611,7 +784,10 @@ local skills after static definitions are reloaded."
       (magent-skills-load-project-scope project-scope))
     (when (and project-scope
                (fboundp 'magent-command-refresh-skill-adapters))
-      (magent-command-refresh-skill-adapters project-scope))))
+      (magent-command-refresh-skill-adapters project-scope))
+    (magent-skills--record-scope-catalog 'global)
+    (when project-scope
+      (magent-skills--record-scope-catalog project-scope))))
 
 (defun magent-skills-remove-project-scope (scope)
   "Remove project-local skills registered for SCOPE."

--- a/source-files.txt
+++ b/source-files.txt
@@ -36,6 +36,7 @@ lisp/magent-command-explain.el
 lisp/magent-command-fix.el
 lisp/magent-command-init.el
 lisp/magent-command-review.el
+lisp/magent-command-skills.el
 lisp/magent-command-summarize.el
 lisp/magent-command-test.el
 lisp/magent-command-builtins.el

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -119,7 +119,7 @@
   "Bundled Elisp-native prompt commands.")
 
 (defconst magent-test--builtin-control-command-names
-  '("compact")
+  '("compact" "skills")
   "Magent-owned session control exposed as a slash command.")
 
 (defconst magent-test--builtin-maintenance-command-names
@@ -2977,6 +2977,94 @@
     (should (= (length (magent-skills-list-by-type 'instruction)) 2))
     (should (= (length (magent-skills-list-by-type 'tool)) 1))))
 
+(ert-deftest magent-test-skills-descriptors-are-frontend-neutral ()
+  "Descriptors expose instruction skills without requiring a default prompt."
+  (require 'magent-skills)
+  (let ((magent-skills--registry nil)
+        (magent-skills--scope-catalog (make-hash-table :test #'equal))
+        (magent-runtime--active-project-scope nil)
+        (project-root (make-temp-file "magent-skill-project-" t)))
+    (unwind-protect
+        (progn
+          (magent-skills-register
+           (magent-skill-create
+            :name "reviewer"
+            :description "Review code."
+            :type 'instruction))
+          (magent-skills-register
+           (magent-skill-create
+            :name "project-only"
+            :description "Needs a project."
+            :type 'instruction
+            :requires-project t))
+          (magent-skills-register
+           (magent-skill-create
+            :name "operations"
+            :description "Tool operations."
+            :type 'tool))
+          (let ((global
+                 (magent-skills-list-descriptors 'global 'instruction))
+                (project
+                 (magent-skills-list-descriptors project-root 'instruction)))
+            (should (equal (mapcar #'magent-skill-descriptor-name global)
+                           '("reviewer")))
+            (should
+             (equal (mapcar #'magent-skill-descriptor-name project)
+                    '("project-only" "reviewer")))
+            (should-not
+             (magent-skill-descriptor-command-like-p (car global)))
+            (should (equal
+                     (magent-skill-descriptor-description (car global))
+                     "Review code."))))
+      (delete-directory project-root t))))
+
+(ert-deftest magent-test-skills-descriptors-retain-inactive-project-scopes ()
+  "Project skill catalogs remain exact while another scope is active."
+  (require 'magent-skills)
+  (let* ((magent-skills--registry nil)
+         (magent-skills--scope-catalog (make-hash-table :test #'equal))
+         (magent-runtime--active-project-scope nil)
+         (project-a (file-truename
+                     (directory-file-name
+                      (make-temp-file "magent-skill-project-a-" t))))
+         (project-b (file-truename
+                     (directory-file-name
+                      (make-temp-file "magent-skill-project-b-" t)))))
+    (unwind-protect
+        (progn
+          (magent-skills-register
+           (magent-skill-create
+            :name "policy" :description "Global policy."
+            :type 'instruction :source-layer 'user))
+          (magent-skills-register
+           (magent-skill-create
+            :name "policy" :description "Project A policy."
+            :type 'instruction :source-layer 'project
+            :source-scope project-a))
+          (magent-skills-remove-project-scope project-a)
+          (magent-skills-register
+           (magent-skill-create
+            :name "policy" :description "Project B policy."
+            :type 'instruction :source-layer 'project
+            :source-scope project-b))
+          (should
+           (equal
+            (magent-skill-descriptor-description
+             (magent-skills-resolve-descriptor "policy" project-a))
+            "Project A policy."))
+          (should
+           (equal
+            (magent-skill-descriptor-description
+             (magent-skills-resolve-descriptor "policy" project-b))
+            "Project B policy."))
+          (should
+           (equal
+            (magent-skill-descriptor-description
+             (magent-skills-resolve-descriptor "policy" 'global))
+            "Global policy.")))
+      (delete-directory project-a t)
+      (delete-directory project-b t))))
+
 (ert-deftest magent-test-skills-clear ()
   "Test clearing all skills."
   (require 'magent-skills)
@@ -3233,6 +3321,46 @@
         (should (eq (magent-command-spec-source-layer command) 'builtin))
         (should (functionp (magent-command-spec-workflow command)))
         (should-not (magent-skills-get name))))))
+
+(ert-deftest magent-test-command-skills-lists-scope-without-provider ()
+  "The core /skills workflow lists descriptors without submitting a turn."
+  (require 'magent-command-skills)
+  (let ((magent-command--registry nil)
+        (magent-command--active-invocations (make-hash-table :test #'eq))
+        (magent-skills--registry nil)
+        (magent-skills--scope-catalog (make-hash-table :test #'equal))
+        (runtime-session
+         (magent-runtime-session-create
+          :id "session-1"
+          :scope 'global
+          :magent-session (magent-session-create)))
+        completion)
+    (magent-skills-register
+     (magent-skill-create
+      :name "reviewer"
+      :description "Review code."
+      :type 'instruction))
+    (magent-skills-register
+     (magent-skill-create
+      :name "operations"
+      :description "Tool operations."
+      :type 'tool))
+    (let ((magent-command--allow-core-registration t))
+      (magent-command-skills-register))
+    (cl-letf (((symbol-function 'magent-runtime-submit)
+               (lambda (&rest _)
+                 (error "/skills must not submit a provider turn"))))
+      (magent-test--without-command-step-ledger
+        (magent-command-invoke
+         "skills" runtime-session
+         :on-complete
+         (lambda (status result)
+           (setq completion (list status result))))))
+    (should (eq (car completion) 'completed))
+    (should
+     (equal
+      (magent-agent-result-content-string (cadr completion))
+      "Available skills:\n- reviewer: Review code."))))
 
 (ert-deftest magent-test-command-register-requires-workflow-and-policy ()
   "Test command registration requires one Workflow and explicit policy."
@@ -10486,10 +10614,11 @@
                    magent-default-agent))))
 
 (ert-deftest magent-test-acp-available-commands-list-command-skills ()
-  "Test ACP exposes SKILL.md default prompts through command adapters."
+  "ACP exposes every instruction skill plus legacy default-prompt adapters."
   (require 'magent-acp)
   (require 'magent-command-controls)
   (let ((magent-skills--registry nil)
+        (magent-skills--scope-catalog (make-hash-table :test #'equal))
         (magent-command--registry nil)
         (magent-command--skill-adapter-registrations
          (make-hash-table :test #'equal)))
@@ -10511,21 +10640,26 @@
            (names (mapcar (lambda (command)
                             (map-elt command 'name))
                           (append commands nil)))
-           (command (cl-find-if (lambda (entry)
-                                  (equal (map-elt entry 'name) "init"))
-                                (append commands nil))))
-      (should (equal names
-                     (sort (copy-sequence
-                            '("compact" "init"))
-                           #'string<)))
-      (should command)
-      (should (equal (map-elt command 'description)
+           (legacy-command
+            (cl-find-if (lambda (entry)
+                          (equal (map-elt entry 'name) "init"))
+                        (append commands nil)))
+           (skill-command
+            (cl-find-if (lambda (entry)
+                          (equal (map-elt entry 'name) "$init"))
+                        (append commands nil))))
+      (should (equal names '("compact" "init" "$init" "$note")))
+      (should legacy-command)
+      (should skill-command)
+      (should (equal (map-elt skill-command 'description)
                      "Initialize project instructions, similar to Codex /init.")))))
 
 (ert-deftest magent-test-acp-available-commands-lists-all-bundled-slash-commands ()
   "Test ACP available commands expose every bundled Elisp command."
   (require 'magent-acp)
-  (let ((magent-command--registry nil))
+  (let ((magent-command--registry nil)
+        (magent-skills--registry nil)
+        (magent-skills--scope-catalog (make-hash-table :test #'equal)))
     (magent-test--register-builtin-commands-only)
     (let* ((commands (append (magent-acp--available-commands) nil))
            (names (mapcar (lambda (command)
@@ -10544,6 +10678,88 @@
           (should-not (string-empty-p (map-elt command 'description)))
           (should (equal (map-elt command 'description)
                          (magent-command-spec-description spec))))))))
+
+(ert-deftest magent-test-acp-available-skill-commands-use-session-scope ()
+  "ACP skill projection remains exact for concurrently retained projects."
+  (require 'magent-acp)
+  (let* ((magent-command--registry nil)
+         (magent-skills--registry nil)
+         (magent-skills--scope-catalog (make-hash-table :test #'equal))
+         (magent-runtime--active-project-scope nil)
+         (project-a (file-truename
+                     (directory-file-name
+                      (make-temp-file "magent-acp-project-a-" t))))
+         (project-b (file-truename
+                     (directory-file-name
+                      (make-temp-file "magent-acp-project-b-" t))))
+         (session-a
+          (magent-runtime-session-create :id "session-a" :scope project-a))
+         (session-b
+          (magent-runtime-session-create :id "session-b" :scope project-b)))
+    (unwind-protect
+        (progn
+          (magent-skills-register
+           (magent-skill-create
+            :name "global-skill" :type 'instruction
+            :description "Global."))
+          (magent-skills-register
+           (magent-skill-create
+            :name "project-a" :type 'instruction
+            :description "Project A."
+            :source-layer 'project :source-scope project-a))
+          (magent-skills-remove-project-scope project-a)
+          (magent-skills-register
+           (magent-skill-create
+            :name "project-b" :type 'instruction
+            :description "Project B."
+            :source-layer 'project :source-scope project-b))
+          (let ((names-a
+                 (mapcar
+                  (lambda (entry) (map-elt entry 'name))
+                  (append (magent-acp--available-commands session-a) nil)))
+                (names-b
+                 (mapcar
+                  (lambda (entry) (map-elt entry 'name))
+                  (append (magent-acp--available-commands session-b) nil))))
+            (should (equal names-a '("$global-skill" "$project-a")))
+            (should (equal names-b '("$global-skill" "$project-b")))))
+      (delete-directory project-a t)
+      (delete-directory project-b t))))
+
+(ert-deftest magent-test-acp-skill-command-resolves-without-default-prompt ()
+  "ACP `/$skill' syntax resolves against instruction skill descriptors."
+  (require 'magent-acp)
+  (let ((magent-skills--registry nil)
+        (magent-skills--scope-catalog (make-hash-table :test #'equal))
+        (project-root (make-temp-file "magent-acp-skill-project-" t)))
+    (unwind-protect
+        (progn
+          (magent-skills-register
+           (magent-skill-create
+            :name "reviewer"
+            :description "Review code."
+            :type 'instruction))
+          (magent-skills-register
+           (magent-skill-create
+            :name "project-only"
+            :description "Project policy."
+            :type 'instruction
+            :requires-project t))
+          (let ((parsed
+                 (magent-acp--skill-command
+                  "/$reviewer focus on tests" 'global)))
+            (should (eq (plist-get parsed :kind) 'skill))
+            (should (equal (plist-get parsed :name) "reviewer"))
+            (should (equal (plist-get parsed :argument) "focus on tests")))
+          (should-error
+           (magent-acp--skill-command "/$missing" 'global)
+           :type 'user-error)
+          (should-error
+           (magent-acp--skill-command "/$project-only" 'global)
+           :type 'user-error)
+          (should
+           (magent-acp--skill-command "/$project-only" project-root)))
+      (delete-directory project-root t))))
 
 (ert-deftest magent-test-acp-slash-command-resolves-all-bundled-commands ()
   "Test every bundled slash command resolves to its Elisp command spec."
@@ -10846,6 +11062,90 @@
                                     :content-blocks))
                  2)))
     (should (equal (map-elt response 'stopReason) "end_turn"))))
+
+(ert-deftest magent-test-acp-session-prompt-selects-skill-as-normal-turn ()
+  "ACP `/$skill' keeps raw input while explicitly selecting the skill."
+  (require 'magent-acp)
+  (let ((magent-skills--registry nil)
+        (magent-skills--scope-catalog (make-hash-table :test #'equal))
+        (runtime-session
+         (magent-runtime-session-create
+          :id "session-1"
+          :scope 'global
+          :pending-skills '("existing-skill")))
+        submitted response failure)
+    (magent-skills-register
+     (magent-skill-create
+      :name "reviewer"
+      :description "Review code."
+      :type 'instruction))
+    (cl-letf (((symbol-function 'magent-acp--runtime-session-by-id)
+               (lambda (session-id)
+                 (and (equal session-id "session-1") runtime-session)))
+              ((symbol-function 'magent-runtime-submit)
+               (lambda (session prompt &rest args)
+                 (setq submitted (list session prompt args))
+                 (setf (magent-runtime-session-pending-skills session) nil)
+                 (funcall (plist-get args :on-complete)
+                          'completed (magent-agent-result-completed "ok"))
+                 "submission-1")))
+      (magent-acp--handle-request
+       '((:notification-handlers . nil) (:request-handlers . nil))
+       '((:method . "session/prompt")
+         (:params . ((sessionId . "session-1")
+                     (prompt
+                      . [((type . "text")
+                          (text . "/$reviewer focus on tests"))
+                         ((type . "resource")
+                          (resource
+                           . ((uri . "file:///tmp/example.txt")
+                              (text . "body"))))]))))
+       (lambda (value) (setq response value))
+       (lambda (err &optional _raw) (setq failure err))))
+    (should-not failure)
+    (should (eq (car submitted) runtime-session))
+    (should
+     (equal (cadr submitted)
+            (concat "/$reviewer focus on tests\n"
+                    "[Attached: file:///tmp/example.txt]")))
+    (let* ((args (nth 2 submitted))
+           (metadata (plist-get args :turn-metadata))
+           (blocks (plist-get metadata :content-blocks)))
+      (should (equal (plist-get args :skills)
+                     '("existing-skill" "reviewer")))
+      (should (equal (plist-get metadata :explicit-skill) "reviewer"))
+      (should (eq (plist-get metadata :skill-invocation) 'acp-command))
+      (should (= (length blocks) 2))
+      (should (equal (map-elt (aref blocks 0) 'text)
+                     "/$reviewer focus on tests")))
+    (should-not (magent-runtime-session-pending-skills runtime-session))
+    (should (equal (map-elt response 'stopReason) "end_turn"))))
+
+(ert-deftest magent-test-acp-session-prompt-rejects-unknown-skill-command ()
+  "Unknown `/$skill' input fails before an ordinary model submission."
+  (require 'magent-acp)
+  (let ((magent-skills--registry nil)
+        (magent-skills--scope-catalog (make-hash-table :test #'equal))
+        (runtime-session
+         (magent-runtime-session-create :id "session-1" :scope 'global))
+        submitted response failure)
+    (cl-letf (((symbol-function 'magent-acp--runtime-session-by-id)
+               (lambda (_session-id) runtime-session))
+              ((symbol-function 'magent-runtime-submit)
+               (lambda (&rest _args) (setq submitted t))))
+      (magent-acp--handle-request
+       '((:notification-handlers . nil) (:request-handlers . nil))
+       '((:method . "session/prompt")
+         (:params . ((sessionId . "session-1")
+                     (prompt . [((type . "text")
+                                 (text . "/$missing"))]))))
+       (lambda (value) (setq response value))
+       (lambda (err &optional _raw) (setq failure err))))
+    (should-not submitted)
+    (should-not response)
+    (should failure)
+    (should (string-match-p "unknown or unavailable instruction skill"
+                            (map-elt failure 'message)))))
 
 (ert-deftest magent-test-acp-session-prompt-expands-slash-command ()
   "Test ACP dispatches a legacy command-like skill through its adapter."


### PR DESCRIPTION
## Summary

- expose every scope-visible instruction skill as `/$name` through ACP and agent-shell
- add frontend-neutral, scope-aware skill descriptors and provider-free `/skills` discovery
- preserve legacy `default-prompt` adapters and document concurrent project-scope behavior
- validate with `make compile` and `make test` (556 ERT tests plus live smoke)