### PR TITLE
fix: address MELPA review feedback

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,12 +24,13 @@ jobs:
 
       - name: Install Emacs package dependencies
         run: |
+          # Keep Transient's macro providers ahead of packages that pull it in.
           emacs -Q --batch \
             --eval "(require 'package)" \
             --eval "(setq package-archives '((\"gnu\" . \"https://elpa.gnu.org/packages/\") (\"nongnu\" . \"https://elpa.nongnu.org/nongnu/\") (\"melpa\" . \"https://melpa.org/packages/\")))" \
             --eval "(package-initialize)" \
             --eval "(package-refresh-contents)" \
-            --eval "(dolist (pkg '(gptel yaml cond-let compat llama with-editor acp shell-maker agent-shell)) (unless (package-installed-p pkg) (package-install pkg)))"
+            --eval "(dolist (pkg '(compat cond-let llama gptel yaml with-editor acp shell-maker agent-shell)) (unless (package-installed-p pkg) (package-install pkg)))"
 
       - name: Run coverage
         run: make coverage

--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -46,7 +46,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         LOCAL_REPO: ${{ github.workspace }}
         # RECIPE is your recipe as written for MELPA:
-        RECIPE: (magent :fetcher github :repo "Jamie-Cui/magent" :files ("lisp/*.el" "prompts" "skills" "capabilities"))
+        RECIPE: (magent :fetcher github :repo "Jamie-Cui/magent" :files ("lisp/magent*.el" "prompts" "skills" "capabilities"))
         # set this to true if warnings should be treated as errors:
         WARN_IS_ERROR: false
         # set this to false (or remove it) if the package isn't on MELPA:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,12 @@ on:
 jobs:
   ert:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs:
+          - emacs-29-4
+          - emacs-30-1
 
     steps:
       - uses: actions/checkout@v4
@@ -16,10 +22,10 @@ jobs:
         with:
           github_access_token: ${{ github.token }}
 
-      - name: Install Emacs 29.4
+      - name: Install ${{ matrix.emacs }}
         run: |
           nix profile install --accept-flake-config \
-            github:purcell/nix-emacs-ci/868482a78575138aebb1b5c16a9266b95c800f2e#emacs-29-4
+            github:purcell/nix-emacs-ci/868482a78575138aebb1b5c16a9266b95c800f2e#${{ matrix.emacs }}
           emacs --version
 
       - name: Install Emacs package dependencies
@@ -29,10 +35,13 @@ jobs:
             --eval "(setq package-archives '((\"gnu\" . \"https://elpa.gnu.org/packages/\") (\"nongnu\" . \"https://elpa.nongnu.org/nongnu/\") (\"melpa\" . \"https://melpa.org/packages/\")))" \
             --eval "(package-initialize)" \
             --eval "(package-refresh-contents)" \
-            --eval "(dolist (pkg '(gptel yaml cond-let compat llama with-editor acp shell-maker agent-shell)) (unless (package-installed-p pkg) (package-install pkg)))"
+            --eval "(dolist (pkg '(gptel yaml cond-let compat llama with-editor acp shell-maker agent-shell package-lint)) (unless (package-installed-p pkg) (package-install pkg)))"
 
       - name: Byte-compile
         run: make compile
+
+      - name: Lint
+        run: make lint
 
       - name: Run ERT unit tests
         run: make test-unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,14 @@ jobs:
 
       - name: Install Emacs package dependencies
         run: |
+          # Install Transient's macro providers before packages that pull it in.
+          # Emacs 30 can otherwise byte-compile Transient before these are active.
           emacs -Q --batch \
             --eval "(require 'package)" \
             --eval "(setq package-archives '((\"gnu\" . \"https://elpa.gnu.org/packages/\") (\"nongnu\" . \"https://elpa.nongnu.org/nongnu/\") (\"melpa\" . \"https://melpa.org/packages/\")))" \
             --eval "(package-initialize)" \
             --eval "(package-refresh-contents)" \
-            --eval "(dolist (pkg '(gptel yaml cond-let compat llama with-editor acp shell-maker agent-shell package-lint)) (unless (package-installed-p pkg) (package-install pkg)))"
+            --eval "(dolist (pkg '(compat cond-let llama gptel yaml with-editor acp shell-maker agent-shell package-lint)) (unless (package-installed-p pkg) (package-install pkg)))"
 
       - name: Byte-compile
         run: make compile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ See `docs/AGENT_JOBS.org` and `docs/AGENT_WORKFLOW.org` for child-agent lifecycl
 
 ```bash
 make compile    # Byte-compile all Elisp files
+make lint       # Validate declarations and package metadata
 make test-unit  # Run ERT unit tests in batch mode
 make test       # Run unit tests plus deterministic live smoke tests
 make coverage   # Run ERT under testcover and write coverage/testcover-summary.tsv
@@ -22,7 +23,7 @@ make clean      # Remove build files and Harbor benchmark containers/networks
 make purge      # Also remove benchmark Docker images and Harbor task cache
 ```
 
-The Makefile auto-detects dependency paths (`gptel`, `acp`, `shell-maker`, `agent-shell`, `cond-let`, `compat`, `yaml`, `llama`, `with-editor`) by scanning `~/.emacs.d/elpa/`. Override any with e.g. `GPTEL_DIR=/path/to/gptel`.
+The Makefile auto-detects dependency paths (`gptel`, `acp`, `shell-maker`, `agent-shell`, `cond-let`, `compat`, `yaml`, `llama`, `with-editor`, `package-lint`) by scanning `~/.emacs.d/elpa/`. Override any with e.g. `GPTEL_DIR=/path/to/gptel`.
 
 Single-file compilation:
 ```bash
@@ -52,9 +53,9 @@ emacs -Q --batch -L lisp -L $(find ~/.emacs.d/elpa -maxdepth 1 -name 'gptel-*' -
 ### GitHub Actions
 
 CI is defined under `.github/workflows/`:
-- `test.yml`: installs Emacs 29.4 via Nix, installs package dependencies, runs `make compile`, `make test-unit`, and `make test-live-smoke` in a temporary daemon.
+- `test.yml`: tests Emacs 29.4 and 30.1 via Nix, installs package dependencies, runs `make compile`, `make lint`, `make test-unit`, and `make test-live-smoke` in a temporary daemon.
 - `coverage.yml`: runs `make coverage` and uploads `coverage/testcover-summary.tsv`.
-- `melpazoid.yml`: runs MELPA-style package checks. Its recipe explicitly includes `lisp/*.el`, `prompts/`, `skills/`, and `capabilities/`, because Magent depends on those production libraries and bundled data at runtime. Keep the explicit library and runtime-data entries aligned with the package source manifest.
+- `melpazoid.yml`: runs MELPA-style package checks. Its recipe explicitly includes `lisp/magent*.el`, `prompts/`, `skills/`, and `capabilities/`, because Magent depends on those production libraries and bundled data at runtime. Keep the explicit library and runtime-data entries aligned with the package source manifest.
 
 Package metadata should stay centralized in `magent.el` and `magent-pkg.el`; non-main modules should not carry `Package-Requires` headers. Keep SPDX license identifiers in every Elisp source file so melpazoid can detect licensing consistently.
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ COMPAT_DIR ?= $(call elpa-package-dir,compat-*)
 YAML_DIR ?= $(call elpa-package-dir,yaml-[0-9]*)
 LLAMA_DIR ?= $(call elpa-package-dir,llama-*)
 WITH_EDITOR_DIR ?= $(call elpa-package-dir,with-editor-*)
+PACKAGE_LINT_DIR ?= $(call elpa-package-dir,package-lint-[0-9]*)
 
 LOADPATH = -L lisp \
 	$(if $(GPTEL_DIR),-L "$(GPTEL_DIR)") \
@@ -39,6 +40,8 @@ LOADPATH = -L lisp \
 	$(if $(LLAMA_DIR),-L "$(LLAMA_DIR)") \
 	$(if $(WITH_EDITOR_DIR),-L "$(WITH_EDITOR_DIR)")
 
+PACKAGE_LINT_LOADPATH = $(if $(PACKAGE_LINT_DIR),-L "$(PACKAGE_LINT_DIR)")
+
 # Compilation flags
 BYTE_COMPILE_FLAGS = --eval "(setq byte-compile-error-on-warn nil)" \
 	--eval "(setq byte-compile-warnings '(not cl-functions))"
@@ -47,7 +50,7 @@ SRCS = $(shell sed -e '/^[[:space:]]*\#/d' -e '/^[[:space:]]*$$/d' "$(SOURCE_MAN
 
 COMPILED = $(SRCS:.el=.elc)
 
-.PHONY: all compile clean purge test test-unit test-benchmark test-live test-live-smoke coverage help \
+.PHONY: all compile lint check-declare package-lint clean purge test test-unit test-benchmark test-live test-live-smoke coverage help \
 	benchmark benchmark-prepare benchmark-run benchmark-test
 
 all: compile
@@ -58,6 +61,9 @@ help:
 	@echo "Development targets:"
 	@echo "  make          - Default; same as make compile"
 	@echo "  compile       - Byte compile all Elisp files"
+	@echo "  lint          - Validate declarations and package metadata"
+	@echo "  check-declare - Validate declarations in production Elisp files"
+	@echo "  package-lint  - Run package-lint with warnings treated as failures"
 	@echo "  clean         - Remove build files and Harbor trial containers/networks"
 	@echo "  purge         - Clean plus benchmark Docker images and Harbor task cache"
 	@echo "  help          - Show this help message"
@@ -78,6 +84,21 @@ help:
 
 compile: $(COMPILED)
 	@echo "Compilation complete: $(words $(COMPILED)) files"
+
+lint: check-declare package-lint
+
+check-declare:
+	@echo "Checking declarations..."
+	@$(EMACS_BATCH) $(LOADPATH) \
+		-l check-declare \
+		--eval '(when (check-declare-directory "lisp") (kill-emacs 1))'
+
+package-lint:
+	@echo "Running package-lint..."
+	@$(EMACS_BATCH) $(PACKAGE_LINT_LOADPATH) \
+		-l package-lint \
+		--eval '(setq package-lint-main-file (expand-file-name "lisp/magent.el") package-lint-batch-fail-on-warnings t)' \
+		-f package-lint-batch-and-exit $(SRCS)
 
 lisp/%.elc: lisp/%.el
 	@echo "Compiling $<..."

--- a/README.org
+++ b/README.org
@@ -63,7 +63,7 @@ input or selected with ~M-x magent-agent-shell-run-command~.  The complete
 - [[https://elpa.gnu.org/packages/compat.html][compat]] 30.1+
 - [[https://elpa.gnu.org/packages/yaml.html][yaml]] 1.0+
 - acp 0.13.1+
-- agent-shell 0.62.1+
+- agent-shell 0.66.1+
 - [[https://github.com/BurntSushi/ripgrep][ripgrep]] (for the ~grep~ tool)
 
 * Installation

--- a/docs/CONTRIBUTING.org
+++ b/docs/CONTRIBUTING.org
@@ -21,14 +21,16 @@ sandboxing, seatbelt, bubblewrap, and shell isolation parity are out of scope.
 - gptel 0.9.8+
 - compat 30.1+
 - yaml 1.0+
-- acp 0.12.2+
-- agent-shell 0.57.1+
+- acp 0.13.1+
+- agent-shell 0.66.1+
+- package-lint (development only)
 - ripgrep (for grep tool)
 
 ** Building
 
 #+begin_src bash
 make compile    # Byte-compile all files
+make lint       # Validate declarations and package metadata
 make test-unit  # Run batch ERT unit tests
 make test       # Run unit tests plus deterministic live smoke tests
 make coverage   # Run ERT under built-in testcover
@@ -122,15 +124,16 @@ headers, request bodies, or API-key material.
 
 GitHub Actions runs:
 
-- ~test.yml~: Emacs 29.4 installation, dependency installation, byte-compile,
-  unit tests, and deterministic live smoke tests in a temporary daemon.
+- ~test.yml~: Emacs 29.4 and 30.1 installation, dependency installation,
+  byte-compile, declaration/package lint, unit tests, and deterministic live
+  smoke tests in a temporary daemon.
 - ~coverage.yml~: ~make coverage~, uploading ~coverage/testcover-summary.tsv~.
 - ~melpazoid.yml~: MELPA-style package checks.
 
-The melpazoid recipe explicitly includes ~lisp/*.el~, ~prompts/~, ~skills/~,
-and ~capabilities/~. Those production libraries and bundled runtime data must
-stay in the package recipe because Magent resolves them at runtime. Keep the
-recipe aligned with ~source-files.txt~ and ~prompts/manifest.txt~.
+The melpazoid recipe explicitly includes ~lisp/magent*.el~, ~prompts/~,
+~skills/~, and ~capabilities/~. Those production libraries and bundled runtime
+data must stay in the package recipe because Magent resolves them at runtime.
+Keep the recipe aligned with ~source-files.txt~ and ~prompts/manifest.txt~.
 
 Keep package metadata centralized in ~magent.el~ and ~magent-pkg.el~. Do not
 add ~Package-Requires~ headers to secondary modules; package-lint treats those

--- a/docs/CONTRIBUTING.zh.org
+++ b/docs/CONTRIBUTING.zh.org
@@ -22,14 +22,16 @@ shell isolation parity 不在范围内。
 - gptel 0.9.8+
 - compat 30.1+
 - yaml 1.0+
-- acp 0.12.2+
-- agent-shell 0.57.1+
+- acp 0.13.1+
+- agent-shell 0.66.1+
+- package-lint（仅开发时需要）
 - ripgrep，用于 ~grep~ tool
 
 ** 构建
 
 #+begin_src bash
 make compile    # Byte-compile all files
+make lint       # 检查声明和 package metadata
 make test-unit  # Run batch ERT unit tests
 make test       # Run unit tests plus deterministic live smoke tests
 make coverage   # Run ERT under built-in testcover
@@ -126,11 +128,11 @@ emacsclient --eval '(setq debug-on-error t)'
 
 GitHub Actions 运行：
 
-- ~test.yml~ ：安装 Emacs 29.4、安装依赖、byte-compile、unit tests、在临时 daemon 中跑 deterministic live smoke tests。
+- ~test.yml~ ：分别安装 Emacs 29.4 和 30.1、安装依赖、执行 byte-compile、声明/package lint、unit tests，并在临时 daemon 中跑 deterministic live smoke tests。
 - ~coverage.yml~ ：运行 ~make coverage~ 并上传 ~coverage/testcover-summary.tsv~ 。
 - ~melpazoid.yml~ ：运行 MELPA-style package checks。
 
-melpazoid recipe 显式包含 ~lisp/*.el~、~prompts/~、~skills/~ 和 ~capabilities/~。这些 production libraries 和 bundled runtime data 必须保留，因为 Magent 会在运行时解析它们。Recipe 应与 ~source-files.txt~ 和 ~prompts/manifest.txt~ 保持一致。
+melpazoid recipe 显式包含 ~lisp/magent*.el~、~prompts/~、~skills/~ 和 ~capabilities/~。这些 production libraries 和 bundled runtime data 必须保留，因为 Magent 会在运行时解析它们。Recipe 应与 ~source-files.txt~ 和 ~prompts/manifest.txt~ 保持一致。
 
 Package metadata 保持集中在 ~magent.el~ 和 ~magent-pkg.el~ 。不要在 secondary modules 中添加 ~Package-Requires~ headers；package-lint 会把 main file 之外的这些 headers 视为 ineffective。每个 Elisp 文件都应包含 SPDX license identifier。
 

--- a/docs/TROUBLESHOOTING.org
+++ b/docs/TROUBLESHOOTING.org
@@ -30,7 +30,7 @@ shape:
 
 #+begin_src elisp
 (magent :fetcher github :repo "Jamie-Cui/magent"
-        :files ("lisp/*.el" "prompts" "skills" "capabilities"))
+        :files ("lisp/magent*.el" "prompts" "skills" "capabilities"))
 #+end_src
 
 The explicit glob supplies every production Elisp file. The explicit

--- a/docs/TROUBLESHOOTING.zh.org
+++ b/docs/TROUBLESHOOTING.zh.org
@@ -28,7 +28,7 @@ Opening input file: No such file or directory, /workspace/pkg/prompts/system.org
 
 #+begin_src elisp
 (magent :fetcher github :repo "Jamie-Cui/magent"
-        :files ("lisp/*.el" "prompts" "skills" "capabilities"))
+        :files ("lisp/magent*.el" "prompts" "skills" "capabilities"))
 #+end_src
 
 显式 glob 提供全部 production Elisp files；显式目录提供 package 通过相对路径加载的 runtime data。ERT 源码应放在 ~test/~ 下，使其不进入 production package；recipe 应与 ~source-files.txt~ 和 ~prompts/manifest.txt~ 保持一致。

--- a/lisp/magent-action-builtins.el
+++ b/lisp/magent-action-builtins.el
@@ -3,6 +3,10 @@
 ;; Copyright (C) 2026 Jamie Cui
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 
+;;; Commentary:
+
+;; Register the bundled prompt actions and compose the built-in Action layers.
+
 ;;; Code:
 
 (require 'magent-action)

--- a/lisp/magent-action-controls.el
+++ b/lisp/magent-action-controls.el
@@ -3,6 +3,10 @@
 ;; Copyright (C) 2026 Jamie Cui
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 
+;;; Commentary:
+
+;; Define the built-in controls for the current Magent conversation.
+
 ;;; Code:
 
 (require 'magent-action)

--- a/lisp/magent-agent-shell.el
+++ b/lisp/magent-agent-shell.el
@@ -35,14 +35,14 @@
 (declare-function magent--ensure-initialized "magent")
 (declare-function agent-shell--display-buffer "agent-shell")
 (declare-function agent-shell--dwim "agent-shell")
-(declare-function agent-shell--process-pending-request "agent-shell")
 (declare-function agent-shell--send-command "agent-shell")
 (declare-function agent-shell-cwd "agent-shell-project")
 (declare-function agent-shell-status "agent-shell")
 (declare-function agent-shell-interrupt "agent-shell")
 (declare-function agent-shell-insert "agent-shell")
 (declare-function agent-shell-make-agent-config "agent-shell")
-(declare-function agent-shell-queue-request "agent-shell")
+(declare-function agent-shell-prompt-queue "agent-shell-prompt-queue")
+(declare-function agent-shell-prompt-queue-resume "agent-shell-prompt-queue")
 (declare-function agent-shell-start "agent-shell")
 (declare-function shell-maker-busy "shell-maker")
 
@@ -393,8 +393,8 @@ after clearing the stale state."
     (magent-log "WARN recovered stale agent-shell busy state in %s"
                 (buffer-name))
     (when (and process-pending
-               (map-elt agent-shell--state :pending-requests))
-      (agent-shell--process-pending-request))
+               (map-elt agent-shell--state :pending-prompts))
+      (agent-shell-prompt-queue-resume))
     t))
 
 ;;;###autoload
@@ -431,7 +431,7 @@ after clearing the stale state."
       (if (with-current-buffer shell-buffer
             (shell-maker-busy))
           (with-current-buffer shell-buffer
-            (agent-shell-queue-request prompt))
+            (agent-shell-prompt-queue prompt))
         (agent-shell-insert :text prompt
                             :submit t
                             :no-focus no-focus

--- a/lisp/magent-capability.el
+++ b/lisp/magent-capability.el
@@ -141,7 +141,7 @@ so project overlays can be removed without rebuilding static registries.")
 (defconst magent-capability--builtin-dir
   (let ((dir (file-name-directory (or load-file-name buffer-file-name))))
     ;; In the git repo sources are under lisp/ and capabilities/ is at
-    ;; the root (one level up); after MELPA install lisp/*.el is
+    ;; the root (one level up); after MELPA install lisp/magent*.el is
     ;; flattened to the top level.  Try sibling first, then parent.
     (or (let ((d (expand-file-name "capabilities" dir)))
           (and (file-directory-p d) d))

--- a/lisp/magent-doctor.el
+++ b/lisp/magent-doctor.el
@@ -28,7 +28,7 @@
 
 (declare-function flymake-diagnostic-beg "flymake" t t)
 (declare-function flymake-diagnostic-end "flymake" t t)
-(declare-function flymake-diagnostic-text "ext:flymake")
+(declare-function flymake-diagnostic-text "flymake" t t)
 (declare-function flymake-diagnostic-type "flymake" t t)
 (declare-function flymake-diagnostics "flymake")
 (declare-function flycheck-error-filename "ext:flycheck" t t)

--- a/lisp/magent-doctor.el
+++ b/lisp/magent-doctor.el
@@ -28,7 +28,7 @@
 
 (declare-function flymake-diagnostic-beg "flymake" t t)
 (declare-function flymake-diagnostic-end "flymake" t t)
-(declare-function flymake-diagnostic-text "flymake")
+(declare-function flymake-diagnostic-text "ext:flymake")
 (declare-function flymake-diagnostic-type "flymake" t t)
 (declare-function flymake-diagnostics "flymake")
 (declare-function flycheck-error-filename "ext:flycheck" t t)

--- a/lisp/magent-llm-gptel.el
+++ b/lisp/magent-llm-gptel.el
@@ -39,7 +39,6 @@
 (defvar gptel-include-reasoning)
 (defvar gptel-temperature)
 (defvar gptel-proxy)
-(defvar gptel--request-params)
 (defvar magent-include-reasoning)
 
 (defun magent-llm-gptel--managed-context-p (context)

--- a/lisp/magent-skills.el
+++ b/lisp/magent-skills.el
@@ -450,7 +450,7 @@ If SKILL-NAMES is a list, only include those skills."
 (defconst magent-skills--builtin-dir
   (let ((dir (file-name-directory (or load-file-name buffer-file-name))))
     ;; In the git repo sources are under lisp/ and skills/ is at the
-    ;; root (one level up); after MELPA install lisp/*.el is flattened
+    ;; root (one level up); after MELPA install lisp/magent*.el is flattened
     ;; to the top level.  Try sibling first, then parent.
     (or (let ((d (expand-file-name "skills" dir)))
           (and (file-directory-p d) d))

--- a/lisp/magent.el
+++ b/lisp/magent.el
@@ -8,7 +8,7 @@
 ;; Maintainer: Jamie Cui <jamie.cui@outlook.com>
 ;; Keywords: tools, ai, copilot
 ;; Package-Version: 0.1.0
-;; Package-Requires: ((emacs "29.1") (gptel "0.9.8") (yaml "1.0.0") (compat "30.1.0.0") (acp "0.13.1") (agent-shell "0.62.1"))
+;; Package-Requires: ((emacs "29.1") (gptel "0.9.8") (yaml "1.0.0") (compat "30.1.0.0") (acp "0.13.1") (agent-shell "0.66.1"))
 ;; URL: https://github.com/jamie-cui/magent
 
 ;; This file is not part of GNU Emacs.
@@ -72,7 +72,7 @@
 ;;; Code:
 
 ;; Ensure the lisp/ directory is on load-path so sibling modules are
-;; found.  When installed via package.el (MELPA flattens lisp/*.el to
+;; found.  When installed via package.el (MELPA flattens lisp/magent*.el to
 ;; the top level), this is a harmless no-op since the package root is
 ;; already on load-path.
 (eval-and-compile

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -92,6 +92,42 @@
                (length (delete-dups (copy-sequence manifest)))))
     (should (equal sorted-manifest (sort actual #'string<)))))
 
+(ert-deftest magent-test-production-elisp-has-commentary-sections ()
+  "Test every production Elisp module has a Commentary section."
+  (dolist (relative-file
+           (magent-test-source-files magent-test--root-directory))
+    (with-temp-buffer
+      (insert-file-contents
+       (expand-file-name relative-file magent-test--root-directory))
+      (should (re-search-forward "^;;; Commentary:$" nil t)))))
+
+(ert-deftest magent-test-production-elisp-declarations-are-valid ()
+  "Test declarations in every production Elisp module resolve."
+  (require 'check-declare)
+  (dolist (relative-file
+           (magent-test-source-files magent-test--root-directory))
+    (should-not
+     (check-declare-file
+      (expand-file-name relative-file magent-test--root-directory)))))
+
+(ert-deftest magent-test-gptel-adapter-does-not-declare-private-state ()
+  "Test the gptel adapter does not hide private variable API changes."
+  (let ((adapter-file
+         (expand-file-name "lisp/magent-llm-gptel.el"
+                           magent-test--root-directory))
+        declarations)
+    (with-temp-buffer
+      (insert-file-contents adapter-file)
+      (goto-char (point-min))
+      (condition-case nil
+          (while t
+            (pcase (read (current-buffer))
+              (`(defvar ,(and variable (pred symbolp)) . ,_)
+               (when (string-prefix-p "gptel--" (symbol-name variable))
+                 (push variable declarations)))))
+        (end-of-file nil)))
+    (should-not declarations)))
+
 (ert-deftest magent-test-melpazoid-recipe-packages-production-libraries ()
   "Test the MELPA recipe includes all production libraries and runtime data."
   (let ((workflow (expand-file-name ".github/workflows/melpazoid.yml"
@@ -104,7 +140,7 @@
       (setq recipe (read (match-string 1))))
     (should
      (equal (plist-get (cdr recipe) :files)
-            '("lisp/*.el" "prompts" "skills" "capabilities")))
+            '("lisp/magent*.el" "prompts" "skills" "capabilities")))
     (should (member "lisp/magent-action-builtins.el"
                     (magent-test-source-files
                      magent-test--root-directory)))))
@@ -120,7 +156,7 @@
        (re-search-forward "^;; Package-Requires: \\(.*\\)$" nil t))
       (setq requirements (read (match-string 1))))
     (should (version<= "0.13.1" (cadr (assq 'acp requirements))))
-    (should (version<= "0.62.1" (cadr (assq 'agent-shell requirements))))))
+    (should (version<= "0.66.1" (cadr (assq 'agent-shell requirements))))))
 
 (defconst magent-test--builtin-slash-command-names
   '("explain" "fix" "init" "review" "summarize" "test")
@@ -12205,13 +12241,15 @@
                         '((:agent-config . ((:identifier . magent))))))
           (cl-letf (((symbol-function 'magent-runtime-ensure-initialized)
                      #'ignore)
+                    ((symbol-function 'magent-agent-shell-ensure-config)
+                     (lambda () 'magent))
                     ((symbol-function 'magent-agent-shell--buffer)
                      (lambda (&optional _no-create) buffer))
                     ((symbol-function 'magent-agent-shell--recover-stale-busy)
                      #'ignore)
                     ((symbol-function 'shell-maker-busy)
                      (lambda () t))
-                    ((symbol-function 'agent-shell-queue-request)
+                    ((symbol-function 'agent-shell-prompt-queue)
                      (lambda (prompt)
                        (setq queued prompt))))
             (magent-agent-shell-send-prompt
@@ -12991,9 +13029,11 @@
                           (:session . ((:id . "session-1")))
                           (:active-requests . nil)
                           (:pending-restore . nil)
-                          (:pending-requests . nil))))
+                          (:pending-prompts . nil))))
           (cl-letf (((symbol-function 'magent-runtime-ensure-initialized)
                      #'ignore)
+                    ((symbol-function 'magent-agent-shell-ensure-config)
+                     (lambda () 'magent))
                     ((symbol-function 'magent-agent-shell--buffer)
                      (lambda (&optional _no-create) buffer))
                     ((symbol-function 'shell-maker-busy)
@@ -13001,7 +13041,7 @@
                     ((symbol-function 'agent-shell-insert)
                      (lambda (&rest args)
                        (setq inserted args)))
-                    ((symbol-function 'agent-shell-queue-request)
+                    ((symbol-function 'agent-shell-prompt-queue)
                      (lambda (prompt)
                        (setq queued prompt))))
             (magent-agent-shell-send-prompt "hello" :no-focus t))
@@ -13014,6 +13054,22 @@
           (should (eq (plist-get inserted :shell-buffer) buffer)))
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
+
+(ert-deftest magent-test-agent-shell-stale-recovery-resumes-prompt-queue ()
+  "Test stale recovery resumes pending prompts through the public queue API."
+  (require 'magent-agent-shell)
+  (with-temp-buffer
+    (setq-local shell-maker--busy t)
+    (setq-local agent-shell--state '((:pending-prompts . ("queued"))))
+    (let (resumed)
+      (cl-letf (((symbol-function 'magent-agent-shell--stale-busy-p)
+                 (lambda () t))
+                ((symbol-function 'agent-shell-prompt-queue-resume)
+                 (lambda ()
+                   (setq resumed t))))
+        (should (magent-agent-shell--recover-stale-busy t)))
+      (should-not shell-maker--busy)
+      (should resumed))))
 
 (ert-deftest magent-test-agent-shell-send-queues-real-busy ()
   "Test prompt dispatch keeps using agent-shell queue for live work."
@@ -13037,9 +13093,11 @@
                           (:session . ((:id . "session-1")))
                           (:active-requests . (((:method . "session/prompt"))))
                           (:pending-restore . nil)
-                          (:pending-requests . nil))))
+                          (:pending-prompts . nil))))
           (cl-letf (((symbol-function 'magent-runtime-ensure-initialized)
                      #'ignore)
+                    ((symbol-function 'magent-agent-shell-ensure-config)
+                     (lambda () 'magent))
                     ((symbol-function 'magent-agent-shell--buffer)
                      (lambda (&optional _no-create) buffer))
                     ((symbol-function 'shell-maker-busy)
@@ -13047,7 +13105,7 @@
                     ((symbol-function 'agent-shell-insert)
                      (lambda (&rest args)
                        (setq inserted args)))
-                    ((symbol-function 'agent-shell-queue-request)
+                    ((symbol-function 'agent-shell-prompt-queue)
                      (lambda (prompt)
                        (setq queued prompt))))
             (magent-agent-shell-send-prompt "hello" :no-focus t))
@@ -13081,7 +13139,7 @@
                           (:session . ((:id . "session-1")))
                           (:active-requests . nil)
                           (:pending-restore . nil)
-                          (:pending-requests . nil))))
+                          (:pending-prompts . nil))))
           (should-not (magent-agent-shell-processing-p)))
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))


### PR DESCRIPTION
## Summary

- update Magent for agent-shell 0.66.1 prompt queue APIs and correct declaration metadata
- align the MELPA recipe, Commentary sections, dependency metadata, and documentation with review feedback
- add strict declaration and package linting on Emacs 29.4 and 30.1 with focused regression coverage

## Validation

- force-compiled 43 production Elisp files
- passed strict check-declare and package-lint
- passed 567 ERT tests
- passed isolated live smoke tests