### PR TITLE
fix(tools): refresh clean stale buffers before edit_file updates

### DIFF
--- a/README.org
+++ b/README.org
@@ -423,7 +423,7 @@ The AI agent has access to these tools (can be customized per agent):
 | ~read_buffer~        | no          | Read an existing file-visiting buffer, including edits  |
 | ~write_file~         | yes         | Atomically write a file; rejects dirty buffer conflicts |
 | ~write_repo_summary~ | yes         | Update the canonical single-file Org repository summary |
-| ~edit_file~          | yes         | Atomically replace unique text; rejects dirty conflicts |
+| ~edit_file~          | yes         | Atomically replace unique text; refreshes clean stale buffers and rejects dirty conflicts |
 | ~grep~               | no          | Regex search via ripgrep; returns ~file:line:content~     |
 | ~glob~               | no          | Bounded, event-loop-sliced glob traversal               |
 | ~bash~               | yes         | Execute shell commands (default timeout 300s)           |

--- a/lisp/magent-tools.el
+++ b/lisp/magent-tools.el
@@ -269,18 +269,26 @@ buffer contents and state metadata or an error message."
       (format "Error reading buffer: %s"
               (error-message-string err))))))
 
-(defun magent-tools--clean-visiting-buffer (path)
+(defun magent-tools--clean-visiting-buffer (path &optional refresh-stale)
   "Return the clean file-visiting buffer for PATH, or nil.
 Signal a conflict when the visiting buffer is modified or its file changed on
-disk since it was visited."
+disk since it was visited.  When REFRESH-STALE is non-nil, refresh a clean
+stale buffer from disk without running revert hooks or reinitializing modes."
   (when-let* ((buffer (find-buffer-visiting path)))
     (with-current-buffer buffer
       (when (buffer-modified-p)
         (error "buffer_conflict: visiting buffer %S has unsaved changes"
                (buffer-name buffer)))
       (unless (verify-visited-file-modtime buffer)
-        (error "disk_conflict: %s changed on disk since buffer %S visited it"
-               path (buffer-name buffer))))
+        (if refresh-stale
+            (let ((before-revert-hook nil)
+                  (after-revert-hook nil))
+              (revert-buffer t t t)
+              (unless (verify-visited-file-modtime buffer)
+                (error "disk_conflict: %s changed while refreshing buffer %S"
+                       path (buffer-name buffer))))
+          (error "disk_conflict: %s changed on disk since buffer %S visited it"
+                 path (buffer-name buffer)))))
     buffer))
 
 (defun magent-tools--atomic-write-string (path content &optional coding-system)
@@ -644,8 +652,8 @@ and bounded by `magent-glob-max-results' and
 (defun magent-tools--edit-file (callback path old-text new-text)
   "Edit file at PATH by replacing OLD-TEXT with NEW-TEXT asynchronously.
 OLD-TEXT must match exactly once in the file.  Rejects a modified visiting
-buffer; updates and saves a clean visiting buffer so Emacs and disk remain
-synchronized.
+buffer; refreshes a clean stale buffer without revert hooks, then updates and
+saves it so Emacs and disk remain synchronized.
 CALLBACK is called with success message or error."
   (condition-case err
       (progn
@@ -654,7 +662,7 @@ CALLBACK is called with success message or error."
         (unless (stringp new-text)
           (error "new_text must be a string"))
         (let ((path (magent-tools--resolve-path path)))
-          (if-let* ((buffer (magent-tools--clean-visiting-buffer path)))
+          (if-let* ((buffer (magent-tools--clean-visiting-buffer path t)))
               (with-current-buffer buffer
                 (save-excursion
                   (atomic-change-group
@@ -1784,7 +1792,7 @@ See `magent-agent-loop-filter-display-args'.")
 (defvar magent-tools--edit-file-tool
   (gptel-make-tool
    :name "edit_file"
-   :description "Edit a file by replacing an exact text match using atomic disk replacement. The old_text must appear exactly once. If Emacs has a clean visiting buffer, updates and saves that buffer; fails with buffer_conflict instead of overwriting unsaved buffer edits. Use this for precise, surgical edits instead of rewriting entire files."
+   :description "Edit a file by replacing an exact text match using atomic disk replacement. The old_text must appear exactly once. If Emacs has a clean visiting buffer, refreshes stale disk contents without revert hooks, then updates and saves that buffer; fails with buffer_conflict instead of overwriting unsaved buffer edits. Use this for precise, surgical edits instead of rewriting entire files."
    :args (list '(:name "path"
                        :type string
                        :description "Absolute or relative path to the file")
@@ -1855,7 +1863,7 @@ See `magent-agent-loop-filter-display-args'.")
 (defvar magent-tools--emacs-eval-tool
   (gptel-make-tool
    :name "emacs_eval"
-   :description "Evaluate an Emacs Lisp expression. Returns the result as a string. Use for buffer inspection, Emacs state queries, running compilation, navigating code with xref, etc. When you need multiple pieces of Emacs state, batch them in a single call using (let ...) or (list ...) rather than making separate calls — but only after you have gathered enough context to know what you need."
+   :description "Evaluate an Emacs Lisp expression. Returns the result as a string. Use for buffer inspection, Emacs state queries, running compilation, navigating code with xref, etc. Do not use this tool to revert or synchronize a file-visiting buffer after edit_file reports a conflict: edit_file refreshes clean stale buffers itself and preserves dirty buffers. When you need multiple pieces of Emacs state, batch them in a single call using (let ...) or (list ...) rather than making separate calls — but only after you have gathered enough context to know what you need."
    :args (list '(:name "sexp"
                        :type string
                        :description "Emacs Lisp s-expression to evaluate")

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -6961,6 +6961,37 @@
         (kill-buffer buffer))
       (delete-file tmpfile))))
 
+(ert-deftest magent-test-tools-write-file-rejects-clean-stale-visiting-buffer ()
+  "Test write_file does not overwrite a disk change behind a clean buffer."
+  (require 'magent-tools)
+  (let* ((tmpfile (make-temp-file "magent-write-stale-"))
+         (buffer nil)
+         result)
+    (unwind-protect
+        (progn
+          (with-temp-file tmpfile
+            (insert "old buffer text"))
+          (setq buffer (find-file-noselect tmpfile t))
+          (with-temp-file tmpfile
+            (insert "new disk text"))
+          (with-current-buffer buffer
+            (set-visited-file-modtime (seconds-to-time 0)))
+          (magent-tools--write-file
+           (lambda (value) (setq result (magent-test-tool-output value)))
+           tmpfile "replacement")
+          (should (string-match-p "disk_conflict" result))
+          (should
+           (equal (with-temp-buffer
+                    (insert-file-contents tmpfile)
+                    (buffer-string))
+                  "new disk text"))
+          (with-current-buffer buffer
+            (should (equal (buffer-string) "old buffer text"))
+            (should-not (buffer-modified-p))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer))
+      (delete-file tmpfile))))
+
 (ert-deftest magent-test-tools-edit-file ()
   "Test edit_file tool implementation."
   (require 'magent-tools)
@@ -7062,6 +7093,49 @@
                     (insert-file-contents tmpfile)
                     (buffer-string))
                   "goodbye world")))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer))
+      (delete-file tmpfile))))
+
+(ert-deftest magent-test-tools-edit-file-refreshes-clean-stale-buffer ()
+  "Test edit_file safely refreshes a clean buffer after a disk change."
+  (require 'magent-tools)
+  (let* ((tmpfile (make-temp-file "magent-edit-stale-"))
+         (buffer nil)
+         major-mode-before
+         before-revert-ran
+         after-revert-ran
+         result)
+    (unwind-protect
+        (progn
+          (with-temp-file tmpfile
+            (insert "hello old"))
+          (setq buffer (find-file-noselect tmpfile t))
+          (with-temp-file tmpfile
+            (insert "hello changed on disk"))
+          (with-current-buffer buffer
+            (setq major-mode-before major-mode)
+            (set-visited-file-modtime (seconds-to-time 0))
+            (add-hook 'before-revert-hook
+                      (lambda () (setq before-revert-ran t)) nil t)
+            (add-hook 'after-revert-hook
+                      (lambda () (setq after-revert-ran t)) nil t))
+          (magent-tools--edit-file
+           (lambda (value) (setq result (magent-test-tool-output value)))
+           tmpfile "changed" "updated")
+          (should (string-match-p "Successfully" result))
+          (should-not before-revert-ran)
+          (should-not after-revert-ran)
+          (with-current-buffer buffer
+            (should (equal (buffer-string) "hello updated on disk"))
+            (should (eq major-mode major-mode-before))
+            (should-not (buffer-modified-p))
+            (should (verify-visited-file-modtime buffer)))
+          (should
+           (equal (with-temp-buffer
+                    (insert-file-contents tmpfile)
+                    (buffer-string))
+                  "hello updated on disk")))
       (when (buffer-live-p buffer)
         (kill-buffer buffer))
       (delete-file tmpfile))))


### PR DESCRIPTION
## Summary

- Refresh clean stale file-visiting buffers before edit_file updates without running revert hooks or reinitializing modes.
- Preserve dirty-buffer protection and conservative write_file disk-conflict behavior.
- Add regression coverage and document the updated tool behavior.

## Validation

- make compile
- make test-unit: 569 passed
- make test-live-smoke