### PR TITLE
fix(agent-shell): avoid TRAMP I/O while building context

### DIFF
--- a/lisp/magent-agent-shell.el
+++ b/lisp/magent-agent-shell.el
@@ -314,6 +314,27 @@ Return non-nil when SKILL-NAME is selected after toggling."
     (line-beginning-position)
     (line-end-position))))
 
+(defun magent-agent-shell--get-region-context (orig &rest args)
+  "Build region context through ORIG without remote path queries.
+
+For remote files, agent-shell shortens the file name against
+`:agent-cwd' with `file-in-directory-p'.  That can synchronously query
+TRAMP while agent-shell is starting and deadlock with the in-process
+ACP request.  Keep the full remote file name instead; constructing
+context must not perform remote file I/O."
+  (let ((agent-cwd (plist-get args :agent-cwd)))
+    (when (or (and (stringp buffer-file-name)
+                   (file-remote-p buffer-file-name))
+              (and (stringp agent-cwd)
+                   (file-remote-p agent-cwd)))
+      (setq args (plist-put (copy-sequence args) :agent-cwd nil))))
+  (apply orig args))
+
+(unless (advice-member-p #'magent-agent-shell--get-region-context
+                         'agent-shell--get-region-context)
+  (advice-add 'agent-shell--get-region-context :around
+              #'magent-agent-shell--get-region-context))
+
 (defun magent-agent-shell--get-current-line-context (orig &rest args)
   "Suppress empty current-line context before delegating to ORIG.
 

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -12315,6 +12315,50 @@
         "line-context"))
       (should called))))
 
+(ert-deftest magent-test-agent-shell-remote-line-context-avoids-file-io ()
+  "Test remote current-line context does not query the TRAMP filesystem."
+  (require 'magent-agent-shell)
+  (with-temp-buffer
+    (insert "remote line\n")
+    (goto-char (point-min))
+    (setq buffer-file-name "/ssh:test.invalid:/srv/project/example.el"
+          default-directory "/ssh:test.invalid:/srv/project/")
+    (let (context)
+      (cl-letf (((symbol-function 'file-in-directory-p)
+                 (lambda (&rest _args)
+                   (ert-fail "Remote line context performed file I/O"))))
+        (setq context
+              (agent-shell--get-current-line-context
+               :agent-cwd "/ssh:test.invalid:/srv/project/")))
+      (setq context (substring-no-properties context))
+      (should (string-match-p
+               (regexp-quote buffer-file-name)
+               context))
+      (should (string-match-p "remote line" context)))))
+
+(ert-deftest magent-test-agent-shell-remote-region-context-avoids-file-io ()
+  "Test explicit remote region context does not query the TRAMP filesystem."
+  (require 'magent-agent-shell)
+  (with-temp-buffer
+    (insert "first remote line\nsecond remote line\n")
+    (goto-char (point-min))
+    (push-mark (line-end-position) t t)
+    (setq buffer-file-name "/ssh:test.invalid:/srv/project/example.el"
+          default-directory "/ssh:test.invalid:/srv/project/")
+    (let (context)
+      (cl-letf (((symbol-function 'file-in-directory-p)
+                 (lambda (&rest _args)
+                   (ert-fail "Remote region context performed file I/O"))))
+        (setq context
+              (agent-shell--get-region-context
+               :deactivate t
+               :agent-cwd "/ssh:test.invalid:/srv/project/")))
+      (setq context (substring-no-properties context))
+      (should (string-match-p
+               (regexp-quote buffer-file-name)
+               context))
+      (should (string-match-p "first remote line" context)))))
+
 (ert-deftest magent-test-agent-shell-send-prompt-queues-skills ()
   "Test agent-shell prompt submission records request-local skills."
   (require 'magent-agent-shell)


### PR DESCRIPTION
## Summary

- Avoid synchronous TRAMP filesystem queries while agent-shell builds line and region context.
- Preserve full remote paths and context text for remote buffers.
- Add regression coverage for current-line and explicit-region TRAMP contexts.

## Validation

- make compile
- make lint
- make test-unit (572/572)
- make test-live-smoke
- Live TRAMP magent-start and region-context checks against a real SSH buffer