### PR TITLE
fix: isolate benchmark cleanup, memory files, and shell context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ COVERAGE_MIN ?= 65
 SOURCE_MANIFEST ?= source-files.txt
 BENCHMARK_CONFIG ?= $(abspath benchmark/config.toml)
 HARBOR_CACHE = $(HOME)/.cache/harbor
+MAGENT_BENCHMARK_OWNER ?= $(realpath .)
+MAGENT_BENCHMARK_OWNER_LABEL = io.magent.benchmark.owner
 
 # Auto-detect dependency paths
 elpa-package-dir = $(shell found=; \
@@ -158,7 +160,9 @@ clean:
 	@echo "Cleaning Harbor benchmark containers and networks..."
 	@set -e; \
 	if command -v "$(DOCKER)" >/dev/null 2>&1 && $(DOCKER) info >/dev/null 2>&1; then \
-		$(DOCKER) ps -a --format '{{.ID}} {{.Names}}' | \
+		$(DOCKER) ps -a \
+			--filter "label=$(MAGENT_BENCHMARK_OWNER_LABEL)=$(MAGENT_BENCHMARK_OWNER)" \
+			--format '{{.ID}} {{.Names}}' | \
 		while read -r id name; do \
 			case "$$name" in \
 				*__env-main-1) \
@@ -166,7 +170,9 @@ clean:
 					$(DOCKER) rm -f "$$id" >/dev/null ;; \
 			esac; \
 		done; \
-		$(DOCKER) network ls --format '{{.ID}} {{.Name}}' | \
+		$(DOCKER) network ls \
+			--filter "label=$(MAGENT_BENCHMARK_OWNER_LABEL)=$(MAGENT_BENCHMARK_OWNER)" \
+			--format '{{.ID}} {{.Name}}' | \
 		while read -r id name; do \
 			case "$$name" in \
 				*__env_default) \

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -87,8 +87,10 @@ OpenCode 和 Magent 会在 model step 结束时更新 live token；`seen...` 持
 Public-network task 会忽略 agent provider allowlist，因此 wrapper 只过滤 Harbor
 为此逐 trial 重复产生的良性 warning；其他 warning、最终结果表和报告路径仍会正常输出。
 
-项目根目录的 `make clean` 会停止并删除名称匹配 Harbor trial 约定的 benchmark
-容器和网络，同时删除 Elisp 编译产物及本地可重建环境。`make purge` 还会删除
+项目根目录的 `make clean` 会停止并删除同时带有当前 checkout ownership label、且
+名称匹配 Harbor trial 约定的 benchmark 容器和网络，同时删除 Elisp 编译产物及本地
+可重建环境。未带当前 checkout ownership label 的其他 benchmark job 不会被匹配。
+`make purge` 还会删除
 benchmark Docker 镜像和 `~/.cache/harbor` task cache，之后重跑需要重新下载和构建。
 两个命令都保留 `benchmark/config.toml`、`benchmark/jobs/` 和
 `benchmark/reports/`，也不会调用可能影响其他项目的全局 Docker prune。

--- a/benchmark/docker-compose.owner.yaml
+++ b/benchmark/docker-compose.owner.yaml
@@ -1,0 +1,9 @@
+services:
+  main:
+    labels:
+      io.magent.benchmark.owner: "${MAGENT_BENCHMARK_OWNER}"
+
+networks:
+  default:
+    labels:
+      io.magent.benchmark.owner: "${MAGENT_BENCHMARK_OWNER}"

--- a/benchmark/magent_benchmark/job.py
+++ b/benchmark/magent_benchmark/job.py
@@ -22,6 +22,8 @@ from .profiles import (
 
 
 _LOOPBACK_PROXY_HOSTS = {"127.0.0.1", "localhost", "::1"}
+_OWNER_COMPOSE = Path(__file__).resolve().parents[1] / "docker-compose.owner.yaml"
+_OWNER_VALUE_ENV = "MAGENT_BENCHMARK_OWNER"
 _PROXY_COMPOSE = Path(__file__).resolve().parents[1] / "docker-compose.proxy.yaml"
 _PROXY_VALUE_ENV = "MAGENT_BENCHMARK_CONTAINER_PROXY"
 
@@ -45,6 +47,11 @@ def _container_proxy_url(proxy: str) -> str:
     if port is not None:
         netloc += f":{port}"
     return parsed._replace(netloc=netloc).geturl()
+
+
+def _benchmark_owner() -> str:
+    """Return the canonical checkout root used to label Docker resources."""
+    return str(_OWNER_COMPOSE.resolve().parent.parent)
 
 
 def _agent_config(
@@ -183,18 +190,23 @@ def build_job(
             }
         ],
     }
+    if not _OWNER_COMPOSE.is_file():
+        raise ValueError(f"ownership compose overlay is missing: {_OWNER_COMPOSE}")
+    environment: dict[str, Any] = {
+        "env": {_OWNER_VALUE_ENV: _benchmark_owner()},
+        "extra_docker_compose": [str(_OWNER_COMPOSE)],
+    }
+    job["environment"] = environment
     if proxy:
         container_proxy = _container_proxy_url(proxy)
         if not _PROXY_COMPOSE.is_file():
             raise ValueError(f"proxy compose overlay is missing: {_PROXY_COMPOSE}")
-        job["environment"] = {
-            # Harbor also exposes environment.env to the host-side Compose
-            # process.  Keep the standard proxy names in the Compose overlay
-            # so Docker itself does not try to use a container-only address.
-            "env": {_PROXY_VALUE_ENV: container_proxy},
-            "extra_allowed_hosts": [urlparse(container_proxy).hostname],
-            "extra_docker_compose": [str(_PROXY_COMPOSE)],
-        }
+        # Harbor also exposes environment.env to the host-side Compose
+        # process.  Keep the standard proxy names in the Compose overlay
+        # so Docker itself does not try to use a container-only address.
+        environment["env"][_PROXY_VALUE_ENV] = container_proxy
+        environment["extra_allowed_hosts"] = [urlparse(container_proxy).hostname]
+        environment["extra_docker_compose"].append(str(_PROXY_COMPOSE))
         job["agent_setup_timeout_multiplier"] = 2
     magent = next(agent for agent in job["agents"] if agent.get("import_path"))
     magent.setdefault("kwargs", {}).update(

--- a/benchmark/tests/test_profiles.py
+++ b/benchmark/tests/test_profiles.py
@@ -155,6 +155,15 @@ def test_auto_effort_does_not_inherit_harbor_codex_high_default(
     config, profile, suite = _config(tmp_path)
     job, _ = build_job(config, profile, suite, "model-x", "smoke")
     assert job["agents"][0]["kwargs"]["reasoning_effort"] is None
+    assert job["environment"]["env"] == {
+        "MAGENT_BENCHMARK_OWNER": str(Path(__file__).resolve().parents[2]),
+    }
+    assert job["environment"]["extra_docker_compose"] == [
+        str(Path(__file__).resolve().parents[1] / "docker-compose.owner.yaml")
+    ]
+    assert JobConfig.model_validate(job).environment.env == {
+        "MAGENT_BENCHMARK_OWNER": str(Path(__file__).resolve().parents[2]),
+    }
 
 
 def test_job_proxy_covers_trial_build_and_runtime_without_fingerprinting_secret(
@@ -169,20 +178,29 @@ def test_job_proxy_covers_trial_build_and_runtime_without_fingerprinting_secret(
     environment = job["environment"]
     container_proxy = "http://host.docker.internal:10808"
     assert environment["env"] == {
+        "MAGENT_BENCHMARK_OWNER": str(Path(__file__).resolve().parents[2]),
         "MAGENT_BENCHMARK_CONTAINER_PROXY": container_proxy,
     }
     assert environment["extra_allowed_hosts"] == ["host.docker.internal"]
     assert environment["extra_docker_compose"] == [
+        str(Path(__file__).resolve().parents[1] / "docker-compose.owner.yaml"),
         str(Path(__file__).resolve().parents[1] / "docker-compose.proxy.yaml")
     ]
     assert job["agent_setup_timeout_multiplier"] == 2
     assert "AgentSetupTimeoutError" in job["retry"]["include_exceptions"]
     assert proxy not in str(fingerprint)
     assert JobConfig.model_validate(job).environment.env == {
+        "MAGENT_BENCHMARK_OWNER": str(Path(__file__).resolve().parents[2]),
         "MAGENT_BENCHMARK_CONTAINER_PROXY": container_proxy,
     }
-    overlay = yaml.safe_load(
+    owner_overlay = yaml.safe_load(
         Path(environment["extra_docker_compose"][0]).read_text()
+    )
+    owner_label = {"io.magent.benchmark.owner": "${MAGENT_BENCHMARK_OWNER}"}
+    assert owner_overlay["services"]["main"]["labels"] == owner_label
+    assert owner_overlay["networks"]["default"]["labels"] == owner_label
+    overlay = yaml.safe_load(
+        Path(environment["extra_docker_compose"][1]).read_text()
     )
     proxy_variables = {
         name: "${MAGENT_BENCHMARK_CONTAINER_PROXY}"
@@ -203,9 +221,13 @@ def test_non_loopback_proxy_uses_the_same_compose_overlay(tmp_path: Path) -> Non
     proxy = "http://proxy.example:8080"
     job, _ = build_job(config, profile, suite, "model-x", "smoke", proxy=proxy)
 
-    assert job["environment"]["env"]["MAGENT_BENCHMARK_CONTAINER_PROXY"] == proxy
+    assert job["environment"]["env"] == {
+        "MAGENT_BENCHMARK_OWNER": str(Path(__file__).resolve().parents[2]),
+        "MAGENT_BENCHMARK_CONTAINER_PROXY": proxy,
+    }
     assert job["environment"]["extra_allowed_hosts"] == ["proxy.example"]
     assert job["environment"]["extra_docker_compose"] == [
+        str(Path(__file__).resolve().parents[1] / "docker-compose.owner.yaml"),
         str(Path(__file__).resolve().parents[1] / "docker-compose.proxy.yaml")
     ]
     assert job["agent_setup_timeout_multiplier"] == 2
@@ -322,9 +344,12 @@ def test_config_driven_prepare_writes_single_harbor_job(tmp_path: Path) -> None:
     assert job["jobs_dir"] == str((tmp_path / "jobs").resolve())
     assert job["agents"][0]["model_name"] == "model-x"
     assert job["agents"][0]["env"]["OPENAI_API_KEY"] == "test-key"
-    assert job["environment"]["env"]["MAGENT_BENCHMARK_CONTAINER_PROXY"] == (
-        "http://host.docker.internal:10808"
-    )
+    assert job["environment"]["env"] == {
+        "MAGENT_BENCHMARK_OWNER": str(Path(__file__).resolve().parents[2]),
+        "MAGENT_BENCHMARK_CONTAINER_PROXY": (
+            "http://host.docker.internal:10808"
+        ),
+    }
     assert "test-key" not in fingerprint.read_text()
     assert "127.0.0.1:10808" not in fingerprint.read_text()
     assert output.stat().st_mode & 0o777 == 0o600
@@ -510,18 +535,36 @@ case "$1" in
     exit 0
     ;;
   ps)
-    printf '%s\n' \
-      'bench-container django__django-13033__trial__env-main-1' \
-      'other-container goods-wiki-api-1'
+    case "$*" in
+      *"label=io.magent.benchmark.owner=$MAKE_TEST_OWNER"*)
+        printf '%s\n' \
+          'bench-container django__django-13033__trial__env-main-1'
+        ;;
+      *)
+        printf '%s\n' \
+          'bench-container django__django-13033__trial__env-main-1' \
+          'foreign-bench rust__rust-123__trial__env-main-1' \
+          'other-container goods-wiki-api-1'
+        ;;
+    esac
     ;;
   rm)
     ;;
   network)
     case "$2" in
       ls)
-        printf '%s\n' \
-          'bench-network django__django-13033__trial__env_default' \
-          'other-network goods-wiki_default'
+        case "$*" in
+          *"label=io.magent.benchmark.owner=$MAKE_TEST_OWNER"*)
+            printf '%s\n' \
+              'bench-network django__django-13033__trial__env_default'
+            ;;
+          *)
+            printf '%s\n' \
+              'bench-network django__django-13033__trial__env_default' \
+              'foreign-network rust__rust-123__trial__env_default' \
+              'other-network goods-wiki_default'
+            ;;
+        esac
         ;;
       rm)
         ;;
@@ -555,7 +598,13 @@ def _run_make_cleanup(
     home: Path,
 ) -> subprocess.CompletedProcess[str]:
     environment = os.environ.copy()
-    environment.update({"HOME": str(home), "MAKE_TEST_LOG": str(log)})
+    environment.update(
+        {
+            "HOME": str(home),
+            "MAKE_TEST_LOG": str(log),
+            "MAKE_TEST_OWNER": str(project.resolve()),
+        }
+    )
     return subprocess.run(
         [
             "make",
@@ -594,6 +643,18 @@ def test_make_clean_and_purge_target_only_benchmark_docker_state(
     calls = log.read_text().splitlines()
     assert "docker rm -f bench-container" in calls
     assert "docker network rm bench-network" in calls
+    assert any(
+        "ps -a --filter "
+        f"label=io.magent.benchmark.owner={project.resolve()}" in call
+        for call in calls
+    )
+    assert any(
+        "network ls --filter "
+        f"label=io.magent.benchmark.owner={project.resolve()}" in call
+        for call in calls
+    )
+    assert not any("foreign-bench" in call for call in calls)
+    assert not any("foreign-network" in call for call in calls)
     assert not any("other-container" in call for call in calls)
     assert not any("other-network" in call for call in calls)
     assert not any(call.startswith("docker image ") for call in calls)

--- a/lisp/magent-agent-shell.el
+++ b/lisp/magent-agent-shell.el
@@ -33,6 +33,7 @@
 (defvar shell-maker--request-process)
 
 (declare-function magent--ensure-initialized "magent")
+(declare-function agent-shell--context "agent-shell")
 (declare-function agent-shell--display-buffer "agent-shell")
 (declare-function agent-shell--dwim "agent-shell")
 (declare-function agent-shell--send-command "agent-shell")
@@ -57,6 +58,9 @@
 
 (defvar-local magent-agent-shell--owns-session-strategy-p nil
   "Non-nil when Magent installed the buffer-local session strategy.")
+
+(defvar magent-agent-shell--context-request-p nil
+  "Dynamically non-nil while agent-shell builds context for Magent.")
 
 (defun magent-agent-shell--ensure-loaded ()
   "Load `agent-shell' before using its runtime API."
@@ -310,6 +314,18 @@ Return non-nil when SKILL-NAME is selected after toggling."
     (line-beginning-position)
     (line-end-position))))
 
+(defun magent-agent-shell--context (orig &rest args)
+  "Call ORIG with ARGS under the exact target shell's context ownership."
+  (let ((magent-agent-shell--context-request-p
+         (magent-agent-shell--magent-buffer-p
+          (plist-get args :shell-buffer))))
+    (apply orig args)))
+
+(unless (advice-member-p #'magent-agent-shell--context
+                         'agent-shell--context)
+  (advice-add 'agent-shell--context :around
+              #'magent-agent-shell--context))
+
 (defun magent-agent-shell--get-region-context (orig &rest args)
   "Build region context through ORIG without remote path queries.
 
@@ -319,10 +335,11 @@ TRAMP while agent-shell is starting and deadlock with the in-process
 ACP request.  Keep the full remote file name instead; constructing
 context must not perform remote file I/O."
   (let ((agent-cwd (plist-get args :agent-cwd)))
-    (when (or (and (stringp buffer-file-name)
-                   (file-remote-p buffer-file-name))
-              (and (stringp agent-cwd)
-                   (file-remote-p agent-cwd)))
+    (when (and magent-agent-shell--context-request-p
+               (or (and (stringp buffer-file-name)
+                        (file-remote-p buffer-file-name))
+                   (and (stringp agent-cwd)
+                        (file-remote-p agent-cwd))))
       (setq args (plist-put (copy-sequence args) :agent-cwd nil))))
   (apply orig args))
 
@@ -339,7 +356,9 @@ temporarily activating the current line as a region.  On a blank
 line this creates an empty BOL region, which agent-shell 0.57.1
 formats as an inverted range such as README.org:3-2.  Blank line
 context is not useful for Magent, so skip it."
-  (unless (magent-agent-shell--blank-current-line-p)
+  (if (and magent-agent-shell--context-request-p
+           (magent-agent-shell--blank-current-line-p))
+      nil
     (apply orig args)))
 
 (unless (advice-member-p #'magent-agent-shell--get-current-line-context

--- a/lisp/magent-memory.el
+++ b/lisp/magent-memory.el
@@ -171,6 +171,48 @@ MESSAGE defaults to a stable cancellation explanation."
   "Return the directory where memory snapshots are stored."
   (expand-file-name "snapshots" magent-memory-directory))
 
+(defun magent-memory--ensure-private-directory (directory)
+  "Create DIRECTORY when needed and enforce mode 0700."
+  (let ((old-default-modes (default-file-modes)))
+    (unwind-protect
+        (progn
+          (set-default-file-modes #o700)
+          (make-directory directory t))
+      (set-default-file-modes old-default-modes)))
+  (set-file-modes directory #o700)
+  directory)
+
+(defun magent-memory--write-private-file (file content)
+  "Write CONTENT to FILE while enforcing mode 0600."
+  (magent-memory--ensure-private-directory (file-name-directory file))
+  (let ((old-default-modes (default-file-modes)))
+    (unwind-protect
+        (progn
+          (set-default-file-modes #o600)
+          (when (file-exists-p file)
+            (set-file-modes file #o600))
+          (with-temp-file file
+            (insert content)))
+      (set-default-file-modes old-default-modes)))
+  (set-file-modes file #o600)
+  file)
+
+(defun magent-memory--copy-private-file (source destination)
+  "Copy SOURCE to DESTINATION while enforcing private ownership modes."
+  (magent-memory--ensure-private-directory
+   (file-name-directory destination))
+  (set-file-modes source #o600)
+  (let ((old-default-modes (default-file-modes)))
+    (unwind-protect
+        (progn
+          (set-default-file-modes #o600)
+          (when (file-exists-p destination)
+            (set-file-modes destination #o600))
+          (copy-file source destination t t nil nil))
+      (set-default-file-modes old-default-modes)))
+  (set-file-modes destination #o600)
+  destination)
+
 (defun magent-memory--json-encode (value)
   "Return VALUE encoded as compact JSON."
   (let ((json-encoding-pretty-print nil))
@@ -750,8 +792,7 @@ Return the backup path or nil."
              (backup (expand-file-name
                       (format "emacs-profile-%s.org" stamp)
                       dir)))
-        (make-directory dir t)
-        (copy-file file backup t t t t)
+        (magent-memory--copy-private-file file backup)
         backup))))
 
 (cl-defun magent-memory--write-profile
@@ -759,7 +800,7 @@ Return the backup path or nil."
   "Write managed memory Org for PLAN.
 MANAGED-ORG is the fixed managed subtree.  USER-NOTES are preserved under
 the user-owned heading.  ACTIVE defaults to t."
-  (make-directory magent-memory-directory t)
+  (magent-memory--ensure-private-directory magent-memory-directory)
   (let* ((file (magent-memory-file))
          (backup (magent-memory--backup-active-file))
          (body (concat
@@ -768,8 +809,7 @@ the user-owned heading.  ACTIVE defaults to t."
                 "\n\n* " magent-memory--user-notes-heading "\n"
                 (string-trim-right (or user-notes ""))
                 "\n")))
-    (with-temp-file file
-      (insert body))
+    (magent-memory--write-private-file file body)
     (list :file file
           :backup backup
           :active active)))

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -2222,6 +2222,41 @@
         (should (file-directory-p
                  (magent-memory-snapshots-directory)))))))
 
+(ert-deftest magent-test-memory-profile-and-snapshots-use-private-modes ()
+  "Memory persistence enforces 0700 directories and 0600 files."
+  (require 'magent-memory)
+  (let* ((memory-dir (file-name-as-directory
+                      (make-temp-file "magent-memory-private-" t)))
+         (magent-memory-directory memory-dir)
+         (file (magent-memory-file))
+         (plan (magent-memory-scan-plan--create
+                :roots nil
+                :entry-files nil
+                :files nil
+                :skipped-sensitive nil
+                :skipped-excluded nil
+                :skipped-budget nil
+                :total-bytes 0
+                :generated-at (current-time)
+                :provider "test"
+                :model "test")))
+    (unwind-protect
+        (progn
+          (set-file-modes memory-dir #o755)
+          (with-temp-file file
+            (insert "old profile\n"))
+          (set-file-modes file #o644)
+          (magent-memory--write-profile
+           plan "* Magent Managed Profile\n" "private note")
+          (let* ((snapshots (magent-memory-snapshots-directory))
+                 (backup (car (directory-files snapshots t "\\.org\\'"))))
+            (should backup)
+            (should (= (logand (file-modes memory-dir) #o777) #o700))
+            (should (= (logand (file-modes snapshots) #o777) #o700))
+            (should (= (logand (file-modes file) #o777) #o600))
+            (should (= (logand (file-modes backup) #o777) #o600))))
+      (delete-directory memory-dir t))))
+
 (ert-deftest magent-test-redaction-removes-labeled-and-unlabeled-secrets ()
   "Test outbound redaction removes secrets while retaining stable ids."
   (require 'magent-redaction)
@@ -12852,7 +12887,8 @@
     (insert "first\n\nthird\n")
     (goto-char (point-min))
     (forward-line 1)
-    (let ((called nil))
+    (let ((called nil)
+          (magent-agent-shell--context-request-p t))
       (should-not
        (magent-agent-shell--get-current-line-context
         (lambda (&rest _args)
@@ -12861,7 +12897,8 @@
         :agent-cwd default-directory))
       (should-not called))
     (goto-char (point-min))
-    (let ((called nil))
+    (let ((called nil)
+          (magent-agent-shell--context-request-p t))
       (should
        (equal
         (magent-agent-shell--get-current-line-context
@@ -12880,7 +12917,8 @@
     (goto-char (point-min))
     (setq buffer-file-name "/ssh:test.invalid:/srv/project/example.el"
           default-directory "/ssh:test.invalid:/srv/project/")
-    (let (context)
+    (let ((magent-agent-shell--context-request-p t)
+          context)
       (cl-letf (((symbol-function 'file-in-directory-p)
                  (lambda (&rest _args)
                    (ert-fail "Remote line context performed file I/O"))))
@@ -12902,7 +12940,8 @@
     (push-mark (line-end-position) t t)
     (setq buffer-file-name "/ssh:test.invalid:/srv/project/example.el"
           default-directory "/ssh:test.invalid:/srv/project/")
-    (let (context)
+    (let ((magent-agent-shell--context-request-p t)
+          context)
       (cl-letf (((symbol-function 'file-in-directory-p)
                  (lambda (&rest _args)
                    (ert-fail "Remote region context performed file I/O"))))
@@ -12915,6 +12954,40 @@
                (regexp-quote buffer-file-name)
                context))
       (should (string-match-p "first remote line" context)))))
+
+(ert-deftest magent-test-agent-shell-context-workaround-is-magent-scoped ()
+  "Remote path handling leaves non-Magent agent-shell backends unchanged."
+  (require 'magent-agent-shell)
+  (let ((magent-shell (generate-new-buffer " *magent-context-shell*"))
+        (other-shell (generate-new-buffer " *other-context-shell*"))
+        (remote-cwd "/ssh:test.invalid:/srv/project/"))
+    (unwind-protect
+        (progn
+          (with-current-buffer magent-shell
+            (setq major-mode 'agent-shell-mode)
+            (setq-local agent-shell--state
+                        '((:agent-config . ((:identifier . magent))))))
+          (with-current-buffer other-shell
+            (setq major-mode 'agent-shell-mode)
+            (setq-local agent-shell--state
+                        '((:agent-config . ((:identifier . other))))))
+          (with-temp-buffer
+            (setq buffer-file-name
+                  "/ssh:test.invalid:/srv/project/example.el")
+            (dolist (case `((,magent-shell . nil)
+                            (,other-shell . ,remote-cwd)))
+              (let (captured-cwd)
+                (magent-agent-shell--context
+                 (lambda (&rest _args)
+                   (magent-agent-shell--get-region-context
+                    (lambda (&rest region-args)
+                      (setq captured-cwd
+                            (plist-get region-args :agent-cwd)))
+                    :agent-cwd remote-cwd))
+                 :shell-buffer (car case))
+                (should (equal captured-cwd (cdr case)))))))
+      (kill-buffer magent-shell)
+      (kill-buffer other-shell))))
 
 (ert-deftest magent-test-agent-shell-send-prompt-queues-skills ()
   "Test agent-shell prompt submission records request-local skills."


### PR DESCRIPTION
## Summary

- Label Harbor containers and networks by checkout so `make clean` cannot remove unrelated benchmark resources.
- Enforce 0700 memory directories and 0600 profile and snapshot files, including existing data.
- Scope remote-path and blank-line agent-shell workarounds to requests targeting the Magent backend.
- Add regression coverage for resource ownership, file permissions, and backend isolation.

## Testing

- `make compile`
- `make lint` with the installed package-lint dependency path
- `make test-unit` (592 ERT tests)
- `make benchmark-test` (2 ERT tests and 36 pytest tests)
- `make test-live-smoke` against an isolated Emacs daemon