### PR TITLE
docs: align documentation with runtime behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@ Custom agents: `.magent/agent/*.md` files with YAML frontmatter + markdown body 
 ---
 name: skill-name
 description: Brief description
-tools: [bash, read]
+tools: [bash, read_file]
 type: instruction        # the only supported type
 requires-project: true   # optional: reject use from a global session
 ---

--- a/README.org
+++ b/README.org
@@ -99,7 +99,7 @@ Magent directly from Git:
   :after (agent-shell gptel)
   :demand t
   :custom
-  ;; Uncomment to bypass Magent's tool permission checks and approval prompts.
+  ;; Uncomment to bypass ordinary checks; eval tools still require approval.
   ;; (magent-bypass-permission t)
   (magent-default-effort 'xhigh)
   :config
@@ -236,7 +236,7 @@ must appear exactly once in ~prompts/manifest.txt~.
 | ~magent-agent-shell-interrupt~                     | Interrupt the active Magent agent-shell request                  |
 | ~magent-agent-shell-run-command~                   | Select and run a registered slash command                        |
 | ~magent-agent-shell-toggle-skill-for-next-request~ | Toggle a one-shot instruction skill                              |
-| ~magent-toggle-bypass-permission~                  | Toggle permission bypass for tool filtering and approval prompts |
+| ~magent-toggle-bypass-permission~                  | Toggle ordinary permission bypass; once-only eval approval remains |
 
 Prompt text is entered directly in the agent-shell buffer, and Magent streams
 assistant responses, tool activity, permission prompts, and session updates
@@ -277,11 +277,12 @@ and are consumed by the next prompt.
 
 Elisp-native slash commands are registered through the public
 ~magent-action-register~ API and can be selected with
-~M-x magent-agent-shell-run-command~. Agent-shell advertises twelve bundled
+~M-x magent-agent-shell-run-command~. Agent-shell advertises thirteen bundled
 commands: ~/explain~, ~/fix~, ~/init~, ~/review~, ~/summarize~, ~/test~,
-~/compact~, ~/skills~, ~/doctor~, ~/memory-init~, ~/memory-refresh~, and
-~/memory-clear~. The six prompt commands own package Org resources and
-do not activate same-name skills. ~/summarize~ writes one canonical Org note
+~/compact~, ~/authority~, ~/skills~, ~/doctor~, ~/memory-init~,
+~/memory-refresh~, and ~/memory-clear~. The six prompt commands own package
+Org resources and do not activate same-name skills. ~/summarize~ writes one
+canonical Org note
 for the current Git project and accepts an optional path or semantic scope.
 
 Every instruction skill in the exact session scope is advertised as ~/$name~.

--- a/docs/COMMANDS.org
+++ b/docs/COMMANDS.org
@@ -11,8 +11,8 @@ Magent has one Action registry projected onto two user-facing command surfaces:
 - *Interactive commands* are ~M-x~ wrappers over Actions that opt into
   interactive exposure.
 
-The bundled package provides twelve slash commands. Doctor and the three Memory
-Actions also expose ~M-x magent-action-run-*~ wrappers and use isolated
+The bundled package provides thirteen slash commands. Doctor and the three
+Memory Actions also expose ~M-x magent-action-run-*~ wrappers and use isolated
 durable sessions.
 
 * Slash Commands

--- a/docs/COMMANDS.zh.org
+++ b/docs/COMMANDS.zh.org
@@ -11,7 +11,7 @@ Magent 把同一个 Action registry 投影为两类用户可见的 command 入�
 - *Interactive commands* 是选择了 interactive exposure 的 Action spec 对应的
   ~M-x~ wrapper。
 
-当前内置包提供 12 个 slash commands。Doctor 和三个 Memory Action 还提供
+当前内置包提供 13 个 slash commands。Doctor 和三个 Memory Action 还提供
 ~M-x magent-action-run-*~ wrapper，并使用独立 durable session。
 
 * Slash Commands

--- a/docs/ONBOARDING.org
+++ b/docs/ONBOARDING.org
@@ -61,7 +61,7 @@ Manages conversation history, scoped overlays, and runtime state.
 Multi-agent architecture with specialized agents for different tasks.
 
 *Key Files:*
-- ~magent-agent.el~ — Core agent processing: builds gptel prompts, applies overrides, calls ~gptel-request~
+- ~magent-agent.el~ — Core agent processing: builds gptel prompts, applies overrides, and starts the Magent-owned loop
 - ~magent-project-instructions.el~ — Bounded root-to-resource discovery of scoped project instructions such as ~AGENTS.md~
 - ~magent-agent-info.el~ — Agent metadata struct and helpers
 - ~magent-agent-builtins.el~ — 7 built-in agent definitions

--- a/docs/ONBOARDING.zh.org
+++ b/docs/ONBOARDING.zh.org
@@ -64,7 +64,7 @@ lazy initialization；agent registry、skills、slash commands 和 capabilities 
 
 *关键文件：*
 
-- ~magent-agent.el~ ：核心 agent processing，构造 gptel prompt、应用 overrides、调用 ~gptel-request~ 。
+- ~magent-agent.el~ ：核心 agent processing，构造 gptel prompt、应用 overrides，并启动 Magent-owned loop。
 - ~magent-project-instructions.el~ ：从 project root 到请求相关 resource 有界发现 ~AGENTS.md~ 等 scoped project instructions。
 - ~magent-agent-info.el~ ：agent metadata struct 和 helpers。
 - ~magent-agent-builtins.el~ ：7 个内置 agent definitions。

--- a/docs/TROUBLESHOOTING.org
+++ b/docs/TROUBLESHOOTING.org
@@ -30,7 +30,7 @@ shape:
 
 #+begin_src elisp
 (magent :fetcher github :repo "Jamie-Cui/magent"
-        :files ("lisp/magent*.el" "prompts" "skills" "capabilities"))
+        :files ("lisp/magent*.el" "prompts" "skills"))
 #+end_src
 
 The explicit glob supplies every production Elisp file. The explicit

--- a/docs/TROUBLESHOOTING.zh.org
+++ b/docs/TROUBLESHOOTING.zh.org
@@ -28,7 +28,7 @@ Opening input file: No such file or directory, /workspace/pkg/prompts/system.org
 
 #+begin_src elisp
 (magent :fetcher github :repo "Jamie-Cui/magent"
-        :files ("lisp/magent*.el" "prompts" "skills" "capabilities"))
+        :files ("lisp/magent*.el" "prompts" "skills"))
 #+end_src
 
 显式 glob 提供全部 production Elisp files；显式目录提供 package 通过相对路径加载的 runtime data。ERT 源码应放在 ~test/~ 下，使其不进入 production package；recipe 应与 ~source-files.txt~ 和 ~prompts/manifest.txt~ 保持一致。

--- a/lisp/magent-config.el
+++ b/lisp/magent-config.el
@@ -99,7 +99,7 @@ emacs_eval_live, agent, web_search."
   "Directory where Magent writes repository summary notes.
 When nil, use `org-roam-directory' if that variable is bound.  Magent
 does not create this directory automatically; configure it to an existing
-org-roam directory before using the `/summarize' skill."
+org-roam directory before using the `/summarize' Action."
   :type '(choice (const :tag "Use org-roam-directory" nil)
                  (directory :tag "Org-roam directory"))
   :group 'magent)
@@ -107,8 +107,9 @@ org-roam directory before using the `/summarize' skill."
 (defcustom magent-project-root-function nil
   "Function to find project root directory.
 The function should take no arguments and return the project root
-path as a string.  If nil, uses `projectile-project-root' when
-available, or `default-directory'."
+path as a string.  If nil, try `projectile-project-root', then
+`project-current' from project.el, and finally fall back to
+`default-directory'."
   :type '(choice (function :tag "Custom function")
                  (const :tag "Default" nil))
   :group 'magent)
@@ -207,11 +208,13 @@ wire-protocol configuration."
   (symbol-name (magent-effort-option-or-auto effort)))
 
 (defcustom magent-bypass-permission nil
-  "DANGEROUS: Bypass permission checks for all tools.
-When non-nil, all tool calls are executed without confirmation,
-ignoring agent permission rules and user-defined overrides.
-This is a security risk and should only be enabled in trusted
-environments for debugging or automation purposes.
+  "DANGEROUS: Bypass ordinary Magent tool permission checks.
+When non-nil, exposed tools ignore agent permission rules and user-defined
+overrides.  Tools with a once-only approval policy, including `emacs_eval'
+and `emacs_eval_live', still require a fresh confirmation.  This flag does
+not expose globally disabled tools or tools omitted from an Action's exact
+allowlist.  Enable it only in trusted environments for debugging or
+automation.
 
 This variable is the canonical permission bypass flag used by
 `magent-toggle-bypass-permission' and permission checks."

--- a/lisp/magent-repo-summary.el
+++ b/lisp/magent-repo-summary.el
@@ -6,7 +6,7 @@
 
 ;;; Commentary:
 
-;; Deterministic storage for the `/summarize' skill.  The model supplies an
+;; Deterministic storage for the `/summarize' Action.  The model supplies an
 ;; Org fragment; this module owns repository identity, org-roam metadata,
 ;; timestamp filenames, subtree upserts, and atomic writes.
 

--- a/lisp/magent-skills.el
+++ b/lisp/magent-skills.el
@@ -48,7 +48,7 @@ through these stages: understand intent -> write SKILL.md -> test in Emacs -> it
 name: skill-name
 description: When to trigger and what this skill does
 type: instruction
-tools: [bash, read]      # optional: tools this skill needs
+tools: [bash, read_file] # optional: exact provider tool names this skill needs
 requires-project: true   # optional: reject the skill in global sessions
 capability: true         # optional: auto-activate this instruction skill by context
 ---

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -294,6 +294,7 @@
   "Test the MELPA recipe includes all production libraries and runtime data."
   (let ((workflow (expand-file-name ".github/workflows/melpazoid.yml"
                                     magent-test--root-directory))
+        (expected-files '("lisp/magent*.el" "prompts" "skills"))
         recipe)
     (with-temp-buffer
       (insert-file-contents workflow)
@@ -302,7 +303,16 @@
       (setq recipe (read (match-string 1))))
     (should
      (equal (plist-get (cdr recipe) :files)
-            '("lisp/magent*.el" "prompts" "skills")))
+            expected-files))
+    (dolist (relative-file '("docs/TROUBLESHOOTING.org"
+                             "docs/TROUBLESHOOTING.zh.org"))
+      (with-temp-buffer
+        (insert-file-contents
+         (expand-file-name relative-file magent-test--root-directory))
+        (should (re-search-forward "^(magent[[:space:]]+:fetcher" nil t))
+        (goto-char (match-beginning 0))
+        (should (equal (plist-get (cdr (read (current-buffer))) :files)
+                       expected-files))))
     (should (member "lisp/magent-action-builtins.el"
                     (magent-test-source-files
                      magent-test--root-directory)))))
@@ -331,6 +341,23 @@
 (defconst magent-test--builtin-maintenance-command-names
   '("doctor" "memory-clear" "memory-init" "memory-refresh")
   "Magent-owned isolated workflows exposed as slash commands.")
+
+(ert-deftest magent-test-bundled-command-docs-match-runtime-inventory ()
+  "Test user docs enumerate every bundled slash command and the exact count."
+  (let ((names (append magent-test--builtin-control-command-names
+                       magent-test--builtin-maintenance-command-names
+                       magent-test--builtin-slash-command-names)))
+    (should (= (length names) 13))
+    (dolist (entry '(("README.org" . "thirteen bundled")
+                     ("docs/COMMANDS.org" . "thirteen slash commands")
+                     ("docs/COMMANDS.zh.org" . "13 个 slash commands")))
+      (with-temp-buffer
+        (insert-file-contents
+         (expand-file-name (car entry) magent-test--root-directory))
+        (should (search-forward (cdr entry) nil t))
+        (dolist (name names)
+          (goto-char (point-min))
+          (should (search-forward (format "~/%s~" name) nil t)))))))
 
 (magent-define-workflow magent-test--empty-action-workflow (_invocation)
   "Return immediately for registry and frontend discovery tests."
@@ -1024,12 +1051,12 @@
   (let* ((content
           (concat "---\n"
                   "description: \"Say \\\"hi\\\", then C:\\\\tmp\\nnext\"\n"
-                  "tools: [bash, read]\n"
+                  "tools: [bash, read_file]\n"
                   "---\n"))
          (fm (car (magent-file-loader-parse-frontmatter content))))
     (should (equal (plist-get fm :description)
                    "Say \"hi\", then C:\\tmp\nnext"))
-    (should (equal (plist-get fm :tools) '("bash" "read")))))
+    (should (equal (plist-get fm :tools) '("bash" "read_file")))))
 
 (ert-deftest magent-test-frontmatter-keeps-commas-in-scalar-fields ()
   "Comma-containing scalar fields remain scalar values."
@@ -3412,15 +3439,21 @@
     (should (null magent-skills--registry))))
 
 (ert-deftest magent-test-skills-register-builtin ()
-  "Test code-defined builtin skill registration."
+  "Test code-defined builtin skill registration and canonical tool examples."
   (require 'magent-skills)
+  (require 'magent-tools)
   (let ((magent-skills--registry nil))
     (cl-letf (((symbol-function 'magent-log) #'ignore))
       (magent-skills--register-builtin))
     (should (null (magent-skills-get "emacs")))
     (let ((skill (magent-skills-get "skill-creator")))
       (should skill)
-      (should (eq (magent-skill-type skill) 'instruction)))))
+      (should (eq (magent-skill-type skill) 'instruction))
+      (let ((prompt (magent-skill-prompt skill)))
+        (should (string-match "tools: \\[\\([^]]+\\)\\]" prompt))
+        (dolist (name (split-string (match-string 1 prompt)
+                                    "[[:space:],]+" t))
+          (should (magent-tools-catalog-entry name)))))))
 
 (ert-deftest magent-test-skills-load-order-preserves-directory-precedence ()
   "Test later skill directories override earlier directories deterministically."
@@ -5154,7 +5187,8 @@
 (ert-deftest magent-test-skills-parse-tools ()
   "Test canonical YAML-sequence tool parsing."
   (require 'magent-skills)
-  (should (equal (magent-skills--parse-tools '("bash" "read")) '(bash read)))
+  (should (equal (magent-skills--parse-tools '("bash" "read_file"))
+                 '(bash read_file)))
   (should-error (magent-skills--parse-tools "bash, read, write"))
   (should-error (magent-skills--parse-tools "bash"))
   (should-error (magent-skills--parse-tools 'bash))
@@ -5169,13 +5203,13 @@
     (unwind-protect
         (progn
           (with-temp-file skillfile
-            (insert "---\nname: test-skill\ndescription: A test\ntype: instruction\ntools: [bash, read]\nrequires-project: true\n---\nDo the thing."))
+            (insert "---\nname: test-skill\ndescription: A test\ntype: instruction\ntools: [bash, read_file]\nrequires-project: true\n---\nDo the thing."))
           (let ((skill (magent-skills-load-file skillfile)))
             (should skill)
             (should (equal (magent-skill-name skill) "test-skill"))
             (should (equal (magent-skill-description skill) "A test"))
             (should (eq (magent-skill-type skill) 'instruction))
-            (should (equal (magent-skill-tools skill) '(bash read)))
+            (should (equal (magent-skill-tools skill) '(bash read_file)))
             (should (magent-skill-requires-project skill))
             (should (string-match-p "Do the thing" (magent-skill-prompt skill)))))
       (delete-directory tmpdir t))))


### PR DESCRIPTION
## Summary

- align English and Chinese docs with runtime ownership, slash command inventory, and the MELPA recipe
- correct canonical skill tool examples and permission and project-root documentation
- add regression coverage for documented tool names, packaged runtime data, and bundled commands

## Validation

- make compile
- make lint
- make test-unit (593/593)
- make test-live-smoke