### PR TITLE
fix(packaging): specify lisp directory for VC installs

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,0 +1,127 @@
+name: Bug report
+description: Report a reproducible problem in Magent
+title: "[Bug] "
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a Magent problem. Please provide a minimal
+        reproduction and remove credentials or sensitive provider data.
+
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Existing issues
+      options:
+        - label: I searched the existing issues for this problem.
+          required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the observable problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include exact versions or commits where possible.
+      value: |
+        - Magent version or commit:
+        - Loaded Magent source path:
+        - Emacs version:
+        - gptel version:
+        - agent-shell version:
+        - acp version:
+        - Operating system:
+        - Provider and model:
+        - Installation method:
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: List the smallest sequence that reliably demonstrates the problem.
+      placeholder: |
+        1. Start Magent with ...
+        2. Submit the prompt ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: prompt
+    attributes:
+      label: Prompt or input
+      description: Include the smallest prompt that reproduces the problem.
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened, including the exact error or terminal state?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: Frequency
+      options:
+        - Always
+        - Intermittently
+        - Once
+        - Unknown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Suspected area
+      description: Optional; choose Unknown if you are unsure.
+      options:
+        - Unknown
+        - Runtime or agent loop
+        - gptel transport
+        - Tools, permissions, or approvals
+        - Child-agent jobs
+        - Actions
+        - Sessions, ledger, or persistence
+        - ACP or agent-shell
+        - Skills or capabilities
+        - Packaging or CI
+        - Documentation
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostic output
+      description: |
+        Add the smallest relevant excerpt from *Messages*, *Backtrace*,
+        *magent-log*, or an isolated live test. Remove API keys, authorization
+        headers, provider request bodies, and other sensitive data.
+      render: shell
+
+  - type: checkboxes
+    id: sensitive-data
+    attributes:
+      label: Sensitive-data confirmation
+      options:
+        - label: I reviewed all included logs and attachments for credentials and sensitive data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/2-feature-rfc.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-rfc.yml
@@ -1,0 +1,99 @@
+name: Feature request or RFC
+description: Propose a user-facing feature or architectural change
+title: "[Proposal] "
+labels: ["enhancement"]
+
+body:
+  - type: checkboxes
+    id: existing-proposal
+    attributes:
+      label: Existing proposals
+      options:
+        - label: I searched the existing issues for this proposal.
+          required: true
+
+  - type: dropdown
+    id: proposal-type
+    attributes:
+      label: Proposal type
+      options:
+        - Feature request
+        - Architecture RFC
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: Describe the user need or current limitation before describing an implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the externally observable result.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Optional API, interaction, workflow, or data-model proposal.
+
+  - type: textarea
+    id: non-goals
+    attributes:
+      label: Non-goals
+      description: What should explicitly remain outside this proposal?
+
+  - type: dropdown
+    id: architecture
+    attributes:
+      label: Architectural impact
+      description: Select every area that may be affected.
+      multiple: true
+      options:
+        - No known architectural impact
+        - gptel provider transport
+        - ACP or agent-shell frontend
+        - Runtime or agent loop
+        - Actions
+        - Tools, permissions, or approvals
+        - Child-agent lifecycle
+        - Session schema, ledger, or persistence
+        - Skills or capabilities
+        - Packaging or runtime data
+    validations:
+      required: true
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility and migration
+      description: |
+        Could this affect existing configuration, saved sessions, agent or
+        skill files, public commands, or provider behavior?
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Include existing workflows or smaller solutions that were considered.
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Testing and documentation
+      description: Describe expected ERT, live-smoke, migration, and documentation work.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/README.org
+++ b/README.org
@@ -90,11 +90,15 @@ Add the project to your Emacs load path:
 ** Installing from Git with ~use-package~
 
 When your ~use-package~ supports the ~:vc~ keyword, it can install and load
-Magent directly from Git:
+Magent directly from Git.  Magent stores its Emacs Lisp sources under
+~lisp/~, so keep the explicit ~:lisp-dir~ entry in the VC package
+specification:
 
 #+begin_src elisp
 (use-package magent
-  :vc (:url "https://github.com/Jamie-Cui/magent" :rev "master")
+  :vc (:url "https://github.com/Jamie-Cui/magent"
+       :rev "master"
+       :lisp-dir "lisp")
   :ensure t
   :after (agent-shell gptel)
   :demand t

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -240,6 +240,26 @@
                (length (delete-dups (copy-sequence manifest)))))
     (should (equal sorted-manifest (sort actual #'string<)))))
 
+(ert-deftest magent-test-readme-vc-recipe-selects-lisp-directory ()
+  "Test the documented package-vc recipe loads Magent from lisp/."
+  (with-temp-buffer
+    (insert-file-contents
+     (expand-file-name "README.org" magent-test--root-directory))
+    (goto-char (point-min))
+    (should
+     (re-search-forward
+      "^\\*\\* Installing from Git with ~use-package~$" nil t))
+    (should (re-search-forward "^#\\+begin_src elisp$" nil t))
+    (let ((recipe-start (point)))
+      (should (re-search-forward "^#\\+end_src$" nil t))
+      (let ((recipe (buffer-substring-no-properties
+                     recipe-start (match-beginning 0))))
+        (should (string-match-p "(use-package magent" recipe))
+        (should (string-match-p ":vc" recipe))
+        (should
+         (string-match-p
+          ":lisp-dir[[:blank:]]+\\\"lisp\\\"" recipe))))))
+
 (ert-deftest magent-test-production-elisp-has-commentary-sections ()
   "Test every production Elisp module has a Commentary section."
   (dolist (relative-file


### PR DESCRIPTION
## Summary

- add structured GitHub issue forms for bug reports and feature proposals
- document `:lisp-dir "lisp"` for `use-package :vc` installations
- add an ERT regression test for the documented VC recipe

Fixes #43.

## Testing

- `make test-unit` (603 tests)
