### PR TITLE
ci: automate ELPA compatibility and issue triage

### DIFF
--- a/.github/scripts/label-issue.js
+++ b/.github/scripts/label-issue.js
@@ -1,0 +1,224 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+const LABEL_DEFINITIONS = {
+  rfc: {
+    color: "5319e7",
+    description: "Architecture request for comments",
+  },
+  doc: {
+    color: "0075ca",
+    description: "Documentation changes",
+  },
+  runtime: {
+    color: "c5def5",
+    description: "Runtime or agent loop",
+  },
+  gptel: {
+    color: "c5def5",
+    description: "gptel provider transport",
+  },
+  tools: {
+    color: "c5def5",
+    description: "Tools, permissions, or approvals",
+  },
+  agents: {
+    color: "c5def5",
+    description: "Child-agent lifecycle and jobs",
+  },
+  actions: {
+    color: "c5def5",
+    description: "Magent Actions, not GitHub Actions",
+  },
+  sessions: {
+    color: "c5def5",
+    description: "Sessions, ledger, or persistence",
+  },
+  frontend: {
+    color: "c5def5",
+    description: "ACP or agent-shell frontend",
+  },
+  skills: {
+    color: "c5def5",
+    description: "Skills or automatic capabilities",
+  },
+  packaging: {
+    color: "c5def5",
+    description: "Packaging or continuous integration",
+  },
+};
+
+const COMPONENT_LABELS = [
+  "runtime",
+  "gptel",
+  "tools",
+  "agents",
+  "actions",
+  "sessions",
+  "frontend",
+  "skills",
+  "packaging",
+];
+
+const BUG_AREA_LABELS = {
+  "Runtime or agent loop": "runtime",
+  "gptel transport": "gptel",
+  "Tools, permissions, or approvals": "tools",
+  "Child-agent jobs": "agents",
+  Actions: "actions",
+  "Sessions, ledger, or persistence": "sessions",
+  "ACP or agent-shell": "frontend",
+  "Skills or capabilities": "skills",
+  "Packaging or CI": "packaging",
+  Documentation: "doc",
+};
+
+const PROPOSAL_AREA_LABELS = {
+  "gptel provider transport": "gptel",
+  "ACP or agent-shell frontend": "frontend",
+  "Runtime or agent loop": "runtime",
+  Actions: "actions",
+  "Tools, permissions, or approvals": "tools",
+  "Child-agent lifecycle": "agents",
+  "Session schema, ledger, or persistence": "sessions",
+  "Skills or capabilities": "skills",
+  "Packaging or runtime data": "packaging",
+};
+
+function issueFormSections(body) {
+  const text = body || "";
+  const matches = [...text.matchAll(/^### ([^\r\n]+)\r?\n/gm)];
+  const sections = new Map();
+
+  for (let index = 0; index < matches.length; index += 1) {
+    const match = matches[index];
+    const start = match.index + match[0].length;
+    const end = matches[index + 1]?.index ?? text.length;
+    sections.set(match[1].trim(), text.slice(start, end).trim());
+  }
+
+  return sections;
+}
+
+function addMappedLabels(desired, section, mapping) {
+  for (const [option, label] of Object.entries(mapping)) {
+    if (section.includes(option)) {
+      desired.add(label);
+    }
+  }
+}
+
+function labelPlan(body) {
+  const sections = issueFormSections(body);
+  const isBugForm = sections.has("Suspected area");
+  const isProposalForm =
+    sections.has("Proposal type") && sections.has("Architectural impact");
+
+  if (!isBugForm && !isProposalForm) {
+    return null;
+  }
+
+  const desired = new Set();
+  const managed = new Set(COMPONENT_LABELS);
+
+  if (isBugForm) {
+    managed.add("doc");
+    addMappedLabels(
+      desired,
+      sections.get("Suspected area"),
+      BUG_AREA_LABELS,
+    );
+  }
+
+  if (isProposalForm) {
+    managed.add("rfc");
+    if (sections.get("Proposal type").includes("Architecture RFC")) {
+      desired.add("rfc");
+    }
+    addMappedLabels(
+      desired,
+      sections.get("Architectural impact"),
+      PROPOSAL_AREA_LABELS,
+    );
+  }
+
+  return {desired, managed};
+}
+
+async function ensureLabels(github, context) {
+  const existing = new Set(
+    (
+      await github.paginate(github.rest.issues.listLabelsForRepo, {
+        ...context.repo,
+        per_page: 100,
+      })
+    ).map((label) => label.name),
+  );
+
+  if (existing.has("documentation") && !existing.has("doc")) {
+    await github.rest.issues.updateLabel({
+      ...context.repo,
+      name: "documentation",
+      new_name: "doc",
+      ...LABEL_DEFINITIONS.doc,
+    });
+    existing.delete("documentation");
+    existing.add("doc");
+  }
+
+  for (const [name, definition] of Object.entries(LABEL_DEFINITIONS)) {
+    if (!existing.has(name)) {
+      await github.rest.issues.createLabel({
+        ...context.repo,
+        name,
+        ...definition,
+      });
+    }
+  }
+}
+
+async function labelIssue({github, context, core}) {
+  const issue = context.payload.issue;
+  const plan = labelPlan(issue.body || "");
+
+  if (!plan) {
+    core.info("Skipping an issue that was not created from a known form");
+    return;
+  }
+
+  await ensureLabels(github, context);
+
+  const current = new Set(
+    issue.labels.map((label) =>
+      typeof label === "string" ? label : label.name,
+    ),
+  );
+  const add = [...plan.desired].filter((label) => !current.has(label));
+  const remove = [...plan.managed].filter(
+    (label) => current.has(label) && !plan.desired.has(label),
+  );
+
+  if (add.length > 0) {
+    await github.rest.issues.addLabels({
+      ...context.repo,
+      issue_number: issue.number,
+      labels: add,
+    });
+  }
+
+  for (const name of remove) {
+    await github.rest.issues.removeLabel({
+      ...context.repo,
+      issue_number: issue.number,
+      name,
+    });
+  }
+
+  core.info(
+    `Issue labels reconciled (added: ${add.join(", ") || "none"}; ` +
+      `removed: ${remove.join(", ") || "none"})`,
+  );
+}
+
+module.exports = labelIssue;
+module.exports.issueFormSections = issueFormSections;
+module.exports.labelPlan = labelPlan;

--- a/.github/scripts/label-issue.test.js
+++ b/.github/scripts/label-issue.test.js
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const labelIssue = require("./label-issue.js");
+
+function form(fields) {
+  return Object.entries(fields)
+    .map(([heading, value]) => `### ${heading}\n\n${value}`)
+    .join("\n\n");
+}
+
+test("ignores blank issues", () => {
+  assert.equal(labelIssue.labelPlan("Free-form issue body"), null);
+});
+
+test("maps the bug area without reading free text", () => {
+  const plan = labelIssue.labelPlan(
+    form({
+      Summary: "The runtime text mentions Documentation but is not classified.",
+      "Suspected area": "Runtime or agent loop",
+    }),
+  );
+
+  assert.deepEqual([...plan.desired], ["runtime"]);
+  assert.equal(plan.managed.has("doc"), true);
+  assert.equal(plan.managed.has("rfc"), false);
+});
+
+test("maps RFC and multiple proposal areas", () => {
+  const plan = labelIssue.labelPlan(
+    form({
+      "Proposal type": "Architecture RFC",
+      "Architectural impact": [
+        "- Runtime or agent loop",
+        "- Actions",
+        "- Skills or capabilities",
+      ].join("\n"),
+    }),
+  );
+
+  assert.deepEqual([...plan.desired], ["rfc", "runtime", "actions", "skills"]);
+  assert.equal(plan.managed.has("doc"), false);
+});
+
+test("reconciles managed labels and preserves manual labels", async () => {
+  const created = [];
+  const updated = [];
+  const added = [];
+  const removed = [];
+  const github = {
+    paginate: async () => [{name: "runtime"}, {name: "documentation"}],
+    rest: {
+      issues: {
+        listLabelsForRepo: () => {},
+        createLabel: async (input) => created.push(input.name),
+        updateLabel: async (input) => updated.push(input.new_name),
+        addLabels: async (input) => added.push(...input.labels),
+        removeLabel: async (input) => removed.push(input.name),
+      },
+    },
+  };
+  const context = {
+    repo: {owner: "Jamie-Cui", repo: "magent"},
+    payload: {
+      issue: {
+        number: 42,
+        body: form({"Suspected area": "Documentation"}),
+        labels: [{name: "runtime"}, {name: "security"}, {name: "rfc"}],
+      },
+    },
+  };
+
+  await labelIssue({github, context, core: {info: () => {}}});
+
+  assert.deepEqual(updated, ["doc"]);
+  assert.equal(created.includes("doc"), false);
+  assert.deepEqual(added, ["doc"]);
+  assert.deepEqual(removed, ["runtime"]);
+});

--- a/.github/workflows/elpa-compatibility.yml
+++ b/.github/workflows/elpa-compatibility.yml
@@ -1,0 +1,223 @@
+name: ELPA compatibility
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/elpa-compatibility.yml"
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: elpa-compatibility
+  cancel-in-progress: false
+
+jobs:
+  test:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/test.yml
+
+  report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      report: ${{ steps.report.outputs.report }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31.10.6
+        with:
+          github_access_token: ${{ github.token }}
+
+      - name: Install Emacs 30.1
+        run: |
+          nix profile install --accept-flake-config \
+            github:purcell/nix-emacs-ci/868482a78575138aebb1b5c16a9266b95c800f2e#emacs-30-1
+          emacs --version
+
+      - name: Report direct dependency versions
+        id: report
+        continue-on-error: true
+        run: |
+          report_file="$RUNNER_TEMP/elpa-dependencies.tsv"
+          set +e
+          make deps-check > "$report_file"
+          status=$?
+          set -e
+
+          if ! awk -F '\t' '
+            NR == 1 {
+              if ($0 != "package\tminimum\tcandidate\tsource\tstatus") exit 1
+              next
+            }
+            {
+              if (NF != 5 ||
+                  $1 !~ /^[a-z0-9-]+$/ ||
+                  $2 !~ /^[0-9A-Za-z.+~-]+$/ ||
+                  $3 !~ /^(-|[0-9A-Za-z.+~-]+)$/ ||
+                  $4 !~ /^(-|runtime|gnu|nongnu|melpa|unknown)$/ ||
+                  $5 !~ /^(satisfied|minimum-unavailable|unavailable|exact|newer-available)$/) exit 1
+            }
+            END { if (NR < 2 || NR > 100) exit 1 }
+          ' "$report_file"; then
+            status=2
+            report_valid=false
+          else
+            report_valid=true
+          fi
+
+          {
+            echo "## Direct ELPA dependencies"
+            echo
+            if [ "$report_valid" = true ]; then
+              echo "| Package | Minimum | Candidate | Source | Status |"
+              echo "| --- | --- | --- | --- | --- |"
+              awk -F '\t' 'NR > 1 { printf "| %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $5 }' "$report_file"
+            else
+              echo "Dependency report unavailable; see the workflow logs."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$report_valid" = true ]; then
+            echo "report=$(base64 -w 0 "$report_file")" >> "$GITHUB_OUTPUT"
+          else
+            echo "report=" >> "$GITHUB_OUTPUT"
+          fi
+          exit "$status"
+
+      - name: Propagate dependency report failure
+        if: steps.report.outcome == 'failure'
+        run: exit 1
+
+  notify:
+    if: ${{ always() && github.event_name == 'schedule' }}
+    needs:
+      - test
+      - report
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Update dependency monitor issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          REPORT_BASE64: ${{ needs.report.outputs.report }}
+          REPORT_RESULT: ${{ needs.report.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          set -euo pipefail
+          marker='<!-- magent-elpa-compatibility-monitor -->'
+          status_marker='magent-elpa-monitor-status'
+          title='Automated ELPA dependency check failed'
+          now=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          body_file="$RUNNER_TEMP/elpa-monitor-body.md"
+          current_body_file="$RUNNER_TEMP/elpa-monitor-current.md"
+          report_file="$RUNNER_TEMP/elpa-monitor-report.tsv"
+
+          issue_number=$(gh issue list \
+            --repo "$GH_REPO" \
+            --state all \
+            --label dependencies \
+            --limit 100 \
+            --json number,body \
+            --jq 'map(select(.body | contains("<!-- magent-elpa-compatibility-monitor -->"))) | sort_by(.number) | last | .number // empty')
+
+          issue_state=''
+          issue_status=''
+          failures=0
+          first_failure=''
+          if [ -n "$issue_number" ]; then
+            issue_state=$(gh issue view "$issue_number" --repo "$GH_REPO" --json state --jq .state)
+            gh issue view "$issue_number" --repo "$GH_REPO" --json body --jq .body > "$current_body_file"
+            issue_status=$(sed -n 's/^<!-- magent-elpa-monitor-status: \([^ ]*\) -->$/\1/p' "$current_body_file" | head -1)
+            failures=$(sed -n 's/^<!-- magent-elpa-monitor-failures: \([0-9][0-9]*\) -->$/\1/p' "$current_body_file" | head -1)
+            first_failure=$(sed -n 's/^<!-- magent-elpa-monitor-first-failure: \([^ ]*\) -->$/\1/p' "$current_body_file" | head -1)
+            failures=${failures:-0}
+          fi
+
+          if [ "$TEST_RESULT" = success ] && [ "$REPORT_RESULT" = success ]; then
+            if [ -z "$issue_number" ] || [ "$issue_status" = recovered ]; then
+              exit 0
+            fi
+
+            sed "s/^<!-- ${status_marker}: [^ ]* -->$/<!-- ${status_marker}: recovered -->/" \
+              "$current_body_file" > "$body_file"
+            gh issue edit "$issue_number" --repo "$GH_REPO" --body-file "$body_file"
+            recovery="The scheduled ELPA dependency monitor recovered in [this workflow run]($RUN_URL)."
+            if [ "$issue_state" = OPEN ]; then
+              gh issue close "$issue_number" --repo "$GH_REPO" --comment "$recovery"
+            else
+              gh issue comment "$issue_number" --repo "$GH_REPO" --body "$recovery"
+            fi
+            exit 0
+          fi
+
+          if [ "$issue_state" = CLOSED ] && [ "$issue_status" = failing ]; then
+            echo "The current incident was closed manually; suppressing a duplicate issue."
+            exit 0
+          fi
+
+          if [ -n "$REPORT_BASE64" ]; then
+            printf '%s' "$REPORT_BASE64" | base64 --decode > "$report_file"
+          else
+            : > "$report_file"
+          fi
+
+          if [ "$issue_state" = OPEN ]; then
+            failures=$((failures + 1))
+            first_failure=${first_failure:-$now}
+          else
+            issue_number=''
+            failures=1
+            first_failure=$now
+          fi
+
+          {
+            echo "$marker"
+            echo "<!-- ${status_marker}: failing -->"
+            echo "<!-- magent-elpa-monitor-failures: $failures -->"
+            echo "<!-- magent-elpa-monitor-first-failure: $first_failure -->"
+            echo "## Automated ELPA dependency monitor"
+            echo
+            echo "The scheduled latest-dependency check did not complete successfully. This issue is maintained by GitHub Actions."
+            echo
+            echo "| Component | Result |"
+            echo "| --- | --- |"
+            echo "| Full test workflow | $TEST_RESULT |"
+            echo "| Dependency report | $REPORT_RESULT |"
+            echo
+            echo "- Consecutive failures: $failures"
+            echo "- First failure: $first_failure"
+            echo "- Latest failure: $now"
+            echo "- [Workflow run]($RUN_URL)"
+            echo
+            echo "### Direct dependency report"
+            echo
+            if [ -s "$report_file" ]; then
+              echo '```text'
+              cat "$report_file"
+              echo '```'
+            else
+              echo "Dependency report unavailable; see the workflow logs."
+            fi
+          } > "$body_file"
+
+          if [ -n "$issue_number" ]; then
+            gh issue edit "$issue_number" --repo "$GH_REPO" --body-file "$body_file"
+          else
+            gh issue create \
+              --repo "$GH_REPO" \
+              --label dependencies \
+              --title "$title" \
+              --body-file "$body_file"
+          fi

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -1,0 +1,22 @@
+name: Label issues
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Apply labels from issue form fields
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const labelIssue = require('./.github/scripts/label-issue.js')
+            await labelIssue({github, context, core})

--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -24,7 +24,7 @@ jobs:
         # RECIPE is your recipe as written for MELPA:
         RECIPE: (magent :fetcher github :repo "Jamie-Cui/magent" :files ("lisp/magent*.el" "prompts" "skills"))
         # set this to true if warnings should be treated as errors:
-        WARN_IS_ERROR: false
+        WARN_IS_ERROR: true
         # set this to false (or remove it) if the package isn't on MELPA:
         EXIST_OK: false
       run: echo $GITHUB_REF && make -C ~/melpazoid

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,13 @@ permissions:
   contents: read
 
 jobs:
+  issue-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Test issue label mapping
+        run: node --test .github/scripts/label-issue.test.js
+
   ert:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,11 @@ name: Test
 on:
   push:
   pull_request:
+  workflow_call:
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   ert:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,10 @@ commands for interaction.
 
 - All files use `;;; -*- lexical-binding: t; -*-`
 - Use Conventional Commits for commit messages.
+- Keep the canonical package version in the `Package-Version` header of
+  `lisp/magent.el`; Git tags and GitHub Releases use the matching `vX.Y.Z`.
+  Record user-visible changes in `CHANGELOG.org` and follow
+  `docs/RELEASING.org` for compatibility and release decisions.
 - Core, built-in agent, slash-command, and internal runtime prompts are editable Org files under `prompts/`; every bundled Org prompt must also appear exactly once in `prompts/manifest.txt`; skill prompts remain self-contained in `skills/*/SKILL.md`
 - Tool implementations follow pattern: `magent-tools--<name>` (internal fn) + `magent-tools--<name>-tool` (gptel-tool var)
 - Byte-compile warnings suppressed: `cl-functions`

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,0 +1,22 @@
+#+TITLE: Changelog
+#+OPTIONS: toc:2 num:nil
+
+All notable user-visible changes to Magent are recorded here.  Entries are
+grouped by release and by ~Added~, ~Changed~, ~Deprecated~, ~Removed~, ~Fixed~,
+or ~Security~ when applicable.
+
+Magent follows Semantic Versioning as defined in
+[[file:docs/RELEASING.org][docs/RELEASING.org]].  There were no release tags before this changelog was
+introduced: version ~0.1.0~ was an untagged development preview, and the first
+intentional tagged release is planned as ~v0.2.0~.
+
+* Unreleased
+
+** Added
+
+- A documented Semantic Versioning policy, public compatibility boundary, and
+  repeatable release checklist.
+- The initial release baseline: the agent-shell and in-process ACP frontend,
+  Magent-owned tool loop, permission and approval controls, durable sessions
+  and child-agent jobs, Elisp-native Actions, instruction skills, automatic
+  capabilities, Doctor, and memory workflows.

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ SRCS = $(shell sed -e '/^[[:space:]]*\#/d' -e '/^[[:space:]]*$$/d' "$(SOURCE_MAN
 
 COMPILED = $(SRCS:.el=.elc)
 
-.PHONY: all compile lint check-declare package-lint clean purge test test-unit test-benchmark test-live test-live-smoke coverage help \
+.PHONY: all compile lint check-declare package-lint deps-check clean purge test test-unit test-benchmark test-live test-live-smoke coverage help \
 	benchmark benchmark-prepare benchmark-run benchmark-test
 
 all: compile
@@ -66,6 +66,7 @@ help:
 	@echo "  lint          - Validate declarations and package metadata"
 	@echo "  check-declare - Validate declarations in production Elisp files"
 	@echo "  package-lint  - Run package-lint with warnings treated as failures"
+	@echo "  deps-check    - Report direct dependencies available from ELPA archives"
 	@echo "  clean         - Remove build files and Harbor trial containers/networks"
 	@echo "  purge         - Clean plus benchmark Docker images and Harbor task cache"
 	@echo "  help          - Show this help message"
@@ -102,6 +103,12 @@ package-lint:
 		--eval '(setq package-lint-main-file (expand-file-name "lisp/magent.el") package-lint-batch-fail-on-warnings t)' \
 		-f package-lint-batch-and-exit $(SRCS)
 
+deps-check:
+	@echo "Checking direct ELPA dependencies..." 1>&2
+	@$(EMACS_BATCH) \
+		-l scripts/check-elpa-deps.el \
+		--eval '(magent-elpa-deps-check-batch "lisp/magent.el")'
+
 lisp/%.elc: lisp/%.el
 	@echo "Compiling $<..."
 	@out=$$($(EMACS_BATCH) $(LOADPATH) $(BYTE_COMPILE_FLAGS) -f batch-byte-compile $< 2>&1); \
@@ -115,6 +122,7 @@ test-unit:
 	@echo "Running unit tests..."
 	@$(EMACS_BATCH) $(LOADPATH) \
 		-l ert \
+		-l test/check-elpa-deps-test.el \
 		-l test/magent-test.el \
 		-f ert-run-tests-batch-and-exit
 

--- a/README.org
+++ b/README.org
@@ -11,6 +11,12 @@ tool access, an Elisp-native slash-command extension API through
 
 homepage: https://jamie-cui.github.io/magent/
 
+* Releases
+
+Magent follows Semantic Versioning.  See [[file:CHANGELOG.org][CHANGELOG.org]] for release history and
+current development status, and [[file:docs/RELEASING.org][docs/RELEASING.org]] for the versioning policy,
+public compatibility boundary, and release checklist.
+
 * Agent Workflow
 
 Magent now uses a durable child-agent lifecycle for collaborative agent work: spawn, message, wait, list, resume/inspect, and close. The lifecycle is implemented on top of the Magent-owned agent loop while provider integration stays with ~gptel-request~.

--- a/docs/CONTRIBUTING.org
+++ b/docs/CONTRIBUTING.org
@@ -62,6 +62,9 @@ All files must include:
 - Use ~;;;~ for section headers
 - Use ~;;~ for inline comments
 - Update README.org for user-facing changes
+- Add user-visible changes to the ~Unreleased~ section of ~CHANGELOG.org~
+- Read ~docs/RELEASING.org~ before changing a public compatibility contract,
+  package version, or release artifact
 - Update AGENTS.md for developer-facing changes
 - Update ~docs/AGENT_JOBS.org~ for child-agent lifecycle changes
 - Update the relevant plan before stopping interrupted plan-driven work
@@ -142,12 +145,13 @@ license identifier.
 
 * Pull Request Process
 
-1. *Fork and branch* — Create a feature branch from ~dev~
+1. *Fork and branch* — Create a feature branch from ~master~
 2. *Make changes* — Follow code style and add tests
 3. *Test* — Run ~make test~ and verify manually
-4. *Document* — Update relevant docs, including CI/package docs when build metadata changes
+4. *Document* — Update relevant docs and ~CHANGELOG.org~, including
+   CI/package docs when build metadata changes
 5. *Commit* — Use conventional commits: ~feat:~, ~fix:~, ~docs:~, ~test:~
-6. *Submit PR* — Target the ~dev~ branch
+6. *Submit PR* — Target the ~master~ branch
 
 * Areas for Contribution
 

--- a/docs/CONTRIBUTING.zh.org
+++ b/docs/CONTRIBUTING.zh.org
@@ -67,6 +67,9 @@ Makefile 会自动探测 ~~/.emacs.d/elpa/~ 下的 ELPA dependency directories�
 - 用 ~;;;~ 做 section headers。
 - 用 ~;;~ 做 inline comments。
 - 用户可见变化更新 ~README.org~ 。
+- User-visible changes 添加到 ~CHANGELOG.org~ 的 ~Unreleased~ section。
+- 修改 public compatibility contract、package version 或 release artifact 前阅读
+  ~docs/RELEASING.zh.org~。
 - 面向开发者的变化更新 ~AGENTS.md~ 或 ~docs/~ 中对应文档。
 - child-agent lifecycle 变化更新 ~docs/AGENT_JOBS.org~ 。
 - plan-driven 工作中断前，更新相关 plan 或 task note。
@@ -138,12 +141,13 @@ Package metadata 保持集中在 ~magent.el~ 和 ~magent-pkg.el~ 。不要在 se
 
 * Pull Request 流程
 
-1. *Fork and branch* ：从 ~dev~ 创建 feature branch。
+1. *Fork and branch* ：从 ~master~ 创建 feature branch。
 2. *Make changes* ：遵循代码风格并添加测试。
 3. *Test* ：运行 ~make test~ 并做必要手动验证。
-4. *Document* ：更新相关文档；构建元数据变化要同步更新 CI/package docs。
+4. *Document* ：更新相关文档和 ~CHANGELOG.org~；构建元数据变化要同步更新
+   CI/package docs。
 5. *Commit* ：使用 Conventional Commits，例如 ~feat:~ 、 ~fix:~ 、 ~docs:~ 、 ~test:~ 。
-6. *Submit PR* ：目标分支为 ~dev~ 。
+6. *Submit PR* ：目标分支为 ~master~ 。
 
 * 可贡献方向
 

--- a/docs/README.org
+++ b/docs/README.org
@@ -23,10 +23,12 @@ Welcome to the Magent documentation. Magent is an Emacs Lisp AI coding agent wit
 
 ** Contribution
 - [[file:CONTRIBUTING.html][CONTRIBUTING.org]] — Contribution guidelines, code style, testing, and PR process
+- [[file:RELEASING.html][RELEASING.org]] — Versioning policy, public compatibility boundary, changelog rules, and release checklist
 - [[file:TROUBLESHOOTING.html#github-actions-failures][TROUBLESHOOTING.org]] — CI, live smoke, and melpazoid failure notes
 
 ** Project Root Documentation
 - [[https://github.com/jamie-cui/magent/blob/master/README.org][../README.org]] — Main project README with features, installation, and usage
+- [[https://github.com/jamie-cui/magent/blob/master/CHANGELOG.org][../CHANGELOG.org]] — Release history and current unreleased changes
 - [[https://github.com/jamie-cui/magent/blob/master/AGENTS.md][../AGENTS.md]] — Development guide for agentic coding tools with build commands, architecture notes, and repository conventions
 
 * Quick Links
@@ -52,12 +54,14 @@ Welcome to the Magent documentation. Magent is an Emacs Lisp AI coding agent wit
 5. [[file:AGENT_JOBS.html][AGENT_JOBS.org]] — Current child-agent job architecture
 6. [[file:UI_BACKENDS.html][UI_BACKENDS.org]] — Current frontend support boundary
 7. [[file:DOCTOR.html][DOCTOR.org]] — Doctor data boundary and extension contract
+8. [[file:RELEASING.html][RELEASING.org]] — Versioning and release process
 
 ** CI And Packaging
 1. [[https://github.com/jamie-cui/magent/blob/master/README.org][../README.org]] — Public workflow badges and development commands
 2. [[file:CONTRIBUTING.html#continuous-integration][CONTRIBUTING.org]] — Local and CI verification sequence
 3. [[file:TROUBLESHOOTING.html#github-actions-failures][TROUBLESHOOTING.org]] — Known GitHub Actions failure signatures
 4. [[https://github.com/jamie-cui/magent/blob/master/AGENTS.md#testing][../AGENTS.md]] — Agent-facing test, coverage, live smoke, and melpazoid notes
+5. [[file:RELEASING.html][RELEASING.org]] — Release gates and artifact checks
 
 * Documentation Standards
 

--- a/docs/README.zh.org
+++ b/docs/README.zh.org
@@ -26,11 +26,13 @@
 ** 贡献
 
 - [[file:../CONTRIBUTING.zh.html][CONTRIBUTING.zh.org]] ：贡献流程、代码风格、测试和 PR 要求。
+- [[file:../RELEASING.zh.html][RELEASING.zh.org]] ：版本规则、公开兼容边界、changelog 规则和 release checklist。
 - [[file:../TROUBLESHOOTING.zh.html#github-actions-失败][TROUBLESHOOTING.zh.org#github-actions-失败]] ：CI、live smoke 和 melpazoid 常见失败。
 
 ** 仓库根目录文档
 
 - [[https://github.com/jamie-cui/magent/blob/master/README.org][../README.org]] ：主 README，包含特性、安装和使用说明。
+- [[https://github.com/jamie-cui/magent/blob/master/CHANGELOG.org][../CHANGELOG.org]] ：发布历史和当前 unreleased changes。
 - [[https://github.com/jamie-cui/magent/blob/master/AGENTS.md][../AGENTS.md]] ：面向 agentic coding 工具的开发指南，包含构建命令、架构要点和仓库约定。
 
 * 推荐阅读路径
@@ -59,6 +61,7 @@
 5. [[file:../AGENT_JOBS.zh.html][AGENT_JOBS.zh.org]]：child-agent job 架构。
 6. [[file:../UI_BACKENDS.zh.html][UI_BACKENDS.zh.org]]：当前 frontend 支持边界。
 7. [[file:../DOCTOR.zh.html][DOCTOR.zh.org]]：Doctor 数据边界和扩展契约。
+8. [[file:../RELEASING.zh.html][RELEASING.zh.org]]：版本和发布流程。
 
 ** CI 与打包
 
@@ -66,6 +69,7 @@
 2. [[file:../CONTRIBUTING.zh.html#持续集成][CONTRIBUTING.zh.org#持续集成]]：本地和 CI 验证顺序。
 3. [[file:../TROUBLESHOOTING.zh.html#github-actions-失败][TROUBLESHOOTING.zh.org#github-actions-失败]]：GitHub Actions 失败特征。
 4. [[https://github.com/jamie-cui/magent/blob/master/AGENTS.md#testing][../AGENTS.md#testing]]：面向 agent 的测试、coverage、live smoke 和 melpazoid 说明。
+5. [[file:../RELEASING.zh.html][RELEASING.zh.org]]：release gates 和 artifact checks。
 
 * 文档维护标准
 

--- a/docs/RELEASING.org
+++ b/docs/RELEASING.org
@@ -1,0 +1,185 @@
+#+title: Releasing Magent
+#+magent_lang: en
+#+magent_alt_url: /RELEASING.zh.html
+#+options: toc:2 num:nil
+
+This document defines Magent's versioning policy, compatibility boundary, and
+release procedure.  It is the canonical release policy; the release history
+lives in [[https://github.com/jamie-cui/magent/blob/master/CHANGELOG.org][CHANGELOG.org]].
+
+* Initial Release Baseline
+
+When this policy was adopted, the source declared version ~0.1.0~ and Magent
+had not published a Git tag or GitHub Release.  The ~0.1.0~ line is therefore
+an untagged development preview.  The first intentional tagged release is
+~v0.2.0~, establishing the baseline for subsequent compatibility decisions.
+
+* Version Source of Truth
+
+- The tracked source of truth is the ~Package-Version~ header in
+  ~lisp/magent.el~.
+- Package metadata uses ~X.Y.Z~ without a leading ~v~.  Git tags and GitHub
+  Releases use ~vX.Y.Z~.
+- After removing the tag's leading ~v~, the tag and ~Package-Version~ must be
+  identical, including any pre-release suffix.
+- Generated package descriptors such as ~magent-pkg.el~ must agree with the
+  header, but are not a second hand-maintained version source.
+- The Python package under ~benchmark/~ has an independent lifecycle and is not
+  required to share Magent's version.
+
+Magent intentionally has no root ~VERSION~ file.  A hand-maintained ~VERSION~
+would duplicate the package header without adding information.  If future
+release tooling requires a raw version file, it should generate and validate
+that file from ~lisp/magent.el~ rather than make maintainers update both.
+
+* Semantic Versioning Policy
+
+Magent follows [[https://semver.org/][Semantic Versioning 2.0.0]].  The highest-impact change included in a
+release determines the version bump.
+
+** Before ~1.0.0~
+
+The ~0.Y.Z~ series communicates active development while still giving users a
+predictable upgrade signal.
+
+| Change                                                        | Next version |
+|---------------------------------------------------------------+--------------|
+| New functionality or any backward-incompatible public change | ~0.(Y+1).0~  |
+| Backward-compatible bug or security fix only                  | ~0.Y.(Z+1)~  |
+| Documentation, test, CI, or internal-only maintenance         | No release required on its own |
+
+Examples:
+
+- ~0.2.0~ to ~0.2.1~ for a compatible session-save bug fix.
+- ~0.2.1~ to ~0.3.0~ for a new Action feature.
+- ~0.2.1~ to ~0.3.0~ when a tool argument, public command, or file format is
+  changed incompatibly.
+
+** From ~1.0.0~ Onward
+
+| Change                                        | Version component |
+|-----------------------------------------------+-------------------|
+| Backward-incompatible public change           | Major             |
+| Backward-compatible functionality             | Minor             |
+| Backward-compatible bug or security fix only  | Patch             |
+
+Deprecating public functionality requires at least a minor release.  Removing
+or incompatibly changing it requires a major release.
+
+** Public Compatibility Boundary
+
+Unless a document explicitly marks an interface experimental, the release
+version covers:
+
+- documented interactive commands and ~defcustom~ options;
+- documented public Elisp functions, including the ~magent-action~ extension
+  API;
+- project-facing agent, skill, capability, permission, and Action definition
+  formats under ~.magent/~;
+- canonical tool names, arguments, approval behavior, and result contracts;
+- supported session and Action persistence formats, including whether sessions
+  created by an earlier release remain readable;
+- documented agent-shell/ACP frontend behavior; and
+- minimum supported Emacs and direct package dependency versions.
+
+Increasing a minimum supported runtime or dependency version is a breaking
+change.  Internal symbols containing ~--~, implementation details, tests,
+benchmarks, and undocumented provider-adapter internals are not public API.
+User-visible behavioral changes should still be recorded in ~CHANGELOG.org~.
+
+** Commit Signals
+
+Magent uses Conventional Commits as input to release decisions:
+
+- ~fix:~ normally indicates a patch change;
+- ~feat:~ normally indicates a minor change;
+- ~!~ or a ~BREAKING CHANGE:~ footer indicates a compatibility break;
+- ~docs:~, ~test:~, ~ci:~, and ~chore:~ do not require a release by themselves;
+  and
+- ~refactor:~ is classified by its observable compatibility impact.
+
+The actual public effect wins when a commit prefix and the change disagree.
+Before ~1.0.0~, both compatible features and breaking changes increment the
+minor component.  From ~1.0.0~ onward, a breaking change increments the major
+component.
+
+* Pre-releases
+
+Prefer stable releases unless external testing is useful.  When needed, use an
+Emacs-compatible SemVer suffix and keep it identical in the package header and
+tag, for example:
+
+#+begin_example
+Package-Version: 0.3.0-pre.1
+Git tag:          v0.3.0-pre.1
+#+end_example
+
+Increment ~pre.1~, ~pre.2~, and so on.  A pre-release is not a compatibility
+promise for the associated final version.  Do not use build metadata in package
+versions unless its ordering and package-archive behavior have first been
+validated.
+
+* Changelog Policy
+
+- Every user-visible pull request adds a concise entry under ~Unreleased~.
+- Describe effects for users and extension authors, not commit mechanics.
+- Put breaking changes first and label them ~BREAKING~.
+- At release time, rename the accumulated section to ~X.Y.Z - YYYY-MM-DD~ and
+  create a new empty ~Unreleased~ section above it.
+- Do not rewrite the notes or artifacts of an existing release.  Correct a
+  released defect with a new version.
+
+* Release Procedure
+
+** Prepare the Release Pull Request
+
+1. Start from current ~master~ and create a release branch.
+2. Confirm the intended version from all changes since the previous tag.  For
+   the first formal release, use ~0.2.0~ and treat ~0.1.0~ as the untagged
+   development preview.
+3. Update ~Package-Version~ in ~lisp/magent.el~.
+4. Finalize ~CHANGELOG.org~: move the relevant ~Unreleased~ entries under the
+   version and release date, and leave a fresh ~Unreleased~ section.
+5. Verify package requirements, the MELPA recipe, ~source-files.txt~, and
+   bundled runtime data remain aligned.
+6. From a clean checkout, run:
+
+#+begin_src sh
+make clean
+make compile
+make lint
+make test
+#+end_src
+
+7. Obtain green required CI for supported Emacs versions, coverage, MELPA
+   packaging, ELPA dependency compatibility, and documentation.
+8. Merge the release pull request into ~master~.  Do not tag a feature branch.
+
+** Tag and Publish
+
+1. Update the local ~master~ with a fast-forward-only pull.
+2. Verify that ~Package-Version~, the changelog release heading, and the
+   intended tag agree.
+3. Create an annotated tag; use a signed tag when signing is configured:
+
+#+begin_src sh
+git tag -a v0.2.0 -m "Magent v0.2.0"
+git push origin v0.2.0
+#+end_src
+
+4. Create the GitHub Release from that tag and copy the matching changelog
+   section into the release notes.
+5. Verify that the release tag installs from a clean Emacs configuration and
+   contains all production Elisp, prompts, and bundled skills.
+
+Tags and published release artifacts are immutable.  If a problem is found
+after publication, fix it on ~master~ and publish a new patch release rather
+than moving or replacing the tag.
+
+* ~1.0.0~ Readiness
+
+Publish ~1.0.0~ when maintainers are prepared to preserve the documented public
+compatibility boundary: installation and supported frontend behavior are
+reliable, the Action extension API and project formats are documented, and
+persistence compatibility has an explicit policy.  Reaching ~1.0.0~ is a
+compatibility commitment, not a measure of feature count.

--- a/docs/RELEASING.zh.org
+++ b/docs/RELEASING.zh.org
@@ -1,0 +1,165 @@
+#+title: 发布 Magent
+#+magent_lang: zh
+#+magent_alt_url: /RELEASING.html
+#+options: toc:2 num:nil
+
+本文定义 Magent 的版本规则、兼容边界和发布流程，是 canonical release
+policy；发布历史记录在
+[[https://github.com/jamie-cui/magent/blob/master/CHANGELOG.org][CHANGELOG.org]]。
+
+* 初始发布基线
+
+采用本规则时，源码声明为 ~0.1.0~，且 Magent 尚未发布任何 Git tag 或 GitHub
+Release。因此 ~0.1.0~ 属于未打 tag 的 development preview；第一个有意维护的
+正式 tag 是 ~v0.2.0~，它将成为后续兼容性判断的基线。
+
+* 版本唯一真相源
+
+- 受 Git 跟踪的唯一真相源是 ~lisp/magent.el~ 中的 ~Package-Version~ header。
+- Package metadata 使用不带 ~v~ 的 ~X.Y.Z~；Git tag 和 GitHub Release 使用
+  ~vX.Y.Z~。
+- 去掉 tag 开头的 ~v~ 后，它必须与 ~Package-Version~ 完全相同，包括
+  pre-release suffix。
+- ~magent-pkg.el~ 等 generated package descriptors 必须与 header 一致，但不作为
+  第二份手工维护的版本来源。
+- ~benchmark/~ 下的 Python package 有独立生命周期，不要求与 Magent 同版本。
+
+Magent 有意不添加根目录 ~VERSION~ 文件。手工维护的 ~VERSION~ 只会重复 package
+header，不能提供额外信息。如果未来 release tooling 必须读取 raw version file，
+应从 ~lisp/magent.el~ 生成并验证它，而不是要求 maintainer 同时修改两处。
+
+* Semantic Versioning 规则
+
+Magent 遵循 [[https://semver.org/][Semantic Versioning 2.0.0]]。一次 release 包含的最高影响级别
+决定版本增量。
+
+** ~1.0.0~ 之前
+
+~0.Y.Z~ 表示项目仍在快速开发，但仍为用户提供可预测的升级信号。
+
+| 变化                                               | 下一个版本 |
+|----------------------------------------------------+------------|
+| 新功能，或任何不向后兼容的公开变化                 | ~0.(Y+1).0~ |
+| 仅包含向后兼容的 bug fix 或 security fix           | ~0.Y.(Z+1)~ |
+| 仅文档、测试、CI 或内部维护                        | 无需单独发布 |
+
+示例：
+
+- ~0.2.0~ 到 ~0.2.1~：修复 session 保存问题且保持兼容。
+- ~0.2.1~ 到 ~0.3.0~：新增 Action 功能。
+- ~0.2.1~ 到 ~0.3.0~：不兼容地修改 tool 参数、公开命令或文件格式。
+
+** ~1.0.0~ 起
+
+| 变化                                      | 递增部分 |
+|-------------------------------------------+----------|
+| 不向后兼容的公开变化                      | Major    |
+| 向后兼容的新功能                          | Minor    |
+| 仅向后兼容的 bug fix 或 security fix      | Patch    |
+
+弃用公开功能至少需要 minor release；删除或不兼容地修改它需要 major release。
+
+** 公开兼容边界
+
+除非文档明确标记为 experimental，release version 覆盖：
+
+- 文档化的 interactive commands 和 ~defcustom~ options；
+- 文档化的 public Elisp functions，包括 ~magent-action~ extension API；
+- ~.magent/~ 下供项目使用的 agent、skill、capability、permission 和 Action
+  definition formats；
+- canonical tool names、arguments、approval behavior 和 result contracts；
+- 支持的 session 与 Action persistence formats，包括旧 release 创建的 session
+  是否仍可读取；
+- 文档化的 agent-shell/ACP frontend behavior；以及
+- 最低支持的 Emacs 和 direct package dependency versions。
+
+提高最低 runtime 或 dependency version 属于 breaking change。包含 ~--~ 的内部
+symbols、implementation details、tests、benchmarks 和未文档化的 provider-adapter
+internals 不属于 public API；但 user-visible behavior change 仍应记录到
+~CHANGELOG.org~。
+
+** Commit 信号
+
+Magent 使用 Conventional Commits 辅助 release 判断：
+
+- ~fix:~ 通常表示 patch change；
+- ~feat:~ 通常表示 minor change；
+- ~!~ 或 ~BREAKING CHANGE:~ footer 表示 compatibility break；
+- ~docs:~、~test:~、~ci:~ 和 ~chore:~ 本身不要求发布；
+- ~refactor:~ 按实际可观察的兼容影响分类。
+
+如果 commit prefix 与实际影响不一致，以 public effect 为准。~1.0.0~ 之前，兼容新
+功能和 breaking change 都递增 minor；~1.0.0~ 起，breaking change 递增 major。
+
+* Pre-release
+
+除非确实需要外部测试，否则优先发布 stable release。需要时，使用 Emacs 可正确
+排序的 SemVer suffix，并确保 package header 与 tag 完全一致，例如：
+
+#+begin_example
+Package-Version: 0.3.0-pre.1
+Git tag:          v0.3.0-pre.1
+#+end_example
+
+依次递增 ~pre.1~、~pre.2~。Pre-release 不承诺满足对应 final version 的兼容要求。
+在确认排序和 package archive behavior 之前，不要在 package version 中使用 build
+metadata。
+
+* Changelog 规则
+
+- 每个 user-visible pull request 都在 ~Unreleased~ 下添加一条简洁记录。
+- 描述对用户和 extension author 的影响，而不是 commit mechanics。
+- Breaking changes 放在最前，并标记为 ~BREAKING~。
+- 发布时，把累计内容改为 ~X.Y.Z - YYYY-MM-DD~，并在上方创建新的空
+  ~Unreleased~ section。
+- 不重写已发布版本的 notes 或 artifacts；已发布问题用新版本修复。
+
+* 发布流程
+
+** 准备 Release Pull Request
+
+1. 从最新 ~master~ 创建 release branch。
+2. 根据上一个 tag 以来的全部变化确认版本。第一个正式 release 使用 ~0.2.0~，并将
+   ~0.1.0~ 视为 untagged development preview。
+3. 更新 ~lisp/magent.el~ 中的 ~Package-Version~。
+4. 整理 ~CHANGELOG.org~：把相关 ~Unreleased~ entries 移到带 version 和 date 的
+   section，并留下新的 ~Unreleased~ section。
+5. 确认 package requirements、MELPA recipe、~source-files.txt~ 和 bundled runtime
+   data 保持一致。
+6. 在 clean checkout 中运行：
+
+#+begin_src sh
+make clean
+make compile
+make lint
+make test
+#+end_src
+
+7. 确认 supported Emacs versions、coverage、MELPA packaging、ELPA dependency
+   compatibility 和 documentation 的 required CI 全部通过。
+8. 把 release pull request 合入 ~master~；不要在 feature branch 上打正式 tag。
+
+** Tag 与发布
+
+1. 用 fast-forward-only pull 更新本地 ~master~。
+2. 确认 ~Package-Version~、changelog release heading 和目标 tag 完全一致。
+3. 创建 annotated tag；已配置 signing 时使用 signed tag：
+
+#+begin_src sh
+git tag -a v0.2.0 -m "Magent v0.2.0"
+git push origin v0.2.0
+#+end_src
+
+4. 从该 tag 创建 GitHub Release，并把对应 changelog section 复制到 release notes。
+5. 从 clean Emacs configuration 验证 release tag 可安装，且包含全部 production
+   Elisp、prompts 和 bundled skills。
+
+Tag 和已发布 artifacts 不可变。发布后发现问题时，应在 ~master~ 修复并发布新的
+patch release，不得移动或替换原 tag。
+
+* ~1.0.0~ 准入条件
+
+当 maintainer 愿意维护文档化的公开兼容边界时再发布 ~1.0.0~：安装和 supported
+frontend behavior 足够可靠，Action extension API 和 project formats 已有完整文档，
+且 persistence compatibility 有明确政策。~1.0.0~ 是兼容性承诺，不是 feature
+数量指标。

--- a/lisp/magent-action.el
+++ b/lisp/magent-action.el
@@ -1041,19 +1041,19 @@ Project Action files are not currently supported."
          (setq finalization-error err))))
     (when finalization-error
       (let ((original-status status)
-            (message
+            (finalization-message
              (format "Action finalization failed: %s"
                      (error-message-string finalization-error))))
         (setq status 'failed
               result
               (magent-execution-result-failed
-               message
+               finalization-message
                (list :status 'finalization-error
                      :original-status original-status))
               fallback-response nil)
         (setf (magent-action-invocation-status invocation) status
               (magent-action-invocation-result invocation) result)
-        (magent-log "ERROR %s" message)))
+        (magent-log "ERROR %s" finalization-message)))
     ;; A stale callback must not clear a newer invocation installed for the
     ;; same control session after live reload or extension-managed recovery.
     (when (and control-session

--- a/lisp/magent-agent-loop.el
+++ b/lisp/magent-agent-loop.el
@@ -493,12 +493,12 @@ across Magent's own serial tool queue without claiming OS-level isolation."
                        :error "Error: Tool execution interrupted")))
                     (error
                      (complete
-                      (let ((message
+                      (let ((failure-message
                              (format "Error: Tool execution failed: %s"
                                      (error-message-string err))))
                         (magent-tool-result-create
                          :status 'failed :success nil
-                         :output message :error message)))))
+                         :output failure-message :error failure-message)))))
                 (complete
                  (condition-case err
                      (apply fn fn-args)

--- a/scripts/build-docs.el
+++ b/scripts/build-docs.el
@@ -44,6 +44,7 @@
            ("Child Agents" . "/AGENT_JOBS.html")
            ("UI Backends" . "/UI_BACKENDS.html")
            ("Troubleshooting" . "/TROUBLESHOOTING.html")
+           ("Releasing" . "/RELEASING.html")
            ("Contributing" . "/CONTRIBUTING.html")))
     (zh . (("总览" . "/zh/")
            ("命令" . "/COMMANDS.zh.html")
@@ -53,6 +54,7 @@
            ("子 Agent" . "/AGENT_JOBS.zh.html")
            ("UI 后端" . "/UI_BACKENDS.zh.html")
            ("故障排查" . "/TROUBLESHOOTING.zh.html")
+           ("发布" . "/RELEASING.zh.html")
            ("贡献" . "/CONTRIBUTING.zh.html")))))
 
 (defun magent-docs--external-url-p (url)
@@ -171,6 +173,8 @@ REPLACEMENTS is an alist of string placeholders to string values."
                  "UI_BACKENDS.zh.org"
                  "TROUBLESHOOTING.org"
                  "TROUBLESHOOTING.zh.org"
+                 "RELEASING.org"
+                 "RELEASING.zh.org"
                  "CONTRIBUTING.org"
                  "CONTRIBUTING.zh.org")))
     (cl-sort files #'<

--- a/scripts/check-elpa-deps.el
+++ b/scripts/check-elpa-deps.el
@@ -1,0 +1,153 @@
+;;; check-elpa-deps.el --- Report direct ELPA dependency versions  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Jamie Cui
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; Read a package's Package-Requires header, compare each direct dependency
+;; with the newest version advertised by GNU ELPA, NonGNU ELPA, or MELPA,
+;; and print a tab-separated report.  Declared versions are compatibility
+;; minimums, so newer versions are informational rather than failures.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'package)
+(require 'subr-x)
+
+(defconst magent-elpa-deps--archives
+  '(("gnu" . "https://elpa.gnu.org/packages/")
+    ("nongnu" . "https://elpa.nongnu.org/nongnu/")
+    ("melpa" . "https://melpa.org/packages/"))
+  "Package archives used by Magent's dependency checks.")
+
+(defun magent-elpa-deps--requirements (package-file)
+  "Return direct requirements declared by PACKAGE-FILE."
+  (with-temp-buffer
+    (insert-file-contents package-file)
+    (mapcar
+     (lambda (requirement)
+       (list (car requirement)
+             (package-version-join (cadr requirement))))
+     (package-desc-reqs (package-buffer-info)))))
+
+(defun magent-elpa-deps--missing-archives (package-dir)
+  "Return archive names that were not downloaded under PACKAGE-DIR."
+  (cl-loop for (name . _url) in magent-elpa-deps--archives
+           unless (file-readable-p
+                   (expand-file-name
+                    (format "archives/%s/archive-contents" name)
+                    package-dir))
+           collect name))
+
+(defun magent-elpa-deps--archive-descriptors (package)
+  "Return archive descriptors for PACKAGE across supported Emacs versions."
+  (let ((entry (cdr (assq package package-archive-contents))))
+    (cond
+     ((package-desc-p entry) (list entry))
+     ((listp entry) (cl-remove-if-not #'package-desc-p entry))
+     (t nil))))
+
+(defun magent-elpa-deps--latest-descriptor (package)
+  "Return the newest available archive descriptor for PACKAGE."
+  (let ((descriptors (magent-elpa-deps--archive-descriptors package)))
+    (when descriptors
+      (cl-reduce
+       (lambda (left right)
+         (if (version-list-< (package-desc-version left)
+                             (package-desc-version right))
+             right
+           left))
+       (cdr descriptors)
+       :initial-value (car descriptors)))))
+
+(defun magent-elpa-deps--print-row (package minimum candidate source status)
+  "Print one dependency report row.
+
+PACKAGE is the dependency name, MINIMUM is its declared version, CANDIDATE is
+the checked version, SOURCE identifies its origin, and STATUS is the result."
+  (princ (format "%s\t%s\t%s\t%s\t%s\n"
+                 package minimum candidate source status)))
+
+(defun magent-elpa-deps--report (requirements)
+  "Print a report for REQUIREMENTS and return an exit status.
+
+Return zero when every declared minimum can be satisfied, or one otherwise."
+  (let ((failed nil))
+    (princ "package\tminimum\tcandidate\tsource\tstatus\n")
+    (dolist (requirement requirements)
+      (let ((package (car requirement))
+            (minimum (cadr requirement)))
+        (if (eq package 'emacs)
+            (let ((satisfied (not (version< emacs-version minimum))))
+              (unless satisfied
+                (setq failed t))
+              (magent-elpa-deps--print-row
+               package minimum emacs-version "runtime"
+               (if satisfied "satisfied" "minimum-unavailable")))
+          (let ((descriptor (magent-elpa-deps--latest-descriptor package)))
+            (if (null descriptor)
+                (progn
+                  (setq failed t)
+                  (magent-elpa-deps--print-row
+                   package minimum "-" "-" "unavailable"))
+              (let* ((candidate
+                      (package-version-join
+                       (package-desc-version descriptor)))
+                     (status
+                      (cond
+                       ((version< candidate minimum)
+                        (setq failed t)
+                        "minimum-unavailable")
+                       ((version< minimum candidate) "newer-available")
+                       (t "exact"))))
+                (magent-elpa-deps--print-row
+                 package minimum candidate
+                 (or (package-desc-archive descriptor) "unknown")
+                 status)))))))
+    (if failed 1 0)))
+
+(defun magent-elpa-deps-check-file (package-file)
+  "Report direct dependency versions for PACKAGE-FILE.
+
+Archive metadata must already be present in `package-archive-contents'."
+  (magent-elpa-deps--report
+   (magent-elpa-deps--requirements package-file)))
+
+(defun magent-elpa-deps--refresh-and-run (operation)
+  "Refresh archive metadata and return the status from OPERATION."
+  (let ((temporary-package-dir
+         (make-temp-file "magent-elpa-deps-" t))
+        status)
+    (unwind-protect
+        (setq status
+              (condition-case error-data
+                  (let ((package-user-dir temporary-package-dir)
+                        (package-gnupghome-dir
+                         (expand-file-name "gnupg" temporary-package-dir))
+                        (package-archives magent-elpa-deps--archives)
+                        (package-archive-contents nil))
+                    (package-refresh-contents)
+                    (let ((missing-archives
+                           (magent-elpa-deps--missing-archives
+                            temporary-package-dir)))
+                      (when missing-archives
+                        (error "Failed to refresh package archives: %s"
+                               (string-join missing-archives ", "))))
+                    (funcall operation))
+                (error
+                 (message "Dependency check failed: %s"
+                          (error-message-string error-data))
+                 2)))
+      (delete-directory temporary-package-dir t))
+    status))
+
+(defun magent-elpa-deps-check-batch (package-file)
+  "Refresh archive metadata, check PACKAGE-FILE, and exit Emacs."
+  (kill-emacs
+   (magent-elpa-deps--refresh-and-run
+    (lambda () (magent-elpa-deps-check-file package-file)))))
+
+(provide 'check-elpa-deps)
+;;; check-elpa-deps.el ends here

--- a/test/check-elpa-deps-test.el
+++ b/test/check-elpa-deps-test.el
@@ -1,0 +1,96 @@
+;;; check-elpa-deps-test.el --- Tests for direct dependency checks  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Offline tests for scripts/check-elpa-deps.el.
+
+;;; Code:
+
+(require 'ert)
+(load (expand-file-name "../scripts/check-elpa-deps.el"
+                        (file-name-directory
+                         (or load-file-name buffer-file-name)))
+      nil t)
+
+(defconst magent-elpa-deps-test--root
+  (expand-file-name ".."
+                    (file-name-directory
+                     (or load-file-name buffer-file-name)))
+  "Magent repository root used by dependency-check tests.")
+
+(defun magent-elpa-deps-test--descriptor (name version archive)
+  "Return a test descriptor for NAME VERSION from ARCHIVE."
+  (package-desc-create
+   :name name
+   :version (version-to-list version)
+   :summary "Test package"
+   :reqs nil
+   :kind 'single
+   :archive archive))
+
+(ert-deftest magent-elpa-deps-test-reads-package-requires ()
+  "Read dependency metadata from the canonical package file."
+  (let ((requirements
+          (magent-elpa-deps--requirements
+           (expand-file-name "lisp/magent.el"
+                             magent-elpa-deps-test--root))))
+    (should (equal (cadr (assq 'emacs requirements)) "29.1"))
+    (should (equal (cadr (assq 'gptel requirements)) "0.9.8"))))
+
+(ert-deftest magent-elpa-deps-test-detects-missing-archive-downloads ()
+  "Distinguish archive download failures from unavailable packages."
+  (let* ((package-dir (expand-file-name "magent-elpa-deps-test"
+                                        temporary-file-directory))
+         (gnu-contents
+          (expand-file-name "archives/gnu/archive-contents" package-dir)))
+    (cl-letf (((symbol-function 'file-readable-p)
+               (lambda (file) (equal file gnu-contents))))
+      (should (equal (magent-elpa-deps--missing-archives package-dir)
+                     '("nongnu" "melpa"))))))
+
+(ert-deftest magent-elpa-deps-test-reports-newer-version-without-failing ()
+  "Treat a newer archive version as information, not an error."
+  (let* ((descriptor
+          (magent-elpa-deps-test--descriptor 'example "2.0" "gnu"))
+         (package-archive-contents `((example ,descriptor)))
+         output status)
+    (with-temp-buffer
+      (let ((standard-output (current-buffer)))
+        (setq status
+              (magent-elpa-deps--report
+               '((emacs "29.1") (example "1.0"))))
+        (setq output (buffer-string))))
+    (should (= status 0))
+    (should (string-match-p
+             "example\t1.0\t2.0\tgnu\tnewer-available"
+             output))))
+
+(ert-deftest magent-elpa-deps-test-selects-newest-archive-version ()
+  "Select the newest descriptor when archives advertise several versions."
+  (let* ((old (magent-elpa-deps-test--descriptor 'example "1.5" "gnu"))
+         (new (magent-elpa-deps-test--descriptor 'example "2.0" "melpa"))
+         (package-archive-contents `((example ,old ,new))))
+    (should (eq (magent-elpa-deps--latest-descriptor 'example) new))))
+
+(ert-deftest magent-elpa-deps-test-fails-for-unavailable-minimum ()
+  "Fail when a package is missing or its declared minimum is unavailable."
+  (let* ((descriptor
+          (magent-elpa-deps-test--descriptor 'old "1.0" "gnu"))
+         (package-archive-contents `((old ,descriptor)))
+         output status)
+    (with-temp-buffer
+      (let ((standard-output (current-buffer)))
+        (setq status
+              (magent-elpa-deps--report
+               '((old "2.0") (missing "1.0"))))
+        (setq output (buffer-string))))
+    (should (= status 1))
+    (should (string-match-p
+             "old\t2.0\t1.0\tgnu\tminimum-unavailable"
+             output))
+    (should (string-match-p
+             "missing\t1.0\t-\t-\tunavailable"
+             output))))
+
+(provide 'check-elpa-deps-test)
+;;; check-elpa-deps-test.el ends here

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -356,6 +356,17 @@
                     (magent-test-source-files
                      magent-test--root-directory)))))
 
+(ert-deftest magent-test-melpazoid-treats-warnings-as-errors ()
+  "Test melpazoid warnings fail CI."
+  (with-temp-buffer
+    (insert-file-contents
+     (expand-file-name ".github/workflows/melpazoid.yml"
+                       magent-test--root-directory))
+    (should
+     (re-search-forward
+      "^[[:space:]]*WARN_IS_ERROR:[[:space:]]*true[[:space:]]*$"
+      nil t))))
+
 (ert-deftest magent-test-package-dependencies-use-stable-agent-shell ()
   "Test package metadata requires the reviewed stable frontend releases."
   (let ((main-file (expand-file-name "lisp/magent.el"


### PR DESCRIPTION
## Summary

- add an Emacs-native audit that reads direct Package-Requires minimums and reports current GNU ELPA, NonGNU ELPA, and MELPA candidates
- run the complete Emacs 29.4 and 30.1 Test workflow weekly against current archive dependencies
- generate a human-readable dependency table in Actions Summary without committing a snapshot or uploading an artifact
- create or update one automated issue when Test or Report fails, and close it after a scheduled recovery
- label structured bug and proposal forms from their selected fields without classifying free-form text
- create missing managed labels and migrate the default `documentation` label to `doc`
- keep Package-Requires minimum versions unchanged and do not claim reproducible historical dependency locking

## Dependency issue lifecycle

- first scheduled failure creates an English issue with the dependencies label
- repeated failures update the same machine-owned body and consecutive-failure count
- successful recovery comments and closes the current issue
- manual issue closure suppresses duplicates until the monitor recovers
- workflow_dispatch and pull_request runs are read-only dry-runs and never modify issues

## Issue form labeling

- bug `Suspected area` selections map to `doc`, `runtime`, `gptel`, `tools`, `agents`, `actions`, `sessions`, `frontend`, `skills`, or `packaging`
- proposal `Architecture RFC` selections add `rfc`, while `Architectural impact` supports multiple component labels
- existing form labels continue to provide `bug` and `enhancement`
- edited forms reconcile only the labels owned by their structured fields
- blank issues and free-form Summary, Problem, and Description text are ignored
- manually managed labels outside the automatic set, such as security and priority labels, are preserved

## Permissions

- workflow defaults and Test/Report jobs use `contents: read`
- only the scheduled dependency Notify job and issue-form labeler receive `issues: write`
- Notify does not check out the repository, execute package code, or copy raw logs into public issues
- the issue labeler checks out only the default-branch script and never executes issue text

## Testing

- dependency audit ERT tests: 5/5
- complete isolated ERT suite: 608/608
- dependency script byte-compiles successfully
- real archive refresh generated a valid report for all direct dependencies
- workflow YAML and embedded Bash syntax passed local validation
- Report success, dependency-failure, and invalid-output paths passed local mocks
- issue create, repeated update, manual-close suppression, and recovery paths passed mocked GitHub CLI tests
- issue label mapping tests: 4/4
- issue labeler JavaScript syntax and workflow YAML passed local validation
- [PR dry-run](https://github.com/Jamie-Cui/magent/actions/runs/32810339920) passed Report and both reusable Test jobs; Notify was skipped as designed