### PR TITLE
refactor: standardize the agent-shell integration boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,14 +134,14 @@ magent.el (package entry point and lazy runtime bootstrap)
   ├─ magent-agent-file.el        (loads custom agents from .magent/agent/*.md)
   ├─ magent-permission.el        (rule-based tool access control per agent)
   ├─ magent-acp.el               (in-process ACP adapter for agent-shell)
-  ├─ magent-agent-shell.el       (agent-shell backend registration and routing)
+  ├─ magent-agent-shell.el       (agent-shell config and isolated context compatibility)
   ├─ magent-file-loader.el       (shared file-backed definition loader and frontmatter parser)
   └─ magent-skills.el            (skill registry, built-in skill definitions, file loading, and interactive commands)
 ```
 
 ### Core Flow
 
-1. **Entry point** (`magent.el`, `magent-agent-shell.el`): `magent.el` loads the package; supported interaction starts with `magent-start`, `magent-agent-shell-start`, or Magent selected from `agent-shell`. Static initialization is **lazy** — triggered on the first supported command via `magent--ensure-initialized`.
+1. **Entry point** (`magent.el`, `magent-agent-shell.el`): `magent.el` loads the package; supported interaction starts with the compatibility command `magent-start` or Magent selected from `agent-shell`. Static initialization is **lazy** — triggered on the first supported command.
 
 2. **Runtime** (`magent-runtime.el`): Owns the ordered initialization pipeline for agents, skills, slash commands, and capabilities. Static bundled definitions load once; project-local overlays under `.magent/` are activated and unloaded as session scope changes.
 
@@ -149,7 +149,7 @@ magent.el (package entry point and lazy runtime bootstrap)
 
 4. **Isolated Actions** (`magent-action-session.el`, `magent-action-session-view.el`, `magent-action-builtin-memory.el`, `magent-action-builtin-doctor.el`): `/doctor` and `/memory-*` are unified Action specs exposed through both agent-shell and `M-x magent-action-run-*`. `magent-action-enabled-builtins` controls their registration as `doctor` and `memory` groups and refreshes frontend discovery after Custom changes. They create isolated sessions under `magent-session-directory/actions`, preserve the current conversation, and can be inspected with `magent-action-list-sessions` or cancelled with `magent-action-cancel`. The old `commands/` format is not read or migrated. Memory Actions respect `magent-bypass-permission`. Doctor uses trusted read-only probes, Magent-owned redaction, and one tool-free direct request outside the runtime queue. Custom probes are trusted Elisp, not sandboxed code. See `docs/DOCTOR.org`.
 
-5. **Supported frontend boundary** (`magent-agent-shell.el`, `magent-acp.el`, `magent-runtime-api.el`): `magent-agent-shell.el` is the only supported frontend integration and uses an in-process ACP client implemented by `magent-acp.el`. ACP routes registered slash input through `magent-action.el`, submits model turns through `magent-runtime-api.el`, and converts runtime observer events to ACP `session/update` messages. ACP prompt requests remain pending until the corresponding command invocation or ordinary Magent turn completes, fails, or is cancelled.
+5. **Supported frontend boundary** (`magent-agent-shell.el`, `magent-acp.el`, `magent-runtime-api.el`): `magent-agent-shell.el` supplies the agent-shell config, the sole compatibility command `magent-start`, and one isolated private context-compatibility block; it does not own buffer selection, prompt submission, queues, skills, Actions, busy-state recovery, or interruption. The config uses an in-process ACP client implemented by `magent-acp.el`. ACP routes registered slash input through `magent-action.el`, submits model turns through `magent-runtime-api.el`, and converts runtime observer events to ACP `session/update` messages. ACP prompt requests remain pending until the corresponding command invocation or ordinary Magent turn completes, fails, or is cancelled.
    - `magent-runtime-queue.el` owns the global single-execution queue and session-scoped cancellation
    - Runtime emits Magent-native observer events; ACP conversion is isolated in `magent-acp.el`
    - ACP text/resource blocks are stored as structured turn metadata and reconstructed as user-role prompt context; local `file://` resources also provide scoped request paths
@@ -177,7 +177,7 @@ magent.el (package entry point and lazy runtime bootstrap)
 - **Action projections are registry-driven**: keep invocation and precedence in `magent-action.el`; frontends discover and dispatch command projections through that public layer rather than private command tables.
 - **Actions own both projections**: keep slash discovery, interactive wrappers, isolated sessions, and lifecycle ownership in `magent-action`; do not add `/magent-*` local command tables to `magent-acp.el`.
 - **Doctor never receives general tools**: keep `magent-action-run-doctor` on the trusted probe plus one tool-free request path. Do not expose `emacs_eval`, shell, file tools, backend objects, credentials, environment variables, or raw provider logs through Doctor probes.
-- **Frontend code stays on the supported path**: keep UI-independent behavior in `magent-runtime-api.el`, ACP conversion in `magent-acp.el`, and agent-shell behavior in `magent-agent-shell.el`.
+- **Frontend code stays on the supported path**: keep UI-independent behavior in `magent-runtime-api.el`, ACP conversion in `magent-acp.el`, and agent-shell behavior in agent-shell itself. `magent-agent-shell.el` owns only Magent's config and the explicitly grouped context compatibility advices.
 - **Core logging is UI-neutral**: `magent-log.el` dispatches formatted messages to sinks and falls back to `message` for warnings/errors when headless.
 - **Tool execution helpers live in `magent-agent-loop.el`**: serial queueing, abort cleanup, lifecycle event emission, and tool-result recording are all loop-owned; UI sinks own visible rendering. As with Codex, repeated tool use is steered by prompt/context rather than a hard `emacs_eval` call-count guard. Do not add hidden final-response recovery requests.
 - **Provider transport stays in gptel**: `magent-llm-gptel.el` may use gptel private FSM details internally for one sampling request, but the Magent loop consumes only normalized events.
@@ -212,16 +212,10 @@ Key settings: `magent-default-agent` (`"build"`), `magent-enable-tools` (list of
 
 | Command | Action |
 |---------|--------|
-| `magent-start` | Open or reuse the project-local Magent agent-shell buffer |
-| `magent-agent-shell-start` | Start a fresh Magent agent-shell buffer |
-| `magent-agent-shell-prompt-region` | Send the active region through agent-shell |
-| `magent-agent-shell-ask-at-point` | Ask about the symbol at point through agent-shell |
-| `magent-agent-shell-interrupt` | Interrupt the active request |
-| `magent-agent-shell-toggle-skill-for-next-request` | Toggle a one-shot instruction skill |
-| `magent-agent-shell-run-command` | Select and run an Elisp-native Action through its command projection |
+| `magent-start` | Start agent-shell with Magent's in-process ACP config |
 
-Use agent-shell's own bindings, session options, mode selector, and slash
-commands for interaction.
+Use agent-shell's own commands, bindings, session options, mode selector, and
+slash menu for interaction. Skills use `/$name`; Actions use `/name`.
 
 ## Conventions
 

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -20,3 +20,17 @@ intentional tagged release is planned as ~v0.2.0~.
   Magent-owned tool loop, permission and approval controls, durable sessions
   and child-agent jobs, Elisp-native Actions, instruction skills, automatic
   capabilities, Doctor, and memory workflows.
+
+** Changed
+
+- Narrowed ~magent-agent-shell.el~ to Magent's ACP config, the single
+  ~magent-start~ compatibility entry, and an isolated temporary context
+  compatibility block. Interactive buffers, prompts, queues, slash menus,
+  skills, and interrupts now use agent-shell's native commands directly.
+
+** Removed
+
+- Removed redundant ~magent-agent-shell-*~ commands for shell creation, prompt
+  submission, region/symbol helpers, interruption, Action selection, and
+  one-shot skill selection, together with private busy-state recovery and
+  request handoff machinery.

--- a/README.org
+++ b/README.org
@@ -31,13 +31,13 @@ See [[file:docs/UI_BACKENDS.org][docs/UI_BACKENDS.org]] for the supported agent-
 ~magent-action~ and skills are complementary extension points, not two ways to
 define the same thing:
 
-|                        | ~magent-action~                                                        | Skill                                                            |
-|------------------------+-----------------------------------------------------------------------+------------------------------------------------------------------|
-| Primary role           | An explicit Emacs or slash-command action                             | Reusable model instructions                                      |
-| Definition             | Trusted Elisp registered with ~magent-action-register~                 | A data-only ~SKILL.md~ file                                        |
-| Activation             | The user enters ~/name~ or runs ~M-x magent-agent-shell-run-command~      | The user enters ~/$name~, selects it, or a capability activates it |
+|                        | ~magent-action~                                                          | Skill                                                            |
+|------------------------+------------------------------------------------------------------------+------------------------------------------------------------------|
+| Primary role           | An explicit Emacs or slash-command action                              | Reusable model instructions                                      |
+| Definition             | Trusted Elisp registered with ~magent-action-register~                   | A data-only ~SKILL.md~ file                                        |
+| Activation             | The user enters ~/name~ or selects it from agent-shell                    | The user enters ~/$name~, selects it, or a capability activates it |
 | Owns                   | Arguments, requirements, session policy, Steps, and multi-step control | Model context and workflow guidance                              |
-| Project trust boundary | Action Workflows are trusted installed Elisp                          | Project skill Markdown never executes code                       |
+| Project trust boundary | Action Workflows are trusted installed Elisp                           | Project skill Markdown never executes code                       |
 
 Use ~magent-action~ when you want a stable, user-triggered entry point in
 Emacs.  Use a skill when you want reusable expertise that the agent can apply
@@ -58,7 +58,7 @@ managed agent, process, and callback Steps provide asynchronous suspension,
 cancellation, progress, and activity recording.
 
 Registered commands are advertised to agent-shell and can be invoked as slash
-input or selected with ~M-x magent-agent-shell-run-command~.  The complete
+input or selected from agent-shell's slash menu.  The complete
 ~use-package~ example below registers ~/ask-name~; see
 [[file:docs/COMMANDS.org][docs/COMMANDS.org]] for the full command API and lifecycle.
 
@@ -169,20 +169,20 @@ agent-shell configuration and in-process ACP client, so no external ACP
 command is required.  To start using Magent:
 
 1. Visit a file in the project you want Magent to work on.
-2. Run ~M-x magent-start~.  Magent opens or reuses the project-local
-   agent-shell buffer through its in-process ACP adapter.  A new buffer prompts
-   you to start a new session or load a saved session from that project.  You
-   can also run ~M-x agent-shell~ and select Magent after registering the
-   configuration as shown in the installation examples above.
+2. Run ~M-x magent-start~.  This compatibility entry starts agent-shell with
+   Magent's in-process ACP config.  By default it prompts you to start a new
+   session or load one saved for the current project.  You can also run
+   ~M-x agent-shell~ and select Magent after registering the configuration as
+   shown in the installation examples above.
 3. Type a prompt at the bottom of the agent-shell buffer and press ~RET~ to
    submit it.  Assistant responses, reasoning, tool calls, and permission
    requests are streamed into the same buffer.
 4. Enter another prompt and press ~RET~ to continue the project-scoped session.
    While a request is running, press ~C-c C-c~ to interrupt it.
 
-From a source buffer, ~M-x magent-agent-shell-prompt-region~ sends the active
-region and ~M-x magent-agent-shell-ask-at-point~ asks about the symbol at point;
-both commands submit their context through agent-shell.
+From a source buffer, use agent-shell's native ~M-x agent-shell-send-region~ or
+~M-x agent-shell-send-dwim~ commands.  In a Magent shell, use
+~M-x agent-shell-interrupt~ (normally ~C-c C-c~) to interrupt a request.
 
 TRAMP projects use the same entry point.  Visit a remote file or Dired
 directory, then run ~M-x magent-start~.  Magent keeps its control plane on the
@@ -248,16 +248,14 @@ must appear exactly once in ~prompts/manifest.txt~.
 
 ** Interactive Commands
 
-| Command                                          | Description                                                      |
-|--------------------------------------------------+------------------------------------------------------------------|
-| ~magent-start~                                     | Open or reuse the project-local Magent agent-shell buffer        |
-| ~magent-agent-shell-start~                         | Start a fresh Magent agent-shell buffer                          |
-| ~magent-agent-shell-prompt-region~                 | Send the selected region through agent-shell                     |
-| ~magent-agent-shell-ask-at-point~                  | Ask about the symbol at point through agent-shell                |
-| ~magent-agent-shell-interrupt~                     | Interrupt the active Magent agent-shell request                  |
-| ~magent-agent-shell-run-command~                   | Select and run a registered slash command                        |
-| ~magent-agent-shell-toggle-skill-for-next-request~ | Toggle a one-shot instruction skill                              |
-| ~magent-toggle-bypass-permission~                  | Toggle ordinary permission bypass; once-only eval approval remains |
+| Command                           | Description                                                         |
+|-----------------------------------+---------------------------------------------------------------------|
+| ~magent-start~                    | Start agent-shell with Magent's in-process ACP config                |
+| ~agent-shell~                     | Select a registered agent backend, including Magent                  |
+| ~agent-shell-send-region~         | Send the selected region through the active agent-shell backend      |
+| ~agent-shell-send-dwim~           | Send the context chosen by agent-shell                               |
+| ~agent-shell-interrupt~           | Interrupt the active agent-shell request                             |
+| ~magent-toggle-bypass-permission~ | Toggle ordinary permission bypass; once-only eval approval remains  |
 
 Prompt text is entered directly in the agent-shell buffer, and Magent streams
 assistant responses, tool activity, permission prompts, and session updates
@@ -291,14 +289,13 @@ workflow associates sessions with the current project:
 ** Slash Commands And Skills
 
 Instruction skills can be selected as one-shot context for the next request.
-In agent-shell, use ~M-x magent-agent-shell-toggle-skill-for-next-request~ to
-toggle a skill and ~M-x magent-agent-shell-clear-skills-for-next-request~ to
-clear selected skills.  Selected skills are scoped to the active Magent session
-and are consumed by the next prompt.
+In agent-shell, submit ~/$name~ or select the skill from the slash menu.
+Selected skills are scoped to the active Magent session and are consumed by the
+next prompt.
 
 Elisp-native slash commands are registered through the public
-~magent-action-register~ API and can be selected with
-~M-x magent-agent-shell-run-command~. By default, agent-shell advertises twelve bundled
+~magent-action-register~ API and can be selected from agent-shell's slash menu.
+By default, agent-shell advertises twelve bundled
 commands: ~/explain~, ~/fix~, ~/init~, ~/review~, ~/test~,
 ~/compact~, ~/authority~, ~/skills~, ~/doctor~, ~/memory-init~,
 ~/memory-refresh~, and ~/memory-clear~. The five prompt commands own package
@@ -320,8 +317,8 @@ disable profile-memory injection, which is controlled separately by
 
 Every instruction skill in the exact session scope is advertised as ~/$name~.
 ~/skills~ lists those descriptors locally. Submit ~/$name~ to select a skill
-for one normal turn; submit ~/name~ or use
-~M-x magent-agent-shell-run-command~ to invoke an Action. See
+for one normal turn; submit ~/name~ or select it from the slash menu to invoke
+an Action. See
 [[file:docs/COMMANDS.org][docs/COMMANDS.org]] for slash-command behavior and
 the third-party Action API. Action definitions and skill descriptors are
 resolved by canonical project scope, and agent-shell uses the exact session

--- a/docs/COMMANDS.org
+++ b/docs/COMMANDS.org
@@ -132,8 +132,8 @@ skipped checks plus remaining risk.
 
 ** Alternate Invocation And Extension
 
-~M-x magent-agent-shell-run-command~ selects and runs any registered slash
-command. The bundled one-turn prompt Actions are data entries in
+agent-shell advertises registered slash commands and runs the selected ~/name~
+input. The bundled one-turn prompt Actions are data entries in
 ~magent-action-builtins.el~; third-party packages use the same public Action API:
 
 #+begin_src emacs-lisp
@@ -388,6 +388,5 @@ belonging to unrelated Magent conversations.
   and should reuse its agent, context, and transcript.
 - Use Doctor or a Memory command when maintenance or sanitized diagnosis needs
   its own durable session; choose slash or M-x according to the current UI.
-- Use ~magent-start~, ~magent-agent-shell-prompt-region~, and
-  ~magent-agent-shell-ask-at-point~ for free-form requests rather than a
-  predefined workflow.
+- Use ~magent-start~ to enter Magent, then agent-shell's native prompt and
+  context commands for free-form requests rather than a predefined workflow.

--- a/docs/COMMANDS.zh.org
+++ b/docs/COMMANDS.zh.org
@@ -119,8 +119,8 @@ bug、regression、不安全的边界情况和缺失测试，并按严重程度�
 
 ** 其他调用方式与扩展
 
-~M-x magent-agent-shell-run-command~ 可以选择并运行任意已注册 slash command。
-内置单 turn prompt Action 是 ~magent-action-builtins.el~ 中的数据项；第三方包使用
+agent-shell 会展示已注册 slash command，并运行选中的 ~/name~ 输入。内置单 turn
+prompt Action 是 ~magent-action-builtins.el~ 中的数据项；第三方包使用
 相同的公开 Action API：
 
 #+begin_src emacs-lisp
@@ -342,5 +342,5 @@ Action-session viewer 优先显示最终结果，并默认折叠详细 activity�
   时，使用 slash command。
 - 当 Magent 维护、profile-memory 管理或脱敏诊断需要独立 durable session 时，
   按当前 UI 选择 slash 或 M-x 入口。
-- 对于不属于预定义工作流的自由请求，使用 ~magent-start~ 、
-  ~magent-agent-shell-prompt-region~ 和 ~magent-agent-shell-ask-at-point~ 。
+- 对于不属于预定义工作流的自由请求，先使用 ~magent-start~ 进入 Magent，再使用
+  agent-shell 自带的 prompt 与 context command。

--- a/docs/ONBOARDING.org
+++ b/docs/ONBOARDING.org
@@ -165,13 +165,11 @@ Skills are instruction-only Markdown injected into the system prompt.
 Companion Elisp is not loaded.
 
 Instruction skills can be selected as one-shot context for the next request.
-The agent-shell frontend exposes
-~magent-agent-shell-toggle-skill-for-next-request~. ACP also advertises every
-visible instruction skill as ~/$name~; this explicitly selects the skill for
-an ordinary turn. Skills never enter the Action registry. Elisp-native Actions
-are registered separately through
-~magent-action-register~ and can be selected with
-~magent-agent-shell-run-command~. ~/skills~ lists the same descriptors without
+ACP advertises every visible instruction skill as ~/$name~ in agent-shell;
+submitting or selecting it explicitly applies the skill to one ordinary turn.
+Skills never enter the Action registry. Elisp-native Actions are registered
+separately through ~magent-action-register~ and are selected as ~/name~ from
+agent-shell's slash menu. ~/skills~ lists the same descriptors without
 a provider request. The bundled ~/init~ command initializes or refreshes the
 project root ~AGENTS.md~ and accepts optional extra text.
 
@@ -483,7 +481,7 @@ Skill instructions for the agent.
 - *Child-agent architecture:* ~docs/AGENT_JOBS.org~
 - *Interactive help:* ~M-x magent-action-run-doctor~ for self-diagnostics
 - *Frontend:* ~M-x magent-start~
-- *Skills:* ~M-x magent-agent-shell-toggle-skill-for-next-request~
+- *Skills:* select ~/$name~ from agent-shell's slash menu
 - *Logs:* open ~*magent-log*~ with ~C-x b~
 - *Agent selection:* ~M-x agent-shell-set-session-mode~ from the agent-shell buffer
 

--- a/docs/ONBOARDING.zh.org
+++ b/docs/ONBOARDING.zh.org
@@ -169,11 +169,11 @@ Agent modes：
 
 Skill 只支持注入 system prompt 的 instruction Markdown，不加载 companion Elisp。
 
-Instruction skills 可以作为下一次请求的一次性上下文。Agent-shell frontend 提供
-~magent-agent-shell-toggle-skill-for-next-request~。ACP 还会把每个可见 instruction
-skill 发布成 ~/$name~；这会在一次普通 turn 中显式选择 skill。Skill 永远不会进入
-Action registry。Elisp-native Action 通过 ~magent-action-register~ 单独注册，并可用
-~magent-agent-shell-run-command~ 选择。~/skills~ 不请求 provider，直接列出相同的
+Instruction skills 可以作为下一次请求的一次性上下文。ACP 会在 agent-shell 中把每个
+可见 instruction skill 发布成 ~/$name~；提交或从 slash menu 选择它，会在一次普通
+turn 中显式应用 skill。Skill 永远不会进入 Action registry。Elisp-native Action 通过
+~magent-action-register~ 单独注册，并以 ~/name~ 从 agent-shell slash menu 选择。
+~/skills~ 不请求 provider，直接列出相同的
 descriptors。内置 ~/init~ 命令用于初始化或刷新项目根目录 ~AGENTS.md~。
 
 每个 turn 都从 selected agent 的 base prompt 开始，随后加入 project context、从项目
@@ -417,7 +417,7 @@ Skill instructions for the agent.
 - *Child-agent architecture:* ~docs/AGENT_JOBS.org~
 - *Interactive help:* ~M-x magent-action-run-doctor~
 - *Frontend:* ~M-x magent-start~ 。
-- *Skills:* ~M-x magent-agent-shell-toggle-skill-for-next-request~ 。
+- *Skills:* 从 agent-shell slash menu 选择 ~/$name~ 。
 - *Logs:* 使用 ~C-x b~ 打开 ~*magent-log*~ 。
 - *Agent selection:* 在 agent-shell buffer 运行 ~M-x agent-shell-set-session-mode~ 。
 

--- a/docs/TROUBLESHOOTING.org
+++ b/docs/TROUBLESHOOTING.org
@@ -360,8 +360,7 @@ magent-session-directory  ; Default: ~/.emacs.d/magent/sessions/
 3. Press ~C-c C-c~ in the agent-shell buffer and confirm the interrupt
 
 *Solution:*
-- Start a new shell with ~M-x magent-agent-shell-start~, then select a new
-  session.
+- Start another shell with ~M-x magent-start~, then select a new session.
 - Restart Emacs if issue persists
 
 ** Performance Issues
@@ -371,7 +370,7 @@ magent-session-directory  ; Default: ~/.emacs.d/magent/sessions/
 
 *Solution:*
 - Confirm that the installed agent-shell version satisfies README requirements.
-- Reproduce in a fresh ~M-x magent-agent-shell-start~ buffer and inspect
+- Reproduce in a fresh ~M-x magent-start~ buffer and inspect
   ~*Messages*~ and ~*magent-log*~ for update or rendering errors.
 
 *** High memory usage
@@ -384,7 +383,7 @@ magent-session-directory  ; Default: ~/.emacs.d/magent/sessions/
 
 #+end_src
 
-Start a new shell with ~M-x magent-agent-shell-start~ and select a new session
+Start another shell with ~M-x magent-start~ and select a new session
 when the current session no longer needs to be retained in the active buffer.
 
 * Diagnostic Commands

--- a/docs/TROUBLESHOOTING.zh.org
+++ b/docs/TROUBLESHOOTING.zh.org
@@ -391,7 +391,7 @@ magent-session-directory  ; Default: ~/.emacs.d/magent/sessions/
 
 *解决：*
 
-- 使用 ~M-x magent-agent-shell-start~ 启动一个新 shell，然后选择新 session。
+- 使用 ~M-x magent-start~ 启动另一个 shell，然后选择新 session。
 - 如果仍然存在，重启 Emacs。
 
 ** 性能问题
@@ -403,7 +403,7 @@ magent-session-directory  ; Default: ~/.emacs.d/magent/sessions/
 *解决：*
 
 - 确认 agent-shell 版本满足 README 要求。
-- 在新的 ~M-x magent-agent-shell-start~ buffer 中复现，并检查 ~*Messages*~ 和
+- 在新的 ~M-x magent-start~ buffer 中复现，并检查 ~*Messages*~ 和
   ~*magent-log*~ 是否有 update/rendering error。
 
 *** 内存占用高
@@ -416,8 +416,8 @@ magent-session-directory  ; Default: ~/.emacs.d/magent/sessions/
 (setq magent-max-history 50)
 #+end_src
 
-当前 session 不再需要保留在 active buffer 时，使用
-~M-x magent-agent-shell-start~ 启动新 shell，然后选择新 conversation。
+当前 session 不再需要保留在 active buffer 时，使用 ~M-x magent-start~ 启动另一个
+shell，然后选择新 conversation。
 
 * Diagnostic Commands
 

--- a/docs/UI_BACKENDS.org
+++ b/docs/UI_BACKENDS.org
@@ -5,8 +5,8 @@
 
 Magent supports one conversational frontend: ~agent-shell~, connected to the
 Magent runtime through the in-process ACP adapter.  Conversational documentation
-and examples must use the commands exported by ~magent-agent-shell.el~ or
-agent-shell itself.  Explicit registered commands may additionally expose
+and examples must use agent-shell itself or the sole Magent compatibility
+command, ~magent-start~.  Explicit registered commands may additionally expose
 trusted ~M-x~ wrappers through ~magent-action~; those wrappers are not another
 conversation frontend.
 
@@ -20,8 +20,9 @@ explicit command registration and invocation belong in ~magent-action.el~.
 
 * Supported Modules
 
-- ~magent-agent-shell.el~ registers the Magent agent-shell configuration and
-  provides the supported interactive entry points.
+- ~magent-agent-shell.el~ supplies the Magent agent-shell configuration, the
+  compatibility entry ~magent-start~, and an isolated context compatibility
+  block. Interactive buffer and prompt behavior remains owned by agent-shell.
 - ~magent-acp.el~ implements the in-process ACP request, notification,
   response, permission, and ~session/update~ adapter.
 - ~magent-action.el~ owns registered slash/interactive command discovery and
@@ -33,7 +34,7 @@ explicit command registration and invocation belong in ~magent-action.el~.
 
 * Supported Flow
 
-1. Start or reuse Magent with ~M-x magent-start~, or register Magent
+1. Start Magent with ~M-x magent-start~, or register Magent
    with ~magent-agent-shell-ensure-config~ and select it from ~M-x agent-shell~.
 2. agent-shell calls the in-process ACP client from ~magent-acp.el~.
 3. ACP normalizes text and resource blocks separately. Local ~file://~ resources
@@ -54,7 +55,7 @@ explicit command registration and invocation belong in ~magent-action.el~.
 * Configuration
 
 - ~magent-agent-shell-session-strategy~ selects the supported frontend's new,
-  latest, or prompt-based session flow for both Magent entry commands and
+  latest, or prompt-based session flow for both the Magent entry command and
   Magent selected from the generic agent-shell picker.  It defaults to ~prompt~,
   offering new and saved sessions from the current scope.
 
@@ -75,8 +76,10 @@ outputs are copied into the fork's private session storage.
 * Development Boundary
 
 Keep frontend-neutral behavior in ~magent-runtime-api.el~, ACP conversion in
-~magent-acp.el~, and supported frontend behavior in ~magent-agent-shell.el~.
-Do not introduce a second interactive frontend inside the core runtime.
+~magent-acp.el~, and interactive frontend behavior in agent-shell. Keep
+~magent-agent-shell.el~ limited to Magent's config and the explicitly grouped
+context compatibility advices. Do not introduce a second interactive frontend
+inside the core runtime.
 
 Skill discovery is also frontend-neutral. ~magent-skills-list-descriptors~ and
 ~magent-skills-resolve-descriptor~ return metadata for an exact session scope
@@ -90,6 +93,9 @@ entry surfaces; it must not infer skills from the Action registry.
 * Current Limitations
 
 - ~agent-shell~ and ~acp~ are hard dependencies of the supported frontend.
+- Magent still explicitly registers its config for the generic agent-shell
+  picker, and temporarily advises four private context functions for remote-safe
+  and blank-line context handling.
 - Runtime execution uses a global single-execution queue.
 - Cancellation is session-scoped: cancelling one ACP session cancels that
   session's active and queued submissions without removing other sessions'

--- a/docs/UI_BACKENDS.zh.org
+++ b/docs/UI_BACKENDS.zh.org
@@ -4,8 +4,8 @@
 #+options: toc:nil num:nil
 
 Magent 只支持一个会话式前端： ~agent-shell~ 。它通过进程内 ACP adapter 连接
-Magent runtime。会话式文档和示例必须使用 ~magent-agent-shell.el~ 导出的命令，
-或者直接使用 agent-shell。显式 registered command 也可以通过 ~magent-action~
+Magent runtime。会话式文档和示例必须直接使用 agent-shell，或者使用 Magent 唯一的
+兼容命令 ~magent-start~。显式 registered command 也可以通过 ~magent-action~
 暴露受信任的 ~M-x~ wrapper；这些 wrapper 不构成另一套会话 frontend。
 
 * 公共接口
@@ -17,7 +17,8 @@ invocation 则属于 ~magent-action.el~ 。
 
 * 受支持的模块
 
-- ~magent-agent-shell.el~ 注册 Magent agent-shell 配置，并提供受支持的交互入口。
+- ~magent-agent-shell.el~ 提供 Magent agent-shell 配置、兼容入口 ~magent-start~，以及
+  隔离的 context compatibility block；交互 buffer 和 prompt 行为仍由 agent-shell 负责。
 - ~magent-acp.el~ 实现进程内 ACP request、notification、response、permission 和
   ~session/update~ adapter。
 - ~magent-action.el~ 负责 registered slash/interactive command discovery 和
@@ -28,7 +29,7 @@ invocation 则属于 ~magent-action.el~ 。
 
 * 受支持的流程
 
-1. 使用 ~M-x magent-start~ 启动或复用 Magent；也可以先调用
+1. 使用 ~M-x magent-start~ 启动 Magent；也可以先调用
    ~magent-agent-shell-ensure-config~ 注册配置，再从 ~M-x agent-shell~ 中选择 Magent。
 2. agent-shell 调用 ~magent-acp.el~ 中的进程内 ACP client。
 3. ACP 分别规范化 text 和 resource blocks。本地 ~file://~ resource 会提供 scoped
@@ -47,7 +48,7 @@ invocation 则属于 ~magent-action.el~ 。
 * 配置
 
 - ~magent-agent-shell-session-strategy~ 用于选择受支持前端的 new、latest 或 prompt
-  session 流程；无论使用 Magent 入口命令还是从通用 agent-shell 选择器中选择 Magent，
+  session 流程；无论使用 Magent 兼容入口还是从通用 agent-shell 选择器中选择 Magent，
   该设置都会生效。默认值是 ~prompt~，会列出当前 scope 中的新 session 和已保存
   session。
 
@@ -66,9 +67,10 @@ one-shot skill 会被显式重置。历史中引用的 spilled tool output 会�
 
 * 开发边界
 
-Frontend-neutral 行为放在 ~magent-runtime-api.el~ ，ACP conversion 放在
-~magent-acp.el~ ，受支持的 frontend 行为放在 ~magent-agent-shell.el~ 。不要在 core
-runtime 内引入第二套交互 frontend。
+Frontend-neutral 行为放在 ~magent-runtime-api.el~，ACP conversion 放在
+~magent-acp.el~，交互 frontend 行为留在 agent-shell。~magent-agent-shell.el~ 只保留
+Magent config 与显式分组的 context compatibility advice。不要在 core runtime 内
+引入第二套交互 frontend。
 
 Skill discovery 同样保持 frontend-neutral。
 ~magent-skills-list-descriptors~ 和 ~magent-skills-resolve-descriptor~ 会针对精确
@@ -81,6 +83,8 @@ registered Action command projections 与 skill descriptors 展示为两个独�
 * 当前限制
 
 - 受支持的 frontend 硬依赖 ~agent-shell~ 和 ~acp~ 。
+- Magent 目前仍需为通用 agent-shell picker 显式注册 config，并临时 advice 四个私有
+  context function，以处理 remote-safe 与空行 context。
 - runtime execution 使用全局单执行队列。
 - cancellation 是 session-scoped：取消一个 ACP session 会取消该 session 的 active
   和 queued submissions，但不会移除其他 session 的 queued work。

--- a/lisp/magent-agent-shell.el
+++ b/lisp/magent-agent-shell.el
@@ -6,55 +6,34 @@
 
 ;;; Commentary:
 
-;; This module is the agent-shell-specific UI backend.  Magent exposes an
-;; in-process ACP client, while agent-shell owns the interactive shell UI.
+;; This module exposes Magent's in-process ACP client to agent-shell.  It owns
+;; the Magent agent configuration and one deliberately isolated compatibility
+;; layer for context collection.  Interactive buffer, prompt, queue, skill,
+;; and interruption behavior belongs to agent-shell.
 
 ;;; Code:
 
-(require 'cl-lib)
 (require 'map)
 (require 'seq)
 (require 'subr-x)
 (require 'magent-acp)
-(require 'magent-action)
 (require 'magent-config)
 (require 'magent-runtime)
-(require 'magent-runtime-api)
-(require 'magent-session)
-(require 'magent-skills)
 
 (defvar gptel-model)
-(defvar agent-shell--state)
 (defvar agent-shell-agent-configs)
-(defvar agent-shell-preferred-agent-config)
 (defvar agent-shell-session-strategy)
-(defvar comint-last-prompt)
-(defvar shell-maker--busy)
-(defvar shell-maker--request-process)
 
-(declare-function magent--ensure-initialized "magent")
 (declare-function agent-shell--context "agent-shell")
-(declare-function agent-shell--display-buffer "agent-shell")
-(declare-function agent-shell--dwim "agent-shell")
-(declare-function agent-shell--send-command "agent-shell")
-(declare-function agent-shell-cwd "agent-shell-project")
-(declare-function agent-shell-status "agent-shell")
-(declare-function agent-shell-interrupt "agent-shell")
-(declare-function agent-shell-insert "agent-shell")
+(declare-function agent-shell--get-current-line-context "agent-shell")
+(declare-function agent-shell--get-files-context "agent-shell")
+(declare-function agent-shell--get-region-context "agent-shell")
+(declare-function agent-shell-get-config "agent-shell")
 (declare-function agent-shell-make-agent-config "agent-shell")
-(declare-function agent-shell-prompt-queue "agent-shell-prompt-queue")
-(declare-function agent-shell-prompt-queue-resume "agent-shell-prompt-queue")
 (declare-function agent-shell-start "agent-shell")
-(declare-function shell-maker-busy "shell-maker")
 
 (defconst magent-agent-shell--identifier 'magent
   "agent-shell config identifier used by Magent.")
-
-(defvar-local magent-agent-shell--pending-skill-names nil
-  "Instruction skills selected for the next Magent agent-shell prompt.")
-
-(defvar-local magent-agent-shell--prompt-skill-queue nil
-  "Per-prompt instruction skills waiting for `agent-shell--send-command'.")
 
 (defvar-local magent-agent-shell--owns-session-strategy-p nil
   "Non-nil when Magent installed the buffer-local session strategy.")
@@ -63,27 +42,12 @@
   "Dynamically non-nil while agent-shell builds context for Magent.")
 
 (defun magent-agent-shell--ensure-loaded ()
-  "Load `agent-shell' before using its runtime API."
+  "Load `agent-shell' before using its public runtime API."
   (require 'agent-shell))
 
 (defun magent-agent-shell--model-id ()
   "Return the current gptel model id for agent-shell display."
   (format "%s" (or (and (boundp 'gptel-model) gptel-model) "gptel")))
-
-(defun magent-agent-shell--instruction-skill-names ()
-  "Return sorted instruction skill names."
-  (sort (copy-sequence (magent-skills-list-by-type 'instruction)) #'string<))
-
-(defun magent-agent-shell--read-instruction-skill (prompt)
-  "Read an instruction skill name with PROMPT."
-  (let ((names (magent-agent-shell--instruction-skill-names)))
-    (unless names
-      (user-error "Magent: no instruction skills are registered"))
-    (completing-read prompt names nil t)))
-
-(defun magent-agent-shell--prepare-skill-context ()
-  "Load project-local skill definitions for the current command context."
-  (magent-runtime-prepare-context))
 
 (defun magent-agent-shell--make-client (buffer)
   "Create Magent's in-process ACP client for BUFFER.
@@ -120,7 +84,9 @@ directory-local frontend configuration keeps precedence."
 
 (defun magent-agent-shell-ensure-config ()
   "Ensure Magent's config maker is registered with agent-shell.
-Return Magent's identifier for use as `agent-shell-preferred-agent-config'."
+Return Magent's identifier for use as an agent-shell preferred config.  This
+explicit registration remains until agent-shell provides third-party config
+discovery."
   (magent-agent-shell--ensure-loaded)
   (setq agent-shell-agent-configs
         (cons #'magent-agent-shell-make-config
@@ -128,184 +94,28 @@ Return Magent's identifier for use as `agent-shell-preferred-agent-config'."
                     agent-shell-agent-configs)))
   magent-agent-shell--identifier)
 
-(defmacro magent-agent-shell--with-config (&rest body)
-  "Evaluate BODY with Magent selected as the preferred agent-shell config."
-  (declare (indent 0))
-  `(let ((agent-shell-preferred-agent-config
-          (magent-agent-shell-ensure-config))
-         (agent-shell-session-strategy
-          magent-agent-shell-session-strategy))
-     (magent-runtime-ensure-initialized)
-     ,@body))
+;;;###autoload
+(defun magent-start ()
+  "Start Magent's preferred conversational frontend."
+  (interactive)
+  (magent-runtime-ensure-initialized)
+  (let ((agent-shell-session-strategy
+         magent-agent-shell-session-strategy))
+    (agent-shell-start :config (magent-agent-shell-make-config))))
 
-(defun magent-agent-shell--directory-key (directory)
-  "Return normalized DIRECTORY key for project comparisons."
-  (file-name-as-directory (expand-file-name directory)))
+;;;; Temporary agent-shell context compatibility
+
+;; Keep all remaining private agent-shell coupling in this section.  These
+;; advices can be removed together once agent-shell offers remote-safe context
+;; construction and suppresses blank current-line context itself.  Magent does
+;; not otherwise inspect or mutate agent-shell or shell-maker private state.
 
 (defun magent-agent-shell--magent-buffer-p (buffer)
-  "Return non-nil when BUFFER is a Magent agent-shell buffer."
+  "Return non-nil when BUFFER uses Magent's agent-shell config."
   (and (buffer-live-p buffer)
-       (with-current-buffer buffer
-         (and (derived-mode-p 'agent-shell-mode)
-              (boundp 'agent-shell--state)
-              (eq (map-nested-elt agent-shell--state
-                                  '(:agent-config :identifier))
-                  magent-agent-shell--identifier)))))
-
-(defun magent-agent-shell--runtime-session (&optional shell-buffer)
-  "Return the runtime session for SHELL-BUFFER, or nil."
-  (let ((buffer (or shell-buffer (current-buffer))))
-    (when (magent-agent-shell--magent-buffer-p buffer)
-      (with-current-buffer buffer
-        (when-let* ((session-id (map-nested-elt agent-shell--state
-                                                '(:session :id))))
-          (let* ((client (map-elt agent-shell--state :client))
-                 (scope (and client
-                             (magent-acp--client-session-scope
-                              client session-id))))
-          (when scope
-            (or (magent-runtime-session-from-id session-id scope)
-                (magent-acp--runtime-session-by-id session-id scope)))))))))
-
-(defun magent-agent-shell--set-runtime-pending-skills
-    (runtime-session skills)
-  "Set RUNTIME-SESSION pending SKILLS."
-  (setf (magent-runtime-session-pending-skills runtime-session)
-        (magent-skills-dedupe-names skills)))
-
-(defun magent-agent-shell--sync-buffer-pending-skills
-    (shell-buffer runtime-session)
-  "Move SHELL-BUFFER pending skills into RUNTIME-SESSION when needed."
-  (with-current-buffer shell-buffer
-    (when magent-agent-shell--pending-skill-names
-      (magent-agent-shell--set-runtime-pending-skills
-       runtime-session
-       (append (magent-runtime-session-pending-skills runtime-session)
-               magent-agent-shell--pending-skill-names))
-      (setq magent-agent-shell--pending-skill-names nil))))
-
-(defun magent-agent-shell--pending-skills (&optional shell-buffer)
-  "Return pending instruction skills for SHELL-BUFFER."
-  (let ((buffer (or shell-buffer (current-buffer))))
-    (if-let* ((runtime-session
-               (magent-agent-shell--runtime-session buffer)))
-        (progn
-          (magent-agent-shell--sync-buffer-pending-skills
-           buffer runtime-session)
-          (magent-runtime-session-pending-skills runtime-session))
-      (with-current-buffer buffer
-        magent-agent-shell--pending-skill-names))))
-
-(defun magent-agent-shell--set-pending-skills (shell-buffer skills)
-  "Set SHELL-BUFFER pending instruction SKILLS."
-  (let ((skills (magent-skills-dedupe-names skills)))
-    (if-let* ((runtime-session
-               (magent-agent-shell--runtime-session shell-buffer)))
-        (magent-agent-shell--set-runtime-pending-skills runtime-session skills)
-      (with-current-buffer shell-buffer
-        (setq magent-agent-shell--pending-skill-names skills)))))
-
-(defun magent-agent-shell--clear-pending-skills (&optional shell-buffer)
-  "Clear pending instruction skills for SHELL-BUFFER."
-  (let ((buffer (or shell-buffer (current-buffer))))
-    (if-let* ((runtime-session
-               (magent-agent-shell--runtime-session buffer)))
-        (magent-runtime-session-clear-pending-skills runtime-session)
-      (with-current-buffer buffer
-        (setq magent-agent-shell--pending-skill-names nil)))))
-
-(defun magent-agent-shell--toggle-pending-skill
-    (shell-buffer skill-name)
-  "Toggle SKILL-NAME for SHELL-BUFFER's next prompt.
-Return non-nil when SKILL-NAME is selected after toggling."
-  (let ((skills (magent-agent-shell--pending-skills shell-buffer)))
-    (if (member skill-name skills)
-        (progn
-          (magent-agent-shell--set-pending-skills
-           shell-buffer (remove skill-name skills))
-          nil)
-      (magent-agent-shell--set-pending-skills
-       shell-buffer (append skills (list skill-name)))
-      t)))
-
-(defun magent-agent-shell--queue-prompt-skills
-    (shell-buffer prompt skills)
-  "Queue SKILLS for PROMPT in SHELL-BUFFER."
-  (when skills
-    (with-current-buffer shell-buffer
-      (setq magent-agent-shell--prompt-skill-queue
-            (append magent-agent-shell--prompt-skill-queue
-                    (list (list :prompt prompt
-                                :skills
-                                (magent-skills-dedupe-names
-                                 skills))))))))
-
-(defun magent-agent-shell--pop-prompt-skills
-    (shell-buffer prompt)
-  "Return queued skills for PROMPT in SHELL-BUFFER, or nil."
-  (with-current-buffer shell-buffer
-    (let ((entry (car magent-agent-shell--prompt-skill-queue)))
-      (when (and entry
-                 (equal prompt (plist-get entry :prompt)))
-        (setq magent-agent-shell--prompt-skill-queue
-              (cdr magent-agent-shell--prompt-skill-queue))
-        (plist-get entry :skills)))))
-
-(defun magent-agent-shell--prepare-command-skills
-    (prompt shell-buffer)
-  "Prepare runtime pending skills for PROMPT in SHELL-BUFFER."
-  (when (magent-agent-shell--magent-buffer-p shell-buffer)
-    (when-let* ((runtime-session
-                 (magent-agent-shell--runtime-session shell-buffer)))
-      (if-let* ((skills (magent-agent-shell--pop-prompt-skills
-                         shell-buffer prompt)))
-          (magent-agent-shell--set-runtime-pending-skills
-           runtime-session skills)
-        (when-let* ((skills
-                     (with-current-buffer shell-buffer
-                       magent-agent-shell--pending-skill-names)))
-          (magent-agent-shell--set-runtime-pending-skills
-           runtime-session skills)
-          (with-current-buffer shell-buffer
-            (setq magent-agent-shell--pending-skill-names nil)))))))
-
-(defun magent-agent-shell--send-command (orig &rest args)
-  "Attach Magent prompt skills before delegating to ORIG with ARGS."
-  (let ((prompt (plist-get args :prompt))
-        (shell-buffer (plist-get args :shell-buffer)))
-    (when (and prompt shell-buffer)
-      (magent-agent-shell--prepare-command-skills prompt shell-buffer))
-    (apply orig args)))
-
-(unless (advice-member-p #'magent-agent-shell--send-command
-                         'agent-shell--send-command)
-  (advice-add 'agent-shell--send-command :around
-              #'magent-agent-shell--send-command))
-
-(defun magent-agent-shell--trim-trailing-input-whitespace ()
-  "Delete trailing whitespace from the active Magent shell input."
-  (when (and (magent-agent-shell--magent-buffer-p (current-buffer))
-             (boundp 'comint-last-prompt)
-             comint-last-prompt)
-    (let ((start (marker-position (cdr comint-last-prompt)))
-          (end (point-max)))
-      (when (and start (<= start end))
-        (save-excursion
-          (goto-char end)
-          (skip-chars-backward " \t\n\r" start)
-          (when (< (point) end)
-            (let ((inhibit-read-only t))
-              (delete-region (point) end))))))))
-
-(defun magent-agent-shell--shell-maker-submit (orig &rest args)
-  "Trim Magent prompt input before delegating to ORIG with ARGS."
-  (magent-agent-shell--trim-trailing-input-whitespace)
-  (apply orig args))
-
-(unless (advice-member-p #'magent-agent-shell--shell-maker-submit
-                         'shell-maker-submit)
-  (advice-add 'shell-maker-submit :around
-              #'magent-agent-shell--shell-maker-submit))
+       (eq (map-elt (ignore-errors (agent-shell-get-config buffer))
+                    :identifier)
+           magent-agent-shell--identifier)))
 
 (defun magent-agent-shell--blank-current-line-p ()
   "Return non-nil when the current buffer line is blank."
@@ -320,11 +130,6 @@ Return non-nil when SKILL-NAME is selected after toggling."
          (magent-agent-shell--magent-buffer-p
           (plist-get args :shell-buffer))))
     (apply orig args)))
-
-(unless (advice-member-p #'magent-agent-shell--context
-                         'agent-shell--context)
-  (advice-add 'agent-shell--context :around
-              #'magent-agent-shell--context))
 
 (defun magent-agent-shell--get-region-context (orig &rest args)
   "Build region context through ORIG without remote path queries.
@@ -342,11 +147,6 @@ context must not perform remote file I/O."
                         (file-remote-p agent-cwd))))
       (setq args (plist-put (copy-sequence args) :agent-cwd nil))))
   (apply orig args))
-
-(unless (advice-member-p #'magent-agent-shell--get-region-context
-                         'agent-shell--get-region-context)
-  (advice-add 'agent-shell--get-region-context :around
-              #'magent-agent-shell--get-region-context))
 
 (defun magent-agent-shell--get-files-context (orig &rest args)
   "Build Magent file context through ORIG without remote file probes.
@@ -370,245 +170,33 @@ containment checks.  Context rendering must not contact the project host."
                    "\n\n")
       (apply orig args))))
 
-(unless (advice-member-p #'magent-agent-shell--get-files-context
-                         'agent-shell--get-files-context)
-  (advice-add 'agent-shell--get-files-context :around
-              #'magent-agent-shell--get-files-context))
-
 (defun magent-agent-shell--get-current-line-context (orig &rest args)
   "Suppress empty current-line context before delegating to ORIG.
 
-`agent-shell--get-current-line-context' builds line context by
-temporarily activating the current line as a region.  On a blank
-line this creates an empty BOL region, which agent-shell 0.57.1
-formats as an inverted range such as README.org:3-2.  Blank line
-context is not useful for Magent, so skip it."
+`agent-shell--get-current-line-context' builds line context by temporarily
+activating the current line as a region.  On a blank line this may create an
+inverted range.  Blank line context is not useful for Magent, so skip it."
   (if (and magent-agent-shell--context-request-p
            (magent-agent-shell--blank-current-line-p))
       nil
     (apply orig args)))
 
-(unless (advice-member-p #'magent-agent-shell--get-current-line-context
-                         'agent-shell--get-current-line-context)
-  (advice-add 'agent-shell--get-current-line-context :around
-              #'magent-agent-shell--get-current-line-context))
+(defconst magent-agent-shell--context-compatibility-advices
+  '((agent-shell--context . magent-agent-shell--context)
+    (agent-shell--get-region-context .
+                                     magent-agent-shell--get-region-context)
+    (agent-shell--get-files-context . magent-agent-shell--get-files-context)
+    (agent-shell--get-current-line-context .
+                                           magent-agent-shell--get-current-line-context))
+  "Private agent-shell context functions temporarily advised by Magent.")
 
-(defun magent-agent-shell--buffers ()
-  "Return live Magent agent-shell buffers without creating side effects."
-  (seq-filter #'magent-agent-shell--magent-buffer-p (buffer-list)))
+(defun magent-agent-shell--install-context-compatibility ()
+  "Install Magent's isolated agent-shell context compatibility advices."
+  (dolist (entry magent-agent-shell--context-compatibility-advices)
+    (unless (advice-member-p (cdr entry) (car entry))
+      (advice-add (car entry) :around (cdr entry)))))
 
-(defun magent-agent-shell--project-buffer ()
-  "Return the Magent agent-shell buffer for the current project, or nil."
-  (let ((project-key (magent-agent-shell--directory-key (agent-shell-cwd))))
-    (seq-find
-     (lambda (buffer)
-       (with-current-buffer buffer
-         (equal project-key
-                (magent-agent-shell--directory-key default-directory))))
-     (magent-agent-shell--buffers))))
-
-(defun magent-agent-shell--buffer (&optional no-create)
-  "Return the current project Magent agent-shell buffer.
-When NO-CREATE is non-nil, return nil instead of creating one."
-  (magent-agent-shell--with-config
-    (or (and (magent-agent-shell--magent-buffer-p (current-buffer))
-             (current-buffer))
-        (magent-agent-shell--project-buffer)
-        (unless no-create
-          (agent-shell-start :config (magent-agent-shell-make-config))))))
-
-(defun magent-agent-shell--state-option-complete-p (option-key complete-key)
-  "Return non-nil when OPTION-KEY either is unset or COMPLETE-KEY is done."
-  (let ((getter (map-nested-elt agent-shell--state
-                                (list :agent-config option-key))))
-    (or (not (functionp getter))
-        (not (ignore-errors (funcall getter)))
-        (map-elt agent-shell--state complete-key))))
-
-(defun magent-agent-shell--bootstrap-complete-p ()
-  "Return non-nil when the current Magent agent-shell finished bootstrap."
-  (and (map-elt agent-shell--state :initialized)
-       (map-nested-elt agent-shell--state '(:session :id))
-       (or (not (map-elt agent-shell--state :needs-authentication))
-           (map-elt agent-shell--state :authenticated))
-       (magent-agent-shell--state-option-complete-p
-        :default-model-id :set-model)
-       (magent-agent-shell--state-option-complete-p
-        :default-session-mode-id :set-session-mode)))
-
-(defun magent-agent-shell--stale-busy-p ()
-  "Return non-nil when current buffer is stuck busy without live work."
-  (and (magent-agent-shell--magent-buffer-p (current-buffer))
-       (bound-and-true-p shell-maker--busy)
-       (magent-agent-shell--bootstrap-complete-p)
-       (not (map-elt agent-shell--state :active-requests))
-       (not (map-elt agent-shell--state :pending-restore))
-       (not (and (boundp 'shell-maker--request-process)
-                 shell-maker--request-process
-                 (process-live-p shell-maker--request-process)))))
-
-(defun magent-agent-shell--recover-stale-busy (&optional process-pending)
-  "Clear stale busy state in current Magent shell.
-When PROCESS-PENDING is non-nil, resume the oldest queued agent-shell prompt
-after clearing the stale state."
-  (when (magent-agent-shell--stale-busy-p)
-    (setq shell-maker--busy nil)
-    (magent-log "WARN recovered stale agent-shell busy state in %s"
-                (buffer-name))
-    (when (and process-pending
-               (map-elt agent-shell--state :pending-prompts))
-      (agent-shell-prompt-queue-resume))
-    t))
-
-;;;###autoload
-(defun magent-agent-shell-start ()
-  "Start a new Magent agent-shell buffer."
-  (interactive)
-  (magent-agent-shell--with-config
-    (agent-shell-start :config (magent-agent-shell-make-config))))
-
-;;;###autoload
-(defun magent-start ()
-  "Open or reuse the Magent agent-shell UI."
-  (interactive)
-  (magent-agent-shell--with-config
-    (if-let* ((shell-buffer (magent-agent-shell--buffer t)))
-        (progn
-          (with-current-buffer shell-buffer
-            (magent-agent-shell--recover-stale-busy t))
-          (agent-shell--display-buffer shell-buffer))
-      (agent-shell--dwim :config (magent-agent-shell-make-config)
-                         :new-shell t))))
-
-;;;###autoload
-(cl-defun magent-agent-shell-send-prompt (prompt &key no-focus skills)
-  "Send PROMPT through the Magent agent-shell backend."
-  (unless (and (stringp prompt)
-               (not (string-empty-p (string-trim prompt))))
-    (user-error "Empty prompt"))
-  (magent-agent-shell--with-config
-    (let ((shell-buffer (magent-agent-shell--buffer)))
-      (magent-agent-shell--queue-prompt-skills shell-buffer prompt skills)
-      (with-current-buffer shell-buffer
-        (magent-agent-shell--recover-stale-busy t))
-      (if (with-current-buffer shell-buffer
-            (shell-maker-busy))
-          (with-current-buffer shell-buffer
-            (agent-shell-prompt-queue prompt))
-        (agent-shell-insert :text prompt
-                            :submit t
-                            :no-focus no-focus
-                            :shell-buffer shell-buffer)))))
-
-;;;###autoload
-(defun magent-agent-shell-toggle-skill-for-next-request (&optional skill-name)
-  "Toggle an instruction skill for the next Magent agent-shell request."
-  (interactive)
-  (magent--ensure-initialized)
-  (magent-agent-shell--with-config
-    (magent-agent-shell--prepare-skill-context)
-    (let* ((shell-buffer (magent-agent-shell--buffer))
-           (name (or skill-name
-                     (magent-agent-shell--read-instruction-skill
-                      "Toggle skill for next request: "))))
-      (unless (member name (magent-agent-shell--instruction-skill-names))
-        (user-error "Magent: '%s' is not an instruction skill" name))
-      (message "Magent: skill %s %s for next request"
-               name
-               (if (magent-agent-shell--toggle-pending-skill
-                    shell-buffer name)
-                   "selected"
-                 "cleared")))))
-
-;;;###autoload
-(defun magent-agent-shell-clear-skills-for-next-request ()
-  "Clear selected instruction skills for the next Magent agent-shell request."
-  (interactive)
-  (magent--ensure-initialized)
-  (magent-agent-shell--with-config
-    (magent-agent-shell--clear-pending-skills
-     (magent-agent-shell--buffer))
-    (message "Magent: selected skills cleared")))
-
-;;;###autoload
-(defun magent-agent-shell-run-command (&optional command-name argument)
-  "Run a registered slash COMMAND-NAME through Magent agent-shell.
-When ARGUMENT is nil, prompt for optional trailing command text."
-  (interactive)
-  (magent--ensure-initialized)
-  (magent-agent-shell--with-config
-    (magent-agent-shell--prepare-skill-context)
-    (let* ((shell-buffer (magent-agent-shell--buffer))
-           (runtime-session
-            (magent-agent-shell--runtime-session shell-buffer))
-           (scope
-            (if runtime-session
-                (magent-runtime-session-scope runtime-session)
-              (or (magent-runtime-active-project-scope) 'global)))
-           (name
-            (or command-name
-                (let ((names (mapcar #'magent-action-spec-name
-                                     (magent-action-list scope))))
-                  (unless names
-                    (user-error "Magent: no slash commands are registered"))
-                  (completing-read "Run Magent command: " names nil t))))
-           (_spec (or (magent-action-get name scope)
-                      (user-error "Magent: unknown command /%s" name)))
-           (extra (if argument
-                      argument
-                    (read-string
-                     (format "Argument for /%s (optional): " name))))
-           (prompt (concat "/" name
-                           (unless (string-blank-p extra)
-                             (concat " " extra)))))
-      (magent-agent-shell-send-prompt prompt))))
-
-;;;###autoload
-(defun magent-agent-shell-run-init-command (&optional extra-instruction)
-  "Run the built-in /init command through Magent agent-shell."
-  (interactive)
-  (magent-agent-shell-run-command "init" extra-instruction))
-
-;;;###autoload
-(defun magent-agent-shell-prompt-region (begin end)
-  "Send region from BEGIN to END through the Magent agent-shell backend."
-  (interactive "r")
-  (magent-agent-shell-send-prompt
-   (buffer-substring-no-properties begin end)))
-
-;;;###autoload
-(defun magent-agent-shell-ask-at-point ()
-  "Ask Magent about the symbol at point using agent-shell."
-  (interactive)
-  (let ((symbol (thing-at-point 'symbol t)))
-    (unless symbol
-      (user-error "No symbol at point"))
-    (magent-agent-shell-send-prompt
-     (format "Explain this code: %s" symbol))))
-
-;;;###autoload
-(defun magent-agent-shell-interrupt (&optional force)
-  "Interrupt the current Magent agent-shell request.
-When FORCE is non-nil, skip agent-shell's confirmation prompt."
-  (interactive "P")
-  (if-let* ((shell-buffer (or (and (magent-agent-shell--magent-buffer-p
-                                    (current-buffer))
-                                   (current-buffer))
-                              (magent-agent-shell--buffer t))))
-      (with-current-buffer shell-buffer
-        (agent-shell-interrupt force))
-    (user-error "No Magent agent-shell buffer")))
-
-(defun magent-agent-shell-processing-p ()
-  "Return non-nil when a Magent agent-shell buffer is busy."
-  (seq-some
-   (lambda (shell-buffer)
-     (with-current-buffer shell-buffer
-       (and (not (magent-agent-shell--stale-busy-p))
-            (memq (ignore-errors
-                    (agent-shell-status :shell-buffer shell-buffer))
-                  '(busy blocked)))))
-   (magent-agent-shell--buffers)))
+(magent-agent-shell--install-context-compatibility)
 
 (provide 'magent-agent-shell)
 ;;; magent-agent-shell.el ends here

--- a/lisp/magent.el
+++ b/lisp/magent.el
@@ -57,10 +57,11 @@
 ;;   M-x customize-group RET magent RET
 ;;
 ;; Usage:
-;;   M-x magent-start                    - Open or reuse the project session
-;;   M-x magent-agent-shell-start        - Start a new Magent shell
-;;   M-x magent-agent-shell-prompt-region - Send the selected region
-;;   M-x magent-agent-shell-ask-at-point - Ask about the symbol at point
+;;   M-x magent-start                    - Start the Magent frontend
+;;   M-x agent-shell                     - Select a registered agent backend
+;;
+;; Once inside Magent, use agent-shell's native commands and slash menu for
+;; prompt submission, region/context transfer, Actions, skills, and interrupts.
 ;;
 ;; Setup:
 ;; 1. Configure gptel with your provider and API key:

--- a/test/magent-live-test.el
+++ b/test/magent-live-test.el
@@ -60,7 +60,7 @@
                      "\\`magit-section-"
                      "\\`acp-"
                      "\\`shell-maker-"
-                     "\\`agent-shell-"
+                     "\\`agent-shell-[0-9]"
                      "\\`cond-let-"
                      "\\`yaml-[0-9]"
                      "\\`llama-"
@@ -121,6 +121,36 @@
     (unless value
       (ert-fail (or message "Timed out waiting for live Magent condition")))
     value))
+
+(defun magent-live-test--agent-shell-state-option-complete-p
+    (state option-key complete-key)
+  "Return non-nil when STATE finished OPTION-KEY as COMPLETE-KEY."
+  (let ((getter (map-nested-elt state (list :agent-config option-key))))
+    (or (not (functionp getter))
+        (not (ignore-errors (funcall getter)))
+        (map-elt state complete-key))))
+
+(defun magent-live-test--agent-shell-bootstrap-complete-p (buffer)
+  "Return non-nil when BUFFER's real agent-shell bootstrap is complete."
+  (with-current-buffer buffer
+    (and (map-elt agent-shell--state :initialized)
+         (map-nested-elt agent-shell--state '(:session :id))
+         (or (not (map-elt agent-shell--state :needs-authentication))
+             (map-elt agent-shell--state :authenticated))
+         (magent-live-test--agent-shell-state-option-complete-p
+          agent-shell--state :default-model-id :set-model)
+         (magent-live-test--agent-shell-state-option-complete-p
+          agent-shell--state :default-session-mode-id :set-session-mode))))
+
+(defun magent-live-test--agent-shell-runtime-session (buffer)
+  "Return the Magent runtime session bound to agent-shell BUFFER."
+  (with-current-buffer buffer
+    (when-let* ((session-id
+                 (map-nested-elt agent-shell--state '(:session :id)))
+                (client (map-elt agent-shell--state :client))
+                (scope (magent-acp--client-session-scope client session-id)))
+      (or (magent-runtime-session-from-id session-id scope)
+          (magent-acp--runtime-session-by-id session-id scope)))))
 
 (defun magent-live-test--redact-sensitive-text (text)
   "Return TEXT with likely provider secrets redacted."
@@ -853,16 +883,13 @@ return that path."
       (unwind-protect
           (progn
             (setq source-buffer
-                  (agent-shell--start
-                   :config config
-                   :no-focus t
-                   :new-session t
-                   :session-strategy 'new))
+                  (agent-shell-start :config config))
             (magent-live-test--wait-until
              (lambda ()
                (and (buffer-live-p source-buffer)
                     (with-current-buffer source-buffer
-                      (and (magent-agent-shell--bootstrap-complete-p)
+                      (and (magent-live-test--agent-shell-bootstrap-complete-p
+                            source-buffer)
                            (not (map-elt agent-shell--state
                                          :active-requests))
                            (map-elt agent-shell--state
@@ -872,7 +899,8 @@ return that path."
              10
              "Magent source agent-shell did not finish initialization")
             (let* ((source-runtime
-                    (magent-agent-shell--runtime-session source-buffer))
+                    (magent-live-test--agent-shell-runtime-session
+                     source-buffer))
                    (source-session
                     (magent-runtime-session-magent-session source-runtime))
                    (source-thread
@@ -902,7 +930,8 @@ return that path."
                           (let ((fork-id
                                  (map-nested-elt
                                   agent-shell--state '(:session :id))))
-                            (and (magent-agent-shell--bootstrap-complete-p)
+                            (and (magent-live-test--agent-shell-bootstrap-complete-p
+                                  fork-buffer)
                                  (not (map-elt agent-shell--state
                                                :active-requests))
                                  fork-id
@@ -910,7 +939,8 @@ return that path."
                  10
                  "Magent forked agent-shell did not finish initialization")
                 (let* ((fork-runtime
-                        (magent-agent-shell--runtime-session fork-buffer))
+                        (magent-live-test--agent-shell-runtime-session
+                         fork-buffer))
                        (fork-session
                         (magent-runtime-session-magent-session fork-runtime))
                        (source-transcript

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -502,7 +502,17 @@
                     magent-permission--glob-to-regexp
                     magent-session--validate-json-state
                     magent-runtime-queue--set-submission-starter
-                    magent-runtime-queue--bootstrap-preserved-backends))
+                    magent-runtime-queue--bootstrap-preserved-backends
+                    magent-agent-shell-start
+                    magent-agent-shell-send-prompt
+                    magent-agent-shell-toggle-skill-for-next-request
+                    magent-agent-shell-clear-skills-for-next-request
+                    magent-agent-shell-run-command
+                    magent-agent-shell-run-init-command
+                    magent-agent-shell-prompt-region
+                    magent-agent-shell-ask-at-point
+                    magent-agent-shell-interrupt
+                    magent-agent-shell-processing-p))
     (should-not (fboundp symbol))))
 
 (ert-deftest magent-test-aa-interactive-command-names-are-canonical ()
@@ -12956,11 +12966,8 @@
       (unwind-protect
           (progn
             (setq shell-buffer
-                  (agent-shell--start
-                   :config (magent-agent-shell-make-config)
-                   :no-focus t
-                   :new-session t
-                   :session-strategy agent-shell-session-strategy))
+                  (agent-shell-start
+                   :config (magent-agent-shell-make-config)))
             (should
              (eq (buffer-local-value 'agent-shell-session-strategy
                                      shell-buffer)
@@ -12968,37 +12975,46 @@
         (when (buffer-live-p shell-buffer)
           (kill-buffer shell-buffer))))))
 
-(ert-deftest magent-test-agent-shell-start-uses-magent-session-strategy ()
-  "Test Magent agent-shell entry points do not inherit global prompt strategy."
-  (require 'magent-agent-shell)
-  (let ((magent-agent-shell-session-strategy 'new)
-        captured)
-    (cl-letf (((symbol-function 'magent-runtime-ensure-initialized)
-               #'ignore)
-              ((symbol-function 'agent-shell-start)
-               (lambda (&rest _args)
-                 (setq captured agent-shell-session-strategy)
-                 'shell-buffer)))
-      (should (eq (magent-agent-shell-start) 'shell-buffer))
-      (should (eq captured 'new)))))
-
 (ert-deftest magent-test-start-is-canonical-agent-shell-entry-point ()
   "Test `magent-start' opens Magent through the supported frontend."
   (require 'magent-agent-shell)
-  (let (captured-config)
+  (let ((magent-agent-shell-session-strategy 'new)
+        captured-config captured-strategy)
     (cl-letf (((symbol-function 'magent-runtime-ensure-initialized)
                #'ignore)
-              ((symbol-function 'magent-agent-shell-ensure-config)
-               (lambda () 'magent))
-              ((symbol-function 'magent-agent-shell--buffer)
-               (lambda (&optional _no-create) nil))
-              ((symbol-function 'agent-shell--dwim)
+              ((symbol-function 'agent-shell-start)
                (lambda (&rest args)
                  (setq captured-config (plist-get args :config))
+                 (setq captured-strategy agent-shell-session-strategy)
                  'shell-buffer)))
       (should (commandp 'magent-start))
       (should (eq (magent-start) 'shell-buffer))
-      (should (eq (map-elt captured-config :identifier) 'magent)))))
+      (should (eq (map-elt captured-config :identifier) 'magent))
+      (should (eq captured-strategy 'new)))))
+
+(ert-deftest magent-test-agent-shell-adapter-has-a-narrow-private-boundary ()
+  "Test production coupling is limited to context compatibility advices."
+  (require 'magent-agent-shell)
+  (let ((source (expand-file-name "lisp/magent-agent-shell.el"
+                                  magent-test--root-directory)))
+    (with-temp-buffer
+      (insert-file-contents source)
+      (dolist (private-state '("agent-shell--state"
+                               "agent-shell--send-command"
+                               "agent-shell--display-buffer"
+                               "agent-shell--dwim"
+                               "shell-maker--"))
+        (goto-char (point-min))
+        (should-not (search-forward private-state nil t)))))
+  (should
+   (equal
+    magent-agent-shell--context-compatibility-advices
+    '((agent-shell--context . magent-agent-shell--context)
+      (agent-shell--get-region-context .
+                                       magent-agent-shell--get-region-context)
+      (agent-shell--get-files-context . magent-agent-shell--get-files-context)
+      (agent-shell--get-current-line-context .
+                                             magent-agent-shell--get-current-line-context)))))
 
 (ert-deftest magent-test-agent-shell-suppresses-blank-line-context ()
   "Test blank current-line context does not produce inverted line ranges."
@@ -13116,165 +13132,32 @@
     (unwind-protect
         (progn
           (with-current-buffer magent-shell
-            (setq major-mode 'agent-shell-mode)
-            (setq-local agent-shell--state
-                        '((:agent-config . ((:identifier . magent))))))
+            (setq major-mode 'agent-shell-mode))
           (with-current-buffer other-shell
-            (setq major-mode 'agent-shell-mode)
-            (setq-local agent-shell--state
-                        '((:agent-config . ((:identifier . other))))))
+            (setq major-mode 'agent-shell-mode))
           (with-temp-buffer
             (setq buffer-file-name
                   "/ssh:test.invalid:/srv/project/example.el")
-            (dolist (case `((,magent-shell . nil)
-                            (,other-shell . ,remote-cwd)))
-              (let (captured-cwd)
-                (magent-agent-shell--context
-                 (lambda (&rest _args)
-                   (magent-agent-shell--get-region-context
-                    (lambda (&rest region-args)
-                      (setq captured-cwd
-                            (plist-get region-args :agent-cwd)))
-                    :agent-cwd remote-cwd))
-                 :shell-buffer (car case))
-                (should (equal captured-cwd (cdr case)))))))
+            (cl-letf (((symbol-function 'agent-shell-get-config)
+                       (lambda (buffer)
+                         `((:identifier
+                            . ,(if (eq buffer magent-shell)
+                                   'magent
+                                 'other))))))
+              (dolist (case `((,magent-shell . nil)
+                              (,other-shell . ,remote-cwd)))
+                (let (captured-cwd)
+                  (magent-agent-shell--context
+                   (lambda (&rest _args)
+                     (magent-agent-shell--get-region-context
+                      (lambda (&rest region-args)
+                        (setq captured-cwd
+                              (plist-get region-args :agent-cwd)))
+                      :agent-cwd remote-cwd))
+                   :shell-buffer (car case))
+                  (should (equal captured-cwd (cdr case))))))))
       (kill-buffer magent-shell)
       (kill-buffer other-shell))))
-
-(ert-deftest magent-test-agent-shell-send-prompt-queues-skills ()
-  "Test agent-shell prompt submission records request-local skills."
-  (require 'magent-agent-shell)
-  (let ((buffer (generate-new-buffer "*magent-skill-queue*"))
-        queued)
-    (unwind-protect
-        (progn
-          (with-current-buffer buffer
-            (setq major-mode 'agent-shell-mode)
-            (setq-local shell-maker--busy t)
-            (setq-local agent-shell--state
-                        '((:agent-config . ((:identifier . magent))))))
-          (cl-letf (((symbol-function 'magent-runtime-ensure-initialized)
-                     #'ignore)
-                    ((symbol-function 'magent-agent-shell-ensure-config)
-                     (lambda () 'magent))
-                    ((symbol-function 'magent-agent-shell--buffer)
-                     (lambda (&optional _no-create) buffer))
-                    ((symbol-function 'magent-agent-shell--recover-stale-busy)
-                     #'ignore)
-                    ((symbol-function 'shell-maker-busy)
-                     (lambda () t))
-                    ((symbol-function 'agent-shell-prompt-queue)
-                     (lambda (prompt)
-                       (setq queued prompt))))
-            (magent-agent-shell-send-prompt
-             "hello" :skills '("init") :no-focus t))
-          (should (equal queued "hello"))
-          (with-current-buffer buffer
-            (should (equal magent-agent-shell--prompt-skill-queue
-                           '((:prompt "hello" :skills ("init")))))))
-      (when (buffer-live-p buffer)
-        (kill-buffer buffer)))))
-
-(ert-deftest magent-test-agent-shell-prepares-prompt-skills-for-runtime ()
-  "Test queued prompt skills are applied to the runtime session."
-  (require 'magent-agent-shell)
-  (let* ((buffer (generate-new-buffer "*magent-skill-runtime*"))
-         (runtime-session (magent-runtime-session-create
-                           :id "session-1" :scope 'global))
-         (client (magent-test--acp-client-for-runtime runtime-session)))
-    (unwind-protect
-        (progn
-          (with-current-buffer buffer
-            (setq major-mode 'agent-shell-mode)
-            (setq-local agent-shell--state
-                        `((:agent-config . ((:identifier . magent)))
-                          (:client . ,client)
-                          (:session . ((:id . "session-1")))))
-            (setq-local magent-agent-shell--prompt-skill-queue
-                        '((:prompt "hello" :skills ("init")))))
-          (cl-letf (((symbol-function 'magent-runtime-session-from-id)
-                     (lambda (session-id _scope)
-                       (and (equal session-id "session-1")
-                            runtime-session))))
-            (magent-agent-shell--prepare-command-skills "hello" buffer))
-          (should (equal (magent-runtime-session-pending-skills
-                          runtime-session)
-                         '("init")))
-          (with-current-buffer buffer
-            (should-not magent-agent-shell--prompt-skill-queue)))
-      (when (buffer-live-p buffer)
-        (kill-buffer buffer)))))
-
-(ert-deftest magent-test-agent-shell-keeps-prompt-skills-without-runtime ()
-  "Test queued prompt skills are not consumed before runtime session exists."
-  (require 'magent-agent-shell)
-  (let ((buffer (generate-new-buffer "*magent-skill-no-runtime*")))
-    (unwind-protect
-        (progn
-          (with-current-buffer buffer
-            (setq major-mode 'agent-shell-mode)
-            (setq-local agent-shell--state
-                        '((:agent-config . ((:identifier . magent)))))
-            (setq-local magent-agent-shell--prompt-skill-queue
-                        '((:prompt "hello" :skills ("init")))))
-          (magent-agent-shell--prepare-command-skills "hello" buffer)
-          (with-current-buffer buffer
-            (should (equal magent-agent-shell--prompt-skill-queue
-                           '((:prompt "hello" :skills ("init")))))))
-      (when (buffer-live-p buffer)
-        (kill-buffer buffer)))))
-
-(ert-deftest magent-test-agent-shell-run-command-submits-slash-input ()
-  "Test interactive command selection submits the literal slash request."
-  (require 'magent-agent-shell)
-  (let ((magent-action--registry nil)
-        sent)
-    (magent-action-register "demo" :session-policy 'current :workflow #'magent-test--empty-action-workflow)
-    (cl-letf (((symbol-function 'magent--ensure-initialized) #'ignore)
-              ((symbol-function 'magent-agent-shell--prepare-skill-context)
-               #'ignore)
-              ((symbol-function 'magent-agent-shell--buffer)
-               (lambda (&optional _no-create) 'shell-buffer))
-              ((symbol-function 'magent-agent-shell--runtime-session)
-               (lambda (&optional _buffer) nil))
-              ((symbol-function 'magent-agent-shell-send-prompt)
-               (lambda (prompt &rest _args) (setq sent prompt))))
-      (magent-agent-shell-run-command "demo" "focus on tests"))
-    (should (equal sent "/demo focus on tests"))))
-
-(ert-deftest magent-test-agent-shell-run-command-lists-session-scope ()
-  "Test interactive command selection uses the shell session's scope."
-  (require 'magent-agent-shell)
-  (let ((magent-action--registry nil)
-        (magent-action--sequence 0)
-        (runtime-session
-         (magent-runtime-session-create
-          :id "session-a" :scope "/tmp/project-a"))
-        offered sent)
-    (magent-action-register
-     "project-a-command" :session-policy 'current :workflow #'magent-test--empty-action-workflow
-     :source-layer 'project :source-scope "/tmp/project-a")
-    (magent-action-register
-     "project-b-command" :session-policy 'current :workflow #'magent-test--empty-action-workflow
-     :source-layer 'project :source-scope "/tmp/project-b")
-    (cl-letf (((symbol-function 'magent--ensure-initialized) #'ignore)
-              ((symbol-function 'magent-runtime-ensure-initialized) #'ignore)
-              ((symbol-function 'magent-agent-shell--prepare-skill-context)
-               #'ignore)
-              ((symbol-function 'magent-agent-shell--buffer)
-               (lambda (&optional _no-create) 'shell-buffer))
-              ((symbol-function 'magent-agent-shell--runtime-session)
-               (lambda (&optional _buffer) runtime-session))
-              ((symbol-function 'completing-read)
-               (lambda (_prompt collection &rest _args)
-                 (setq offered collection)
-                 "project-a-command"))
-              ((symbol-function 'read-string) (lambda (&rest _) ""))
-              ((symbol-function 'magent-agent-shell-send-prompt)
-               (lambda (prompt &rest _args) (setq sent prompt))))
-      (magent-agent-shell-run-command))
-    (should (equal offered '("project-a-command")))
-    (should (equal sent "/project-a-command"))))
 
 (ert-deftest magent-test-runtime-cancel-is-session-scoped ()
   "Test runtime cancellation removes only the requested session's work."
@@ -13843,225 +13726,6 @@
                      :project-root "/project-a"
                      :title "Scoped chat"
                      :updated-at 0.0)))))))
-
-(ert-deftest magent-test-agent-shell-buffer-selects-only-magent-shells ()
-  "Test Magent backend ignores non-Magent agent-shell buffers."
-  (require 'magent-agent-shell)
-  (let ((foreign (generate-new-buffer "*foreign-agent-shell*"))
-        (magent-buffer (generate-new-buffer "*magent-agent-shell*")))
-    (unwind-protect
-        (progn
-          (with-current-buffer foreign
-            (setq major-mode 'agent-shell-mode)
-            (setq-local default-directory "/tmp/")
-            (setq-local agent-shell--state
-                        '((:agent-config . ((:identifier . codex))))))
-          (with-current-buffer magent-buffer
-            (setq major-mode 'agent-shell-mode)
-            (setq-local default-directory
-                        (file-name-as-directory default-directory))
-            (setq-local agent-shell--state
-                        '((:agent-config . ((:identifier . magent))))))
-          (cl-letf (((symbol-function 'magent-runtime-ensure-initialized)
-                     #'ignore)
-                    ((symbol-function 'magent-agent-shell-ensure-config)
-                     (lambda () 'config))
-                    ((symbol-function 'agent-shell-cwd)
-                     (lambda () default-directory))
-                    ((symbol-function 'agent-shell-start)
-                     (lambda (&rest _args)
-                       (error "should not create a shell"))))
-            (should (eq (magent-agent-shell--buffer t)
-                        magent-buffer))))
-      (when (buffer-live-p foreign)
-        (kill-buffer foreign))
-      (when (buffer-live-p magent-buffer)
-        (kill-buffer magent-buffer)))))
-
-(ert-deftest magent-test-agent-shell-submit-trims-trailing-input-whitespace ()
-  "Test Magent shell submit removes trailing blank input lines."
-  (require 'magent-agent-shell)
-  (let ((buffer (generate-new-buffer "*magent-trim-input*")))
-    (unwind-protect
-        (with-current-buffer buffer
-          (setq major-mode 'agent-shell-mode)
-          (setq-local agent-shell--state
-                      '((:agent-config . ((:identifier . magent)))))
-          (insert "Magent> hi\n\nthere\n\n")
-          (setq-local comint-last-prompt
-                      (cons (copy-marker (point-min))
-                            (copy-marker (+ (point-min) (length "Magent> ")))))
-          (magent-agent-shell--trim-trailing-input-whitespace)
-          (should (equal (buffer-string)
-                         "Magent> hi\n\nthere")))
-      (when (buffer-live-p buffer)
-        (kill-buffer buffer)))))
-
-(ert-deftest magent-test-agent-shell-processing-p-is-side-effect-free ()
-  "Test processing checks do not initialize runtime or inspect projects."
-  (require 'magent-agent-shell)
-  (let ((initialized nil)
-        (configured nil)
-        (project-looked-up nil)
-        (runtime-checked nil))
-    (cl-letf (((symbol-function 'magent-runtime-ensure-initialized)
-               (lambda ()
-                 (setq initialized t)
-                 (error "processing-p should not initialize runtime")))
-              ((symbol-function 'magent-agent-shell-ensure-config)
-               (lambda ()
-                 (setq configured t)
-                 (error "processing-p should not ensure config")))
-              ((symbol-function 'agent-shell-cwd)
-               (lambda ()
-                 (setq project-looked-up t)
-                 (error "processing-p should not inspect project")))
-              ((symbol-function 'magent-runtime-processing-p)
-               (lambda ()
-                 (setq runtime-checked t)
-                 nil)))
-      (should-not (magent-agent-shell-processing-p))
-      (should-not initialized)
-      (should-not configured)
-      (should-not project-looked-up)
-      (should-not runtime-checked))))
-
-(ert-deftest magent-test-agent-shell-send-recovers-stale-busy ()
-  "Test prompt dispatch clears agent-shell busy state when no work is live."
-  (require 'magent-agent-shell)
-  (let ((buffer (generate-new-buffer "*magent-stale-busy*"))
-        inserted queued)
-    (unwind-protect
-        (progn
-          (with-current-buffer buffer
-            (setq major-mode 'agent-shell-mode)
-            (setq-local shell-maker--busy t)
-            (setq-local shell-maker--request-process nil)
-            (setq-local agent-shell--state
-                        `((:agent-config
-                           . ((:identifier . magent)
-                              (:default-model-id . ,(lambda () "model"))
-                              (:default-session-mode-id . ,(lambda () "build"))))
-                          (:initialized . t)
-                          (:set-model . t)
-                          (:set-session-mode . t)
-                          (:session . ((:id . "session-1")))
-                          (:active-requests . nil)
-                          (:pending-restore . nil)
-                          (:pending-prompts . nil))))
-          (cl-letf (((symbol-function 'magent-runtime-ensure-initialized)
-                     #'ignore)
-                    ((symbol-function 'magent-agent-shell-ensure-config)
-                     (lambda () 'magent))
-                    ((symbol-function 'magent-agent-shell--buffer)
-                     (lambda (&optional _no-create) buffer))
-                    ((symbol-function 'shell-maker-busy)
-                     (lambda () shell-maker--busy))
-                    ((symbol-function 'agent-shell-insert)
-                     (lambda (&rest args)
-                       (setq inserted args)))
-                    ((symbol-function 'agent-shell-prompt-queue)
-                     (lambda (prompt)
-                       (setq queued prompt))))
-            (magent-agent-shell-send-prompt "hello" :no-focus t))
-          (with-current-buffer buffer
-            (should-not shell-maker--busy))
-          (should-not queued)
-          (should (equal (plist-get inserted :text) "hello"))
-          (should (plist-get inserted :submit))
-          (should (plist-get inserted :no-focus))
-          (should (eq (plist-get inserted :shell-buffer) buffer)))
-      (when (buffer-live-p buffer)
-        (kill-buffer buffer)))))
-
-(ert-deftest magent-test-agent-shell-stale-recovery-resumes-prompt-queue ()
-  "Test stale recovery resumes pending prompts through the public queue API."
-  (require 'magent-agent-shell)
-  (with-temp-buffer
-    (setq-local shell-maker--busy t)
-    (setq-local agent-shell--state '((:pending-prompts . ("queued"))))
-    (let (resumed)
-      (cl-letf (((symbol-function 'magent-agent-shell--stale-busy-p)
-                 (lambda () t))
-                ((symbol-function 'agent-shell-prompt-queue-resume)
-                 (lambda ()
-                   (setq resumed t))))
-        (should (magent-agent-shell--recover-stale-busy t)))
-      (should-not shell-maker--busy)
-      (should resumed))))
-
-(ert-deftest magent-test-agent-shell-send-queues-real-busy ()
-  "Test prompt dispatch keeps using agent-shell queue for live work."
-  (require 'magent-agent-shell)
-  (let ((buffer (generate-new-buffer "*magent-real-busy*"))
-        inserted queued)
-    (unwind-protect
-        (progn
-          (with-current-buffer buffer
-            (setq major-mode 'agent-shell-mode)
-            (setq-local shell-maker--busy t)
-            (setq-local shell-maker--request-process nil)
-            (setq-local agent-shell--state
-                        `((:agent-config
-                           . ((:identifier . magent)
-                              (:default-model-id . ,(lambda () "model"))
-                              (:default-session-mode-id . ,(lambda () "build"))))
-                          (:initialized . t)
-                          (:set-model . t)
-                          (:set-session-mode . t)
-                          (:session . ((:id . "session-1")))
-                          (:active-requests . (((:method . "session/prompt"))))
-                          (:pending-restore . nil)
-                          (:pending-prompts . nil))))
-          (cl-letf (((symbol-function 'magent-runtime-ensure-initialized)
-                     #'ignore)
-                    ((symbol-function 'magent-agent-shell-ensure-config)
-                     (lambda () 'magent))
-                    ((symbol-function 'magent-agent-shell--buffer)
-                     (lambda (&optional _no-create) buffer))
-                    ((symbol-function 'shell-maker-busy)
-                     (lambda () shell-maker--busy))
-                    ((symbol-function 'agent-shell-insert)
-                     (lambda (&rest args)
-                       (setq inserted args)))
-                    ((symbol-function 'agent-shell-prompt-queue)
-                     (lambda (prompt)
-                       (setq queued prompt))))
-            (magent-agent-shell-send-prompt "hello" :no-focus t))
-          (with-current-buffer buffer
-            (should shell-maker--busy))
-          (should-not inserted)
-          (should (equal queued "hello")))
-      (when (buffer-live-p buffer)
-        (kill-buffer buffer)))))
-
-(ert-deftest magent-test-agent-shell-processing-p-ignores-stale-busy ()
-  "Test stale shell-maker busy state is not reported as Magent processing."
-  (require 'magent-agent-shell)
-  (let ((buffer (generate-new-buffer "*magent-stale-processing*")))
-    (unwind-protect
-        (progn
-          (with-current-buffer buffer
-            (setq major-mode 'agent-shell-mode)
-            (setq-local default-directory
-                        (file-name-as-directory default-directory))
-            (setq-local shell-maker--busy t)
-            (setq-local shell-maker--request-process nil)
-            (setq-local agent-shell--state
-                        `((:agent-config
-                           . ((:identifier . magent)
-                              (:default-model-id . ,(lambda () "model"))
-                              (:default-session-mode-id . ,(lambda () "build"))))
-                          (:initialized . t)
-                          (:set-model . t)
-                          (:set-session-mode . t)
-                          (:session . ((:id . "session-1")))
-                          (:active-requests . nil)
-                          (:pending-restore . nil)
-                          (:pending-prompts . nil))))
-          (should-not (magent-agent-shell-processing-p)))
-      (when (buffer-live-p buffer)
-        (kill-buffer buffer)))))
 
 (ert-deftest magent-test-list-agents-loads-project-scope-before-first-prompt ()
   "Test listing agents loads project-local agents without a prior prompt."
@@ -16340,30 +16004,6 @@
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 
-(ert-deftest magent-test-agent-shell-runtime-session-rejects-unbound-buffer ()
-  "Agent-shell does not infer session scope from a buffer directory."
-  (require 'magent-agent-shell)
-  (let ((buffer (generate-new-buffer "*magent-agent-shell-scope-test*")))
-    (unwind-protect
-        (progn
-          (with-current-buffer buffer
-            (setq major-mode 'agent-shell-mode)
-            (setq-local agent-shell--state
-                        '((:agent-config . ((:identifier . magent)))
-                          (:session . ((:id . "same"))))))
-          (cl-letf (((symbol-function 'magent-session-scope-from-directory)
-                     (lambda (&rest _)
-                       (error "unexpected cwd-derived scope")))
-                    ((symbol-function 'magent-runtime-session-from-id)
-                     (lambda (&rest _)
-                       (error "unexpected unbound runtime lookup")))
-                    ((symbol-function 'magent-acp--runtime-session-by-id)
-                     (lambda (&rest _args)
-                       (error "unexpected unbound ACP lookup"))))
-            (should-not (magent-agent-shell--runtime-session buffer))))
-      (when (buffer-live-p buffer)
-        (kill-buffer buffer)))))
-
 (ert-deftest magent-test-acp-client-session-binding-survives-buffer-cwd-change ()
   "ACP prompt and cancel keep the scope captured at session bootstrap."
   (require 'magent-acp)
@@ -16448,34 +16088,6 @@
        (lambda (err) (setq failure err))))
     (should failure)
     (should-not prepared)))
-
-(ert-deftest magent-test-agent-shell-runtime-session-prefers-client-binding ()
-  "Agent-shell lookup does not drift when its buffer directory changes."
-  (require 'magent-agent-shell)
-  (let* ((magent-acp--client-session-scopes
-          (make-hash-table :test #'eq :weakness 'key))
-         (magent-runtime-api--sessions (make-hash-table :test #'equal))
-         (buffer (generate-new-buffer "*magent-agent-shell-fixed-scope*"))
-         (client `((:context-buffer . ,buffer)))
-         (runtime
-          (magent-runtime-session-create
-           :id "fixed" :scope "/explicit"
-           :magent-session (magent-session-create :id "fixed"))))
-    (unwind-protect
-        (progn
-          (puthash (list "/explicit" "fixed") runtime
-                   magent-runtime-api--sessions)
-          (magent-acp--bind-client-session client runtime)
-          (with-current-buffer buffer
-            (setq major-mode 'agent-shell-mode)
-            (setq-local default-directory "/changed/")
-            (setq-local agent-shell--state
-                        `((:agent-config . ((:identifier . magent)))
-                          (:client . ,client)
-                          (:session . ((:id . "fixed"))))))
-          (should (eq (magent-agent-shell--runtime-session buffer) runtime)))
-      (when (buffer-live-p buffer)
-        (kill-buffer buffer)))))
 
 (ert-deftest magent-test-runtime-register-refuses-same-scope-lease-replacement ()
   "A same-scope session cannot replace the exact session owning the lease."
@@ -16695,22 +16307,6 @@
                    logs))
           (should-not (magent-session-list-files)))
       (delete-directory directory t))))
-
-(ert-deftest magent-test-agent-shell-interrupt-honors-force-argument ()
-  "Magent forwards nil and non-nil FORCE without forcing confirmation off."
-  (require 'magent-agent-shell)
-  (let ((buffer (generate-new-buffer "*magent-agent-shell-interrupt*"))
-        calls)
-    (unwind-protect
-        (cl-letf (((symbol-function 'magent-agent-shell--buffer)
-                   (lambda (&optional _no-create) buffer))
-                  ((symbol-function 'agent-shell-interrupt)
-                   (lambda (force) (push force calls))))
-          (magent-agent-shell-interrupt nil)
-          (magent-agent-shell-interrupt 'force)
-          (should (equal (nreverse calls) '(nil force))))
-      (when (buffer-live-p buffer)
-        (kill-buffer buffer)))))
 
 (ert-deftest magent-test-session-fork-deep-copies-ledger-and-resets-owned-state ()
   "Forked sessions share history but no mutable conversation state."


### PR DESCRIPTION
## Summary

- reduce `magent-agent-shell.el` to the Magent ACP config, `magent-start`, and one isolated context compatibility block
- remove redundant Magent shell, prompt, interrupt, Action, skill, busy-state, and private runtime handoff paths
- delegate normal interaction to public agent-shell commands and its slash menu
- update unit/live tests and English/Chinese documentation for the narrower boundary

## Compatibility boundary

The remaining private coupling is limited to four grouped context advices for remote-safe and blank-line context handling. Explicit config registration also remains until agent-shell exposes a standard third-party discovery API.

This implements phases 1 and 2 of #50; the upstream discovery/contribution work remains tracked there.

## Verification

- `make compile`
- `make lint`
- `make test` (609 unit tests and 3 live smoke tests)
- isolated Emacs daemon loaded all Magent sources from this checkout

Related to #50.