### PR TITLE
fix: report structured provider errors through ACP

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -20,3 +20,10 @@ intentional tagged release is planned as ~v0.2.0~.
   Magent-owned tool loop, permission and approval controls, durable sessions
   and child-agent jobs, Elisp-native Actions, instruction skills, automatic
   capabilities, Doctor, and memory workflows.
+
+** Fixed
+
+- Preserve structured provider error responses before gptel cleanup and report
+  runtime failures through ACP errors, so agent-shell shows the actionable
+  provider message instead of a generic JSON parse error followed by an unknown
+  stop reason.

--- a/lisp/magent-acp.el
+++ b/lisp/magent-acp.el
@@ -493,13 +493,22 @@ model as ambiguous prompt text."
    `((sessionUpdate . "agent_message_chunk")
      (content . ,(magent-acp--content-block text)))))
 
-(defun magent-acp--complete-prompt-request (on-success status result)
-  "Complete ACP prompt callback ON-SUCCESS from runtime STATUS and RESULT."
-  (funcall
-   on-success
-   `((stopReason . ,(magent-acp--stop-reason status result))
-     ,@(unless (eq status 'completed)
-         `((error . ,(magent-execution-result-content-string result)))))))
+(defun magent-acp--complete-prompt-request
+    (on-success on-failure status result)
+  "Complete an ACP prompt from runtime STATUS and RESULT.
+Return protocol-defined terminal conditions through ON-SUCCESS.  Report other
+runtime failures through ON-FAILURE instead of inventing a non-standard ACP
+stop reason."
+  (if-let* ((stop-reason (magent-acp--stop-reason status result)))
+      (funcall on-success `((stopReason . ,stop-reason)))
+    (magent-acp--call-failure
+     on-failure
+     (acp-make-error
+      :code -32603
+      :message (magent-execution-result-content-string result)
+      :data (and (magent-execution-result-p result)
+                 (magent-json-safe-value
+                  (magent-execution-result-metadata result)))))))
 
 (defun magent-acp--notify (client method params)
   "Deliver incoming ACP notification METHOD PARAMS to CLIENT subscribers.
@@ -672,13 +681,10 @@ Each handler runs inside the CLIENT's context buffer (via
                      (content . [])))
                 (error nil)))))
           ('turn-error
-           (reset-stream)
-           (magent-acp--session-update
-            client session-id
-            `((sessionUpdate . "agent_message_chunk")
-              (content . ,(magent-acp--content-block
-                           (format "Error: %s"
-                                   (or (plist-get event :message) "")))))))
+           ;; The pending session/prompt request reports this through its
+           ;; JSON-RPC error response.  Do not misrepresent transport/runtime
+           ;; failures as assistant-authored message content.
+           (reset-stream))
           ('turn-complete
            (reset-stream)
            (when-let* ((scope (magent-acp--client-session-scope
@@ -778,16 +784,31 @@ Each handler runs inside the CLIENT's context buffer (via
 (defun magent-acp--wrap-callback (client buffer callback)
   "Return CALLBACK wrapped to run in CLIENT/BUFFER context."
   (when callback
-    (lambda (&rest args)
-      (with-temp-buffer
-        (with-current-buffer (or (magent-acp--callback-buffer client buffer)
-                                 (current-buffer))
-          (apply callback args))))))
+    (let ((maximum-arity (cdr (func-arity callback))))
+      (lambda (&rest args)
+        (with-temp-buffer
+          (with-current-buffer
+              (or (magent-acp--callback-buffer client buffer)
+                  (current-buffer))
+            ;; acp.el currently supplies a two-argument failure callback,
+            ;; while older callers use the documented one-argument shape.
+            ;; Keep the transport wrapper compatible with both contracts.
+            (apply callback
+                   (if (and (numberp maximum-arity)
+                            (> (length args) maximum-arity))
+                       (cl-subseq args 0 maximum-arity)
+                     args))))))))
 
 (defun magent-acp--call-failure (on-failure error)
   "Call ON-FAILURE with ERROR."
   (when on-failure
-    (funcall on-failure error)))
+    (let ((raw-message `((jsonrpc . "2.0") (error . ,error)))
+          (arity (func-arity on-failure)))
+      (if (or (eq (cdr arity) 'many)
+              (and (numberp (cdr arity))
+                   (>= (cdr arity) 2)))
+          (funcall on-failure error raw-message)
+        (funcall on-failure error)))))
 
 (defun magent-acp--scope-equal-p (left right)
   "Return non-nil when session scopes LEFT and RIGHT are equal."
@@ -993,14 +1014,17 @@ switching semantics."
     ('completed "end_turn")
     ('cancelled "cancelled")
     (_
-     (let ((failure-status
+     (let ((failure-kind
             (and (magent-execution-result-p result)
-                 (plist-get (magent-execution-result-metadata result) :status))))
-       (pcase failure-status
+                 (let ((metadata
+                        (magent-execution-result-metadata result)))
+                   (or (plist-get metadata :status)
+                       (plist-get metadata :reason))))))
+       (pcase failure-kind
          ('sampling-limit "max_turn_requests")
          ('max-tokens "max_tokens")
          ('refusal "refusal")
-         (_ "error"))))))
+         (_ nil))))))
 
 (defun magent-acp--handle-request (client request on-success on-failure)
   "Handle ACP REQUEST from CLIENT."
@@ -1115,7 +1139,7 @@ switching semantics."
                 :on-complete
                 (lambda (status result)
                   (magent-acp--complete-prompt-request
-                   on-success status result))))
+                   on-success on-failure status result))))
               (skill-command
                (let ((skill-name (plist-get skill-command :name)))
                  (magent-runtime-submit
@@ -1138,7 +1162,7 @@ switching semantics."
                   :on-complete
                   (lambda (status result)
                     (magent-acp--complete-prompt-request
-                     on-success status result)))))
+                     on-success on-failure status result)))))
               (t
                (magent-runtime-submit
                 runtime-session (plist-get input :display-text)
@@ -1155,7 +1179,7 @@ switching semantics."
                 :on-complete
                 (lambda (status result)
                   (magent-acp--complete-prompt-request
-                   on-success status result)))))))
+                   on-success on-failure status result)))))))
           (_
            (error "Unsupported ACP method: %s" method))))
     (error

--- a/lisp/magent-llm-gptel.el
+++ b/lisp/magent-llm-gptel.el
@@ -213,6 +213,58 @@ requests, so Magent normalizes this boundary before curl serializes it."
     (when (magent-llm-gptel--managed-info-p info)
       (magent-llm-gptel--sanitize-info info))))
 
+(defun magent-llm-gptel--curl-provider-error (buffer info)
+  "Return a structured provider error from curl response BUFFER.
+INFO is gptel request metadata containing the curl write-out UUID.  Try each
+HTTP header boundary before the write-out marker so proxy and redirect header
+blocks do not hide an otherwise valid JSON error response."
+  (when-let* (((buffer-live-p buffer))
+              (uuid (plist-get info :uuid)))
+    (with-current-buffer buffer
+      (save-excursion
+        (goto-char (point-max))
+        (when (search-backward uuid nil t)
+          (let ((response-end (max (point-min) (1- (point)))))
+            (goto-char (point-min))
+            (catch 'provider-error
+              (while (re-search-forward "\r?\n\r?\n" response-end t)
+                (let* ((body (string-trim
+                              (buffer-substring-no-properties
+                               (point) response-end)))
+                       (response
+                        (and (not (string-empty-p body))
+                             (ignore-errors
+                               (gptel--json-read-string body))))
+                       (provider-error
+                        (and response
+                             (gptel--parse-response-error response))))
+                  (when provider-error
+                    (throw 'provider-error provider-error)))))))))))
+
+(defun magent-llm-gptel--capture-curl-provider-error (buffer info)
+  "Capture a structured provider error from curl BUFFER into gptel INFO."
+  (when-let* ((provider-error
+               (magent-llm-gptel--curl-provider-error buffer info)))
+    (if (plist-member info :magent-provider-error)
+        (plist-put info :magent-provider-error provider-error)
+      (nconc info (list :magent-provider-error provider-error))))
+  info)
+
+(defun magent-llm-gptel--capture-curl-error-before-cleanup-a
+    (process _status)
+  "Capture a Magent provider error before gptel destroys PROCESS state."
+  (when-let* ((requests
+               (and (boundp 'gptel--request-alist)
+                    (symbol-value 'gptel--request-alist)))
+              (entry (alist-get process requests))
+              (fsm (car entry))
+              (info (gptel-fsm-info fsm))
+              ((magent-llm-gptel--managed-info-p info))
+              (http-status (plist-get info :http-status))
+              ((not (member http-status '("100" "200")))))
+    (magent-llm-gptel--capture-curl-provider-error
+     (process-buffer process) info)))
+
 (defun magent-llm-gptel--install-boundary-advice ()
   "Install adapter-local gptel boundary sanitization advice."
   (unless (advice-member-p #'magent-llm-gptel--reset-reasoning-block-a
@@ -238,7 +290,15 @@ requests, so Magent normalizes this boundary before curl serializes it."
                              'gptel-curl--parse-stream)
       (advice-add 'gptel-curl--parse-stream
                   :around
-                  #'magent-llm-gptel--sanitize-after-parse-stream-a))))
+                  #'magent-llm-gptel--sanitize-after-parse-stream-a)))
+  (when (fboundp 'gptel-curl--stream-cleanup)
+    (unless
+        (advice-member-p
+         #'magent-llm-gptel--capture-curl-error-before-cleanup-a
+         'gptel-curl--stream-cleanup)
+      (advice-add
+       'gptel-curl--stream-cleanup
+       :before #'magent-llm-gptel--capture-curl-error-before-cleanup-a))))
 
 (defun magent-llm-gptel--make-state ()
   "Create adapter-local streaming state."
@@ -584,18 +644,35 @@ context remains paused for Magent recovery."
     (dolist (key '(:status :http-status :error :tokens :stop-reason))
       (when-let* ((value (plist-get info key)))
         (setq metadata (append metadata (list key value)))))
+    (when-let* ((provider-error (plist-get info :magent-provider-error)))
+      (setq metadata
+            (append metadata
+                    (list :provider-error
+                          (magent-json-safe-value provider-error)))))
     metadata))
+
+(defun magent-llm-gptel--provider-error-message (provider-error)
+  "Return a concise message for structured PROVIDER-ERROR."
+  (cond
+   ((stringp provider-error) provider-error)
+   ((listp provider-error)
+    (let ((message (or (plist-get provider-error :message)
+                       (plist-get provider-error :detail))))
+      (if (stringp message)
+          message
+        (format "%S" provider-error))))
+   (provider-error (format "%S" provider-error))))
 
 (defun magent-llm-gptel--error-message (info)
   "Return the most useful provider error message from gptel INFO."
-  (let ((provider-error (plist-get info :error))
+  (let ((captured-error (plist-get info :magent-provider-error))
+        (provider-error (plist-get info :error))
         (status (plist-get info :status)))
     (cond
-     ((stringp provider-error) provider-error)
-     ((and (listp provider-error)
-           (stringp (plist-get provider-error :message)))
-      (plist-get provider-error :message))
-     (provider-error (format "%S" provider-error))
+     (captured-error
+      (magent-llm-gptel--provider-error-message captured-error))
+     (provider-error
+      (magent-llm-gptel--provider-error-message provider-error))
      (status (format "%s" status))
      (t "gptel request failed"))))
 

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -9626,6 +9626,39 @@
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 
+(ert-deftest magent-test-llm-gptel-preserves-structured-curl-provider-error ()
+  "A structured HTTP error survives gptel's generic JSON parse failure."
+  (require 'magent-llm-gptel)
+  (let ((buffer (generate-new-buffer " *magent-test-curl-error*"))
+        (info '(:uuid "response-marker"
+                :error "Malformed JSON in response.")))
+    (unwind-protect
+        (progn
+          (with-current-buffer buffer
+            (insert
+             (concat
+              "HTTP/1.1 200 Connection established\r\n\r\n"
+              "HTTP/2 503\r\ncontent-type: application/json\r\n\r\n"
+              "{\"error\":{\"message\":\"The engine is currently overloaded, "
+              "please try again later\",\"type\":\"engine_overloaded_error\"}}"
+              "(response-marker . 128)")))
+          (magent-llm-gptel--capture-curl-provider-error buffer info)
+          (should
+           (equal (plist-get info :magent-provider-error)
+                  '(:message
+                    "The engine is currently overloaded, please try again later"
+                    :type "engine_overloaded_error")))
+          (should
+           (equal (magent-llm-gptel--error-message info)
+                  "The engine is currently overloaded, please try again later"))
+          (should
+           (equal (plist-get (magent-llm-gptel--metadata info) :provider-error)
+                  '(:message
+                    "The engine is currently overloaded, please try again later"
+                    :type "engine_overloaded_error"))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
 (ert-deftest magent-test-llm-gptel-reasoning-only-done-completes-empty ()
   "Test reasoning-only provider responses complete without leaking reasoning."
   (require 'magent-llm-gptel)
@@ -12514,26 +12547,65 @@
     (should (equal (map-elt success 'stopReason) "end_turn"))))
 
 (ert-deftest magent-test-acp-stop-reason-preserves-failure-kind ()
-  "Test ACP stopReason does not report internal failures as refusals."
+  "Test ACP stopReason is limited to protocol-defined terminal conditions."
   (require 'magent-acp)
   (should (equal (magent-acp--stop-reason
                   'failed
                   (magent-execution-result-failed
                    "Maximum sampling requests reached"
-                   '(:status sampling-limit)))
+                   '(:reason sampling-limit)))
                  "max_turn_requests"))
   (should (equal (magent-acp--stop-reason
                   'failed
                   (magent-execution-result-failed
                    "Request timed out"
                    '(:status timeout)))
-                 "error"))
+                 nil))
   (should (equal (magent-acp--stop-reason
                   'failed
                   (magent-execution-result-failed
                    "Model refused"
                    '(:status refusal)))
                  "refusal")))
+
+(ert-deftest magent-test-acp-provider-failure-uses-json-rpc-error ()
+  "Test provider failures do not become an invalid ACP stop reason."
+  (require 'magent-acp)
+  (let (success failure raw-message)
+    (magent-acp--complete-prompt-request
+     (lambda (value) (setq success value))
+     (lambda (error raw)
+       (setq failure error
+             raw-message raw))
+     'failed
+     (magent-execution-result-failed
+      "The engine is currently overloaded, please try again later"
+      '(:status "HTTP/2 503"
+        :provider-error
+        (:message "The engine is currently overloaded, please try again later"
+         :type "engine_overloaded_error"))))
+    (should-not success)
+    (should (= (map-elt failure 'code) -32603))
+    (should
+     (equal (map-elt failure 'message)
+            "The engine is currently overloaded, please try again later"))
+    (should (equal (plist-get (map-elt failure 'data) :status)
+                   "HTTP/2 503"))
+    (should (equal (map-elt raw-message 'error) failure))))
+
+(ert-deftest magent-test-acp-turn-error-is-not-assistant-content ()
+  "Test runtime failures are reported by the pending ACP request only."
+  (require 'magent-acp)
+  (let* (notifications
+         (client `((:notification-handlers
+                    . (,(lambda (notification)
+                          (push notification notifications))))
+                   (:request-handlers . nil)))
+         (observer (magent-acp--observer client "session-1")))
+    (funcall observer
+             '(:type turn-error
+               :message "The engine is currently overloaded"))
+    (should-not notifications)))
 
 (ert-deftest magent-test-acp-session-prompt-success-runs-in-request-buffer ()
   "Test deferred ACP prompt callbacks run in the buffer supplied by acp.el."


### PR DESCRIPTION
## Summary

- preserve structured provider errors from gptel curl responses before cleanup
- return runtime failures as ACP JSON-RPC errors while limiting stopReason to protocol-defined values
- add regression coverage and a changelog entry; validated with compile, lint, 627 unit tests, and live smoke