### PR TITLE
feat(models): support cross-provider switching

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -14,6 +14,11 @@ intentional tagged release is planned as ~v0.2.0~.
 
 ** Added
 
+- Cross-provider model selection through agent-shell's native ACP model option.
+  Magent catalogs every gptel-registered backend/model, keeps selections
+  session-local, freezes routes per submission, and supports ~Auto~ fallback to
+  agent or gptel defaults.  Child agents may override inherited routes with
+  their own explicit model.
 - A documented Semantic Versioning policy, public compatibility boundary, and
   repeatable release checklist.
 - The initial release baseline: the agent-shell and in-process ACP frontend,

--- a/README.org
+++ b/README.org
@@ -164,6 +164,14 @@ Magent delegates all LLM communication to [[https://github.com/karthink/gptel][g
 
 See [[https://github.com/karthink/gptel#configuration][gptel documentation]] for full provider setup (Anthropic, OpenAI, Ollama, etc.).
 
+Every backend and model registered with gptel is available from agent-shell's
+model selector, including models from different providers.  A selection is
+local to the Magent session and does not mutate global ~gptel-backend~ or
+~gptel-model~.  ~Auto~ clears the session override and shows the model currently
+resolved from the selected agent or gptel defaults.  Changes apply only to new
+submissions; active requests, queued submissions, and provider-native tool
+continuations keep the route frozen when they were submitted.
+
 The only supported Magent frontend is agent-shell.  Magent supplies its own
 agent-shell configuration and in-process ACP client, so no external ACP
 command is required.  To start using Magent:
@@ -442,7 +450,8 @@ The YAML frontmatter supports:
 - ~hidden~: Hide from agent selection UI
 - ~temperature~: Override default temperature
 - ~effort~: Override reasoning effort: ~auto~, ~minimal~, ~low~, ~medium~, ~high~, or ~xhigh~
-- ~model~: Override default model
+- ~model~: Override the default model for this agent.  Child agents prefer this
+  explicit route over the frozen route inherited from their parent.
 - ~permissions~: Mapping of permission groups to ~allow~, ~deny~, ~ask~, or nested file-pattern rules
 
 Unknown frontmatter fields and non-canonical permission keys are rejected.

--- a/docs/UI_BACKENDS.org
+++ b/docs/UI_BACKENDS.org
@@ -58,6 +58,21 @@ explicit command registration and invocation belong in ~magent-action.el~.
   latest, or prompt-based session flow for both the Magent entry command and
   Magent selected from the generic agent-shell picker.  It defaults to ~prompt~,
   offering new and saved sessions from the current scope.
+- ACP exposes one native ~model~ session option containing every model from
+  every backend registered with gptel.  Display names use ~provider:model~;
+  opaque ids keep same-named models from different providers distinct.
+  Selecting a model stores a session-local route without mutating gptel's
+  global backend or model variables.  ~Auto~ clears that route and displays the
+  currently resolved agent/default model.
+
+Model routing is resolved and frozen when a runtime submission is created.
+The precedence for a user-facing turn is session route, explicit agent model,
+then gptel defaults.  A child agent instead prefers its own explicit model over
+the frozen parent route and otherwise inherits the parent.  The route object
+also retains agent-profile and phase fields as an API seam for future
+per-agent or per-phase policy; there is no phase router in the current runtime.
+Switching the session model affects only later submissions, not active work,
+already queued work, or a provider-native tool continuation.
 
 * Session Lifecycle
 
@@ -68,10 +83,10 @@ history.  The source and fork retain separate ids and diverge after creation.
 
 Forking is exact-scope and fail-closed: the requested cwd must resolve to the
 source session's scope, and the source must have no active or queued work.
-Stable frontend options such as the selected agent, effort, and automatic
-capability setting are inherited.  Session approval overrides, child-agent
-jobs, and one-shot skills are deliberately reset.  Referenced spilled tool
-outputs are copied into the fork's private session storage.
+Stable frontend options such as the selected agent, model route, effort, and
+automatic capability setting are inherited.  Session approval overrides,
+child-agent jobs, and one-shot skills are deliberately reset.  Referenced
+spilled tool outputs are copied into the fork's private session storage.
 
 * Development Boundary
 
@@ -106,4 +121,6 @@ entry surfaces; it must not infer skills from the Action registry.
 - ACP session config exposes ~Automatic capabilities~. Disabling it suppresses
   contextual capability auto-resolution for future turns in that session while
   retaining explicitly selected instruction skills.
+- Model routes are session-local in memory.  Cross-Emacs persistence of an
+  explicit route is not yet implemented; a loaded session returns to ~Auto~.
 - Forking an active turn and forking across project scopes are not supported.

--- a/docs/UI_BACKENDS.zh.org
+++ b/docs/UI_BACKENDS.zh.org
@@ -51,6 +51,17 @@ invocation 则属于 ~magent-action.el~ 。
   session 流程；无论使用 Magent 兼容入口还是从通用 agent-shell 选择器中选择 Magent，
   该设置都会生效。默认值是 ~prompt~，会列出当前 scope 中的新 session 和已保存
   session。
+- ACP 暴露一个原生 ~model~ session option，包含 gptel 已注册的所有 backend 和
+  model。显示名使用 ~provider:model~；opaque id 能区分不同 provider 下的同名
+  model。选择模型只会保存 session-local route，不会修改 gptel 的全局 backend 或
+  model 变量。~Auto~ 会清除该 route，并显示当前由 agent/default 解析出的模型。
+
+Model route 会在 runtime submission 创建时完成解析并冻结。用户可见 turn 的优先级为
+session route、agent 显式模型、gptel 默认值；child agent 则优先使用自身显式模型，
+否则继承冻结的 parent route。route object 还保留 agent profile 与 phase 字段，作为
+未来 per-agent/per-phase policy 的 API 接口；当前 runtime 并未实现 phase router。
+切换 session 模型只影响后续 submission，不影响 active work、已经 queued 的 work，
+也不影响 provider-native tool continuation。
 
 * Session 生命周期
 
@@ -60,10 +71,10 @@ Magent 实现 ACP ~session/new~、~session/list~、~session/load~、~session/res
 独立演进。
 
 Fork 按精确 scope fail closed：请求 cwd 必须解析到 source session 的 scope，source
-也不能拥有 active 或 queued work。selected agent、effort 和 automatic capability
-设置等稳定 frontend option 会被继承；session approval override、child-agent job 和
-one-shot skill 会被显式重置。历史中引用的 spilled tool output 会复制到 fork 自己的
-私有 session storage。
+也不能拥有 active 或 queued work。selected agent、model route、effort 和 automatic
+capability 设置等稳定 frontend option 会被继承；session approval override、
+child-agent job 和 one-shot skill 会被显式重置。历史中引用的 spilled tool output
+会复制到 fork 自己的私有 session storage。
 
 * 开发边界
 
@@ -93,4 +104,6 @@ registered Action command projections 与 skill descriptors 展示为两个独�
   per-request agent overrides。
 - ACP session config 暴露 ~Automatic capabilities~ ；关闭后，该 session 后续 turn 不再
   自动解析 contextual capabilities，但显式选择的 instruction skills 仍然生效。
+- Model route 当前只保存在 session 内存中；尚未实现跨 Emacs 持久化。加载已保存的
+  session 后会回到 ~Auto~。
 - 不支持在 active turn 执行期间 fork，也不支持跨 project scope fork。

--- a/lisp/magent-acp.el
+++ b/lisp/magent-acp.el
@@ -22,14 +22,13 @@
 (require 'magent-agent-registry)
 (require 'magent-config)
 (require 'magent-json)
+(require 'magent-llm-gptel)
 (require 'magent-protocol)
 (require 'magent-runtime-api)
 (require 'magent-session)
 (require 'magent-ledger)
 (require 'magent-action)
 (require 'magent-skills)
-
-(defvar gptel-model)
 
 (defconst magent-acp-protocol-version 1
   "ACP protocol version supported by Magent.")
@@ -96,14 +95,82 @@ all protocol traffic.  Keep that implementation detail off the TRAMP host."
                         (mapcar #'magent-acp--mode-entry
                                 (magent-agent-registry-primary-agents))))))
 
-(defun magent-acp--models ()
-  "Return ACP models object for current gptel model."
-  (let ((model-id (format "%s" (or (and (boundp 'gptel-model) gptel-model)
-                                   "gptel"))))
-    `((currentModelId . ,model-id)
-      (availableModels . [((modelId . ,model-id)
-                           (name . ,model-id)
-                           (description . "Current gptel model"))]))))
+(defun magent-acp--model-descriptor-entry (descriptor)
+  "Return an ACP legacy model entry for DESCRIPTOR."
+  `((modelId . ,(magent-model-descriptor-id descriptor))
+    (name . ,(magent-model-descriptor-name descriptor))
+    (description . ,(magent-model-descriptor-description descriptor))))
+
+(defun magent-acp--effective-model-route (&optional runtime-session)
+  "Return the current effective route for RUNTIME-SESSION or gptel defaults."
+  (if runtime-session
+      (magent-runtime-session-effective-model-route runtime-session)
+    (magent-llm-gptel-validate-route
+     (magent-llm-gptel-default-route))))
+
+(defun magent-acp--effective-model-descriptor (&optional runtime-session)
+  "Return the catalog descriptor effective for RUNTIME-SESSION."
+  (when (and (magent-llm-gptel-model-catalog)
+             (if runtime-session
+                 (magent-runtime-session-model-routing-configured-p
+                  runtime-session)
+               (or (default-value 'gptel-backend)
+                   (default-value 'gptel-model))))
+    (let* ((route (magent-acp--effective-model-route runtime-session))
+           (descriptor (magent-llm-gptel-descriptor-for-route route)))
+      (unless descriptor
+        (error "Magent route %s:%s is absent from the gptel model registry"
+               (gptel-backend-name (magent-model-route-backend route))
+               (magent-model-route-model route)))
+      descriptor)))
+
+(defun magent-acp--models (&optional runtime-session)
+  "Return ACP models for all gptel providers and RUNTIME-SESSION."
+  (let ((current (magent-acp--effective-model-descriptor runtime-session)))
+    `((currentModelId . ,(if current
+                             (magent-model-descriptor-id current)
+                           "unconfigured"))
+      (availableModels
+       . ,(vconcat
+           (mapcar #'magent-acp--model-descriptor-entry
+                   (magent-llm-gptel-model-catalog)))))))
+
+(defun magent-acp--model-option-entry (descriptor)
+  "Return an ACP config option value for model DESCRIPTOR."
+  `((value . ,(magent-model-descriptor-id descriptor))
+    (name . ,(magent-model-descriptor-name descriptor))
+    (description . ,(magent-model-descriptor-description descriptor))))
+
+(defun magent-acp--model-config-option (runtime-session)
+  "Return the ACP model config option for RUNTIME-SESSION."
+  (let* ((effective (magent-acp--effective-model-descriptor runtime-session))
+         (explicit
+          (magent-runtime-session-model-route-option runtime-session))
+         (current-value
+          (if explicit
+              (let ((descriptor
+                     (magent-llm-gptel-descriptor-for-route explicit)))
+                (unless descriptor
+                  (error "Explicit Magent model route is absent from gptel"))
+                (magent-model-descriptor-id descriptor))
+            magent-llm-gptel-auto-model-id)))
+    `((id . "model")
+      (name . "Model")
+      (description . "Provider and model for future Magent turns in this session.")
+      (category . "model")
+      (type . "select")
+      (currentValue . ,current-value)
+      (options
+       . ,(vconcat
+           (cons
+            `((value . ,magent-llm-gptel-auto-model-id)
+              (name . ,(format "Auto → %s"
+                               (if effective
+                                   (magent-model-descriptor-name effective)
+                                 "Unconfigured")))
+              (description . "Use the selected agent model, then gptel defaults."))
+            (mapcar #'magent-acp--model-option-entry
+                    (magent-llm-gptel-model-catalog))))))))
 
 (defun magent-acp--effort-option-entry (effort)
   "Return ACP config option value entry for EFFORT."
@@ -149,7 +216,8 @@ all protocol traffic.  Keep that implementation detail off the TRAMP host."
                   (description . "Auto-activate matching instruction skills."))
                  ((value . "disabled")
                   (name . "Disabled")
-                  (description . "Use only explicitly selected instruction skills."))]))))
+                  (description . "Use only explicitly selected instruction skills."))]))
+   (magent-acp--model-config-option runtime-session)))
 
 (defun magent-acp--command-entry (command)
   "Return ACP available command entry for COMMAND."
@@ -192,7 +260,7 @@ the leading slash, so agent-shell displays them as `/$NAME'."
   "Return common ACP session response for RUNTIME-SESSION."
   `((sessionId . ,(magent-runtime-session-id runtime-session))
     (modes . ,(magent-acp--modes runtime-session))
-    (models . ,(magent-acp--models))
+    (models . ,(magent-acp--models runtime-session))
     (configOptions . ,(magent-acp--config-options runtime-session))))
 
 (defun magent-acp--initialize-response ()
@@ -969,22 +1037,21 @@ does not activate overlays or install a session into the runtime registry."
     (magent-acp--session-response runtime-session)))
 
 (defun magent-acp--handle-set-model (params &optional expected-scope)
-  "Handle ACP session/set_model PARAMS.
-Magent uses gptel as the provider boundary, so the first ACP backend only
-advertises the currently configured gptel model.  Accepting that model keeps
-agent-shell's default bootstrap flow working without adding ACP-side model
-switching semantics."
+  "Handle ACP session/set_model PARAMS."
   (let* ((session-id (map-elt params 'sessionId))
          (model-id (map-elt params 'modelId))
          (runtime-session
-          (magent-acp--runtime-session-by-id session-id expected-scope))
-         (current-model-id (format "%s" (or (and (boundp 'gptel-model)
-                                                 gptel-model)
-                                            "gptel"))))
+          (magent-acp--runtime-session-by-id session-id expected-scope)))
     (unless runtime-session
       (error "Unknown session: %s" session-id))
-    (unless (equal model-id current-model-id)
-      (error "Unknown Magent model: %s" model-id))
+    (if (equal model-id magent-llm-gptel-auto-model-id)
+        (magent-runtime-session-clear-model-route runtime-session)
+      (let ((descriptor (magent-llm-gptel-model-descriptor model-id)))
+        (unless descriptor
+          (error "Unknown Magent model: %s" model-id))
+        (magent-runtime-session-set-model-route
+         runtime-session
+         (magent-llm-gptel-descriptor-route descriptor 'session))))
     (magent-acp--session-response runtime-session)))
 
 (defun magent-acp--handle-set-config-option (params &optional expected-scope)
@@ -1004,6 +1071,15 @@ switching semantics."
          (error "Invalid capabilities option: %s" value))
        (magent-runtime-session-set-capabilities-enabled
         runtime-session (equal value "enabled")))
+      ("model"
+       (if (equal value magent-llm-gptel-auto-model-id)
+           (magent-runtime-session-clear-model-route runtime-session)
+         (let ((descriptor (magent-llm-gptel-model-descriptor value)))
+           (unless descriptor
+             (error "Unknown Magent model: %s" value))
+           (magent-runtime-session-set-model-route
+            runtime-session
+            (magent-llm-gptel-descriptor-route descriptor 'session)))))
       (_
        (error "Unknown Magent config option: %s" config-id)))
     (magent-acp--session-response runtime-session)))

--- a/lisp/magent-agent-info.el
+++ b/lisp/magent-agent-info.el
@@ -15,6 +15,7 @@
 
 (require 'cl-lib)
 (require 'gptel)
+(require 'magent-llm)
 
 (cl-defstruct (magent-agent-info
                (:constructor nil)
@@ -95,6 +96,40 @@ The agent's TEMPERATURE field, if non-nil, overrides `gptel-temperature'."
          (gptel-temperature (or (magent-agent-info-temperature info)
                                 (default-value 'gptel-temperature))))
     (funcall body-thunk)))
+
+(defun magent-agent-info-model-route (info)
+  "Return INFO's explicit `magent-model-route', or nil.
+The route preserves the existing agent MODEL field contract.  A symbol or
+string selects a model on the default gptel backend, a backend object selects
+that backend with the default model, and (BACKEND . MODEL) selects both."
+  (unless (magent-agent-info-p info)
+    (error "Expected Magent agent info, got: %S" info))
+  (when-let* ((model-field (magent-agent-info-model info)))
+    (let ((backend
+           (cond
+            ((and (consp model-field)
+                  (gptel-backend-p (car model-field)))
+             (car model-field))
+            ((gptel-backend-p model-field) model-field)
+            (t (default-value 'gptel-backend))))
+          (model
+           (cond
+            ((and (consp model-field)
+                  (or (symbolp (cdr model-field))
+                      (stringp (cdr model-field))))
+             (if (symbolp (cdr model-field))
+                 (cdr model-field)
+               (intern (cdr model-field))))
+            ((or (symbolp model-field) (stringp model-field))
+             (if (symbolp model-field)
+                 model-field
+               (intern model-field)))
+            (t (default-value 'gptel-model)))))
+      (magent-model-route-create
+       :backend backend
+       :model model
+       :source 'agent
+       :profile-agent (magent-agent-info-name info)))))
 
 (defun magent-agent-info-format-for-display (info)
   "Format INFO as a string for display in listings."

--- a/lisp/magent-agent-shell.el
+++ b/lisp/magent-agent-shell.el
@@ -20,7 +20,6 @@
 (require 'magent-config)
 (require 'magent-runtime)
 
-(defvar gptel-model)
 (defvar agent-shell-agent-configs)
 (defvar agent-shell-session-strategy)
 
@@ -44,10 +43,6 @@
 (defun magent-agent-shell--ensure-loaded ()
   "Load `agent-shell' before using its public runtime API."
   (require 'agent-shell))
-
-(defun magent-agent-shell--model-id ()
-  "Return the current gptel model id for agent-shell display."
-  (format "%s" (or (and (boundp 'gptel-model) gptel-model) "gptel")))
 
 (defun magent-agent-shell--make-client (buffer)
   "Create Magent's in-process ACP client for BUFFER.
@@ -74,7 +69,6 @@ directory-local frontend configuration keeps precedence."
    :shell-prompt-regexp "Magent> "
    :welcome-function #'magent-agent-shell--welcome-message
    :client-maker #'magent-agent-shell--make-client
-   :default-model-id #'magent-agent-shell--model-id
    :default-session-mode-id (lambda () magent-default-agent)
    :install-instructions "Magent uses an in-process ACP client; no external command is required."))
 

--- a/lisp/magent-agent.el
+++ b/lisp/magent-agent.el
@@ -104,6 +104,32 @@ was not already emitted as text deltas."
                skill-name
                (mapconcat #'symbol-name missing ", "))))))
 
+(cl-defun magent-agent-resolve-model-route
+    (agent &key explicit-route parent-route phase)
+  "Resolve and validate the model route for AGENT.
+EXPLICIT-ROUTE is a request or session selection and has highest priority.
+An explicit model on AGENT takes precedence over PARENT-ROUTE, which lets a
+child agent override its inherited parent route.  Otherwise the current gptel
+defaults are used.  PHASE is retained as a policy seam for future request
+builders without adding a phase router today."
+  (unless (magent-agent-info-p agent)
+    (error "Expected Magent agent info, got: %S" agent))
+  (let* ((agent-route (magent-agent-info-model-route agent))
+         (selected (or explicit-route
+                       agent-route
+                       parent-route
+                       (magent-llm-gptel-default-route)))
+         (source (cond
+                  (explicit-route
+                   (or (magent-model-route-source explicit-route) 'request))
+                  (agent-route 'agent)
+                  (parent-route 'parent)
+                  (t 'gptel)))
+         (route
+          (magent-model-route-relabel
+           selected source (magent-agent-info-name agent) phase)))
+    (magent-llm-gptel-validate-route route)))
+
 (defun magent-agent--fail-request-turn
     (session turn-id request-scope detail)
   "Fail SESSION's TURN-ID with DETAIL.
@@ -312,12 +338,16 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
       (magent-agent-info-apply-gptel-overrides
        agent
        (lambda ()
-         (let* ((inherited-backend
-                 (and request-state
-                      (magent-request-context-backend request-state)))
-                (inherited-model
-                 (and request-state
-                      (magent-request-context-model request-state)))
+         (let* ((route
+                 (magent-agent-resolve-model-route
+                  agent
+                  :explicit-route
+                  (and request-state
+                       (magent-request-context-model-route request-state))
+                  :parent-route
+                  (and request-state
+                       (magent-request-context-parent-model-route
+                        request-state))))
                 (inherited-temperature
                  (and request-state
                       (magent-request-context-temperature request-state)))
@@ -327,11 +357,12 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                 (inherited-effort
                  (and request-state
                       (magent-request-context-effort request-state)))
-                (backend (or inherited-backend gptel-backend))
-                (model (or inherited-model gptel-model))
+                (backend (magent-model-route-backend route))
+                (model (magent-model-route-model route))
                 (temperature (or inherited-temperature
+                                 (magent-agent-info-temperature agent)
                                  (and (boundp 'gptel-temperature)
-                                      gptel-temperature)))
+                                      (default-value 'gptel-temperature))))
                 (top-p (or inherited-top-p
                            (magent-agent-info-top-p agent)))
                 (effort-option (or inherited-effort
@@ -343,10 +374,12 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
              (setf (magent-request-context-project-root request-state)
                    (or (magent-request-context-project-root request-state)
                        request-project-root)
+                   (magent-request-context-model-route request-state)
+                   route
                    (magent-request-context-model request-state)
-                   (or (magent-request-context-model request-state) model)
+                   model
                    (magent-request-context-backend request-state)
-                   (or (magent-request-context-backend request-state) backend)
+                   backend
                    (magent-request-context-temperature request-state)
                    (or (magent-request-context-temperature request-state)
                        temperature)
@@ -366,10 +399,11 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                        request-context)
                    (magent-request-context-permission-profile request-state)
                    effective-permission))
-           (magent-log "INFO agent=%s backend=%s model=%s tools=[%s]"
+           (magent-log "INFO agent=%s backend=%s model=%s route-source=%s tools=[%s]"
                        (magent-agent-info-name agent)
                        (gptel-backend-name backend)
                        model
+                       (magent-model-route-source route)
                        (mapconcat #'gptel-tool-name tools ", "))
            (when resolved-skill-names
              (magent-log "INFO active skills=[%s]"
@@ -379,6 +413,13 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                   (gptel-temperature temperature)
                   (request-tools
                    (magent-agent-loop-tools-for-provider tools))
+                  (_tool-capability-preflight
+                   (when (and request-tools
+                              (eq (magent-llm-gptel-route-tool-capability route)
+                                  'unsupported))
+                     (error
+                      "Magent model %s on backend %s does not support tools"
+                      model (gptel-backend-name backend))))
                   (gptel-tools request-tools)
                   (live-p (or request-live-p
                               (and request-state

--- a/lisp/magent-llm-gptel.el
+++ b/lisp/magent-llm-gptel.el
@@ -18,6 +18,7 @@
 
 (require 'cl-lib)
 (require 'subr-x)
+(require 'url-util)
 (require 'gptel)
 (require 'gptel-request)
 (require 'magent-config)
@@ -38,8 +39,150 @@
 (defvar gptel-confirm-tool-calls)
 (defvar gptel-include-reasoning)
 (defvar gptel-temperature)
+(defvar gptel--known-backends)
 (defvar gptel-proxy)
 (defvar magent-include-reasoning)
+
+(defconst magent-llm-gptel-auto-model-id "auto"
+  "ACP model id that clears an explicit Magent session route.")
+
+(defun magent-llm-gptel--model-name (model)
+  "Return gptel MODEL's provider-facing name as a string."
+  (if (fboundp 'gptel--model-name)
+      (gptel--model-name model)
+    (format "%s" model)))
+
+(defun magent-llm-gptel--route-id (backend-name model)
+  "Return an opaque model id for BACKEND-NAME and MODEL."
+  (format "gptel/%s/%s"
+          (url-hexify-string (format "%s" backend-name))
+          (url-hexify-string (magent-llm-gptel--model-name model))))
+
+(defun magent-llm-gptel--model-description (backend-name model)
+  "Return a concise safe description for MODEL on BACKEND-NAME."
+  (let* ((description (get model :description))
+         (capabilities (get model :capabilities))
+         (context-window (get model :context-window))
+         (details
+          (delq nil
+                (list
+                 (and capabilities
+                      (format "capabilities: %s"
+                              (mapconcat (lambda (value) (format "%s" value))
+                                         capabilities ", ")))
+                 (and context-window
+                      (format "context: %sk" context-window))))))
+    (string-join
+     (delq nil
+           (list (and (stringp description) description)
+                 (and details (string-join details "; "))
+                 (unless (or description details)
+                   (format "gptel model from %s" backend-name))))
+     " — ")))
+
+(defun magent-llm-gptel--descriptor (backend-name backend model)
+  "Return a safe model descriptor for BACKEND-NAME, BACKEND, and MODEL."
+  (magent-model-descriptor-create
+   :id (magent-llm-gptel--route-id backend-name model)
+   :name (format "%s:%s" backend-name
+                 (magent-llm-gptel--model-name model))
+   :description (magent-llm-gptel--model-description backend-name model)
+   :backend-name (format "%s" backend-name)
+   :backend backend
+   :model model
+   :capabilities (copy-sequence (get model :capabilities))))
+
+(defun magent-llm-gptel-model-catalog ()
+  "Return descriptors for every model registered with gptel.
+gptel currently exposes backend lookup and model accessors publicly but uses
+the private `gptel--known-backends' registry for its own cross-provider model
+picker.  Keep that private dependency isolated and fail clearly if its shape
+changes."
+  (unless (boundp 'gptel--known-backends)
+    (error "Installed gptel does not expose its backend registry"))
+  (unless (and (proper-list-p gptel--known-backends)
+               (cl-every #'consp gptel--known-backends))
+    (error "Unsupported gptel backend registry shape"))
+  (let ((seen (make-hash-table :test #'equal))
+        descriptors)
+    (dolist (entry gptel--known-backends)
+      (let ((backend-name (car entry))
+            (backend (cdr entry)))
+        (when (gptel-backend-p backend)
+          (dolist (model (gptel-backend-models backend))
+            (let* ((descriptor
+                    (magent-llm-gptel--descriptor
+                     backend-name backend model))
+                   (id (magent-model-descriptor-id descriptor)))
+              (unless (gethash id seen)
+                (puthash id t seen)
+                (push descriptor descriptors)))))))
+    (nreverse descriptors)))
+
+(defun magent-llm-gptel-model-descriptor (model-id)
+  "Return the gptel model descriptor for MODEL-ID, or nil."
+  (cl-find model-id (magent-llm-gptel-model-catalog)
+           :key #'magent-model-descriptor-id :test #'equal))
+
+(defun magent-llm-gptel-descriptor-route (descriptor &optional source)
+  "Return a model route for DESCRIPTOR attributed to SOURCE."
+  (unless (magent-model-descriptor-p descriptor)
+    (error "Expected Magent model descriptor, got: %S" descriptor))
+  (magent-model-route-create
+   :backend (magent-model-descriptor-backend descriptor)
+   :model (magent-model-descriptor-model descriptor)
+   :source (or source 'session)))
+
+(defun magent-llm-gptel-descriptor-for-route (route)
+  "Return the catalog descriptor matching ROUTE, or nil."
+  (when (magent-model-route-p route)
+    (cl-find-if
+     (lambda (descriptor)
+       (and (eq (magent-model-descriptor-backend descriptor)
+                (magent-model-route-backend route))
+            (equal (magent-model-descriptor-model descriptor)
+                   (magent-model-route-model route))))
+     (magent-llm-gptel-model-catalog))))
+
+(defun magent-llm-gptel-default-route ()
+  "Return the current global gptel route."
+  (magent-model-route-create
+   :backend (default-value 'gptel-backend)
+   :model (default-value 'gptel-model)
+   :source 'gptel))
+
+(defun magent-llm-gptel-validate-route (route)
+  "Return ROUTE when its backend and model remain registered and compatible."
+  (unless (magent-model-route-p route)
+    (error "Expected Magent model route, got: %S" route))
+  (let ((backend (magent-model-route-backend route))
+        (model (magent-model-route-model route)))
+    (unless (gptel-backend-p backend)
+      (error "Magent model route has no valid gptel backend"))
+    (unless model
+      (error "Magent model route has no model"))
+    (unless (member model (gptel-backend-models backend))
+      (error "Magent model %s is unavailable on gptel backend %s"
+             model (gptel-backend-name backend)))
+    (unless (magent-llm-gptel-descriptor-for-route route)
+      (error "Magent backend/model route is no longer registered with gptel: %s:%s"
+             (gptel-backend-name backend) model)))
+  route)
+
+(defun magent-llm-gptel-route-tool-capability (route)
+  "Return `supported', `unsupported', or `unknown' for ROUTE tool use."
+  (magent-llm-gptel-validate-route route)
+  (let* ((model (magent-model-route-model route))
+         (properties (and (symbolp model) (symbol-plist model))))
+    (if (and (symbolp model)
+             (plist-member properties :capabilities))
+        (if (cl-some (lambda (capability)
+                       (member (format "%s" capability)
+                               '("tool-use" "tools" "function-calling")))
+                     (get model :capabilities))
+            'supported
+          'unsupported)
+      'unknown)))
 
 (defun magent-llm-gptel--managed-context-p (context)
   "Return non-nil when gptel CONTEXT belongs to this adapter."

--- a/lisp/magent-llm.el
+++ b/lisp/magent-llm.el
@@ -29,6 +29,47 @@
     usage)
   "Valid normalized LLM event types.")
 
+(cl-defstruct (magent-model-route
+               (:constructor magent-model-route-create)
+               (:copier nil))
+  "One immutable provider/model selection for a sampling request.
+BACKEND is a provider adapter object and MODEL is its provider-facing model
+identifier.  SOURCE records which policy layer selected the route.  The
+optional PROFILE-AGENT and PHASE fields make the same contract reusable by
+future per-agent and per-phase request builders."
+  backend
+  model
+  source
+  profile-agent
+  phase)
+
+(cl-defstruct (magent-model-descriptor
+               (:constructor magent-model-descriptor-create)
+               (:copier nil))
+  "Frontend-safe metadata for one selectable model route.
+ID is an opaque stable identifier.  NAME and DESCRIPTION are display values.
+BACKEND-NAME is safe durable metadata, while BACKEND is the live adapter
+object used only inside the runtime.  CAPABILITIES is provider metadata and
+must never contain credentials or backend connection settings."
+  id
+  name
+  description
+  backend-name
+  backend
+  model
+  capabilities)
+
+(defun magent-model-route-relabel (route source &optional profile-agent phase)
+  "Return a new ROUTE attributed to SOURCE, PROFILE-AGENT, and PHASE."
+  (unless (magent-model-route-p route)
+    (error "Expected Magent model route, got: %S" route))
+  (magent-model-route-create
+   :backend (magent-model-route-backend route)
+   :model (magent-model-route-model route)
+   :source source
+   :profile-agent profile-agent
+   :phase phase))
+
 (cl-defstruct (magent-llm-request
                (:constructor magent-llm-request--create)
                (:copier nil))

--- a/lisp/magent-runtime-api.el
+++ b/lisp/magent-runtime-api.el
@@ -34,6 +34,7 @@
   id
   scope
   magent-session
+  model-route
   effort
   pending-skills
   metadata)
@@ -180,6 +181,8 @@ submission so the source frontend stays current."
                   (magent-runtime-api--wrap-session fork-session scope))
             (setf (magent-runtime-session-effort runtime-session)
                   (magent-runtime-session-effort source-runtime-session)
+                  (magent-runtime-session-model-route runtime-session)
+                  (magent-runtime-session-model-route source-runtime-session)
                   (magent-runtime-session-pending-skills runtime-session) nil
                   (magent-runtime-session-metadata runtime-session)
                   (list :capabilities-enabled
@@ -257,6 +260,57 @@ submission so the source frontend stays current."
          (agent (or (magent-session-agent session)
                     (magent-agent-registry-get-default))))
     (and agent (magent-agent-info-name agent))))
+
+(defun magent-runtime-session-model-route-option (runtime-session)
+  "Return RUNTIME-SESSION's explicit model route, or nil for automatic routing."
+  (unless (magent-runtime-session-p runtime-session)
+    (error "Expected a runtime session, got: %S" runtime-session))
+  (magent-runtime-session-model-route runtime-session))
+
+(defun magent-runtime-session-set-model-route (runtime-session route)
+  "Set RUNTIME-SESSION's explicit model ROUTE and return it.
+Pass nil to restore automatic routing."
+  (unless (magent-runtime-session-p runtime-session)
+    (error "Expected a runtime session, got: %S" runtime-session))
+  (magent-runtime-api--assert-session-available runtime-session)
+  (let ((stored-route
+         (when route
+           (magent-model-route-relabel
+            (magent-llm-gptel-validate-route route) 'session))))
+    (setf (magent-runtime-session-model-route runtime-session) stored-route)
+    stored-route))
+
+(defun magent-runtime-session-clear-model-route (runtime-session)
+  "Restore automatic model routing for RUNTIME-SESSION."
+  (magent-runtime-session-set-model-route runtime-session nil))
+
+(defun magent-runtime-session-effective-model-route
+    (runtime-session &optional agent-or-name phase)
+  "Resolve RUNTIME-SESSION's model route for AGENT-OR-NAME and PHASE.
+The returned route is an immutable request-ready snapshot."
+  (unless (magent-runtime-session-p runtime-session)
+    (error "Expected a runtime session, got: %S" runtime-session))
+  (let ((agent (magent-runtime-api--resolve-agent
+                runtime-session agent-or-name)))
+    (magent-agent-resolve-model-route
+     agent
+     :explicit-route (magent-runtime-session-model-route runtime-session)
+     :phase phase)))
+
+(defun magent-runtime-session-model-routing-configured-p
+    (runtime-session &optional agent-or-name)
+  "Return non-nil when RUNTIME-SESSION has enough policy to attempt routing.
+AGENT-OR-NAME selects a request-local agent without changing session state.
+This distinguishes a clean, not-yet-configured gptel installation from an
+invalid explicit route, which must still fail loudly during resolution."
+  (unless (magent-runtime-session-p runtime-session)
+    (error "Expected a runtime session, got: %S" runtime-session))
+  (let ((agent (magent-runtime-api--resolve-agent
+                runtime-session agent-or-name)))
+    (or (magent-runtime-session-model-route runtime-session)
+        (magent-agent-info-model agent)
+        (default-value 'gptel-backend)
+        (default-value 'gptel-model))))
 
 (defun magent-runtime-session-title (runtime-session)
   "Return RUNTIME-SESSION's canonical display title, or nil."
@@ -517,6 +571,7 @@ Any active or queued work for the session is cancelled first."
                  :ui-visibility 'none
                  :origin-context (magent-runtime-submission-context submission)
                  :tool-names (magent-runtime-submission-tool-names submission)
+                 :model-route (magent-runtime-submission-model-route submission)
                  :effort (magent-runtime-submission-effort submission)
                  :skill-names (magent-runtime-submission-skills submission)
                  :approval-provider
@@ -629,7 +684,10 @@ request-local Magent-native events."
          (effective-tools
           (magent-runtime-api--resolve-tools effective-agent tools))
          (effective-skills
-          (or skills (magent-runtime-session-pending-skills runtime-session))))
+          (or skills (magent-runtime-session-pending-skills runtime-session)))
+         (model-routing-configured-p
+          (magent-runtime-session-model-routing-configured-p
+           runtime-session effective-agent)))
     (magent-runtime-api--validate-skill-scope
      runtime-session effective-skills)
     (let* ((turn-id (magent-runtime-api--prepare-turn
@@ -645,6 +703,10 @@ request-local Magent-native events."
              :tool-names effective-tools
              :skills effective-skills
              :agent effective-agent
+             :model-route
+             (and model-routing-configured-p
+                  (magent-runtime-session-effective-model-route
+                   runtime-session effective-agent))
              :effort (or (magent-effort-normalize-option effort)
                          (magent-effort-normalize-option
                           (magent-runtime-session-effort runtime-session)))

--- a/lisp/magent-runtime-queue.el
+++ b/lisp/magent-runtime-queue.el
@@ -26,6 +26,7 @@
   tool-names
   skills
   agent
+  model-route
   effort
   observer
   approval-provider

--- a/lisp/magent-runtime.el
+++ b/lisp/magent-runtime.el
@@ -101,6 +101,8 @@ wins; when all functions return nil, scope is derived from
   parent-request-id
   (agent-depth 0)
   project-root
+  model-route
+  parent-model-route
   model
   backend
   temperature

--- a/lisp/magent-tools.el
+++ b/lisp/magent-tools.el
@@ -1764,10 +1764,9 @@ Return the child loop handle when startup succeeds."
            :project-root (and parent-context
                               (magent-request-context-project-root
                                parent-context))
-           :model (and parent-context
-                       (magent-request-context-model parent-context))
-           :backend (and parent-context
-                         (magent-request-context-backend parent-context))
+           :parent-model-route
+           (and parent-context
+                (magent-request-context-model-route parent-context))
            :temperature (and parent-context
                              (magent-request-context-temperature parent-context))
            :top-p (and parent-context

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -311,8 +311,8 @@
             "\"ext:flymake\" t t)")
         nil t)))))
 
-(ert-deftest magent-test-gptel-adapter-does-not-declare-private-state ()
-  "Test the gptel adapter does not hide private variable API changes."
+(ert-deftest magent-test-gptel-adapter-isolates-private-model-registry ()
+  "Only the documented cross-provider registry exception is declared."
   (let ((adapter-file
          (expand-file-name "lisp/magent-llm-gptel.el"
                            magent-test--root-directory))
@@ -327,7 +327,7 @@
                (when (string-prefix-p "gptel--" (symbol-name variable))
                  (push variable declarations)))))
         (end-of-file nil)))
-    (should-not declarations)))
+    (should (equal declarations '(gptel--known-backends)))))
 
 (ert-deftest magent-test-melpazoid-recipe-packages-production-libraries ()
   "Test the MELPA recipe includes all production libraries and runtime data."
@@ -1958,7 +1958,8 @@
 (ert-deftest magent-test-agent-run-turn-records-runtime-inheritance ()
   "Test request context records inherited runtime sampling settings."
   (require 'magent-agent)
-  (let* ((backend (gptel-make-openai "inherited" :key "key"))
+  (let* ((backend (gptel-make-openai
+                    "inherited" :key "key" :models '(parent-model)))
          (gptel-backend backend)
          (gptel-model 'parent-model)
          (gptel-temperature 0.42)
@@ -1976,8 +1977,11 @@
                          :id "req"
                          :scope "/tmp/project"
                          :session session
-                         :backend backend
-                         :model 'parent-model
+                         :model-route
+                         (magent-model-route-create
+                          :backend backend
+                          :model 'parent-model
+                          :source 'session)
                          :temperature 0.42))
          (capability-resolution
           (magent-capability-resolution-create
@@ -2013,6 +2017,8 @@
        request-state))
     (let* ((request (magent-agent-loop-request captured-loop))
            (metadata (magent-llm-request-metadata request)))
+      (should (eq (magent-llm-request-backend request) backend))
+      (should (eq (magent-llm-request-model request) 'parent-model))
       (should (eq (magent-request-context-model request-state) 'parent-model))
       (should (eq (magent-request-context-backend request-state) backend))
       (should (= (magent-request-context-temperature request-state) 0.42))
@@ -2034,7 +2040,8 @@
   "Inherited and capability skills share one normalized request-state value."
   (require 'magent-agent)
   (require 'magent-capability)
-  (let* ((backend (gptel-make-openai "skills" :key "key"))
+  (let* ((backend (gptel-make-openai
+                    "skills" :key "key" :models '(skills-model)))
          (gptel-backend backend)
          (gptel-model 'skills-model)
          (agent (magent-agent-info-create
@@ -2071,7 +2078,8 @@
 (ert-deftest magent-test-agent-run-turn-startup-error-respects-context-ownership ()
   "Startup errors close owned contexts and preserve inherited contexts."
   (require 'magent-agent)
-  (let* ((gptel-backend (gptel-make-openai "startup" :key "key"))
+  (let* ((gptel-backend (gptel-make-openai
+                          "startup" :key "key" :models '(startup-model)))
          (gptel-model 'startup-model)
          (agent-permission '((bash . allow) (* . deny)))
          (request-permission '((bash . deny) (* . allow)))
@@ -2136,7 +2144,8 @@
   "Test project-scoped runtime turns tell the model the current repo root."
   (require 'magent-agent)
   (require 'magent-capability)
-  (let* ((backend (gptel-make-openai "scope-root" :key "key"))
+  (let* ((backend (gptel-make-openai
+                    "scope-root" :key "key" :models '(scope-model)))
          (gptel-backend backend)
          (gptel-model 'scope-model)
          (magent-system-prompt "Global system.")
@@ -2859,7 +2868,9 @@
 (ert-deftest magent-test-agent-run-turn-keeps-streaming-for-tool-requests ()
   "Test tool-enabled requests still use streaming provider sampling."
   (require 'magent-agent)
-  (let* ((backend (gptel-make-openai "tools" :key "key"))
+  (let* ((backend (gptel-make-openai
+                    "tools" :key "key"
+                    :models '((tool-model :capabilities (tool-use)))))
          (gptel-backend backend)
          (gptel-model 'tool-model)
          (agent (magent-agent-info-create
@@ -2890,6 +2901,48 @@
     (let ((request (magent-agent-loop-request captured-loop)))
       (should (magent-llm-request-tools request))
       (should (magent-llm-request-stream request)))))
+
+(ert-deftest magent-test-agent-run-turn-rejects-known-tool-incapable-route ()
+  "A model explicitly lacking tool support fails before provider sampling."
+  (require 'magent-agent)
+  (let* ((gptel--known-backends nil)
+         (backend
+          (gptel-make-openai
+           "No Tools" :key "key"
+           :models '((magent-text-only-model :capabilities (json)))))
+         (gptel-backend backend)
+         (gptel-model 'magent-text-only-model)
+         (session (magent-session-create :id "no-tools"))
+         (request-state
+          (magent-request-context-create
+           :session session
+           :model-route
+           (magent-model-route-create
+            :backend backend :model 'magent-text-only-model
+            :source 'session)))
+         (agent
+          (magent-agent-info-create :name "build" :mode 'primary))
+         (tool
+          (gptel-make-tool
+           :name "read_file" :description "Read"
+           :args '((:name "path" :type string)) :function #'ignore))
+         sampled)
+    (cl-letf (((symbol-function 'magent-tools-get-gptel-tools-for-permission)
+               (lambda (&rest _args) (list tool)))
+              ((symbol-function 'magent-agent-loop-start)
+               (lambda (_loop) (setq sampled t)))
+              ((symbol-function 'magent-session-save-deferred-for-session)
+               #'ignore)
+              ((symbol-function 'magent-log) #'ignore)
+              ((symbol-function 'magent-lifecycle-events-emit) #'ignore)
+              ((symbol-function 'magent-lifecycle-events-begin-turn)
+               (lambda (_title) 'turn))
+              ((symbol-function 'magent-lifecycle-events-end-turn) #'ignore))
+      (should-error
+       (magent-test--run-turn
+        "read" nil agent nil nil nil nil nil nil request-state)
+       :type 'error))
+    (should-not sampled)))
 
 (ert-deftest magent-test-llm-gptel-applies-temperature-metadata ()
   "Test the gptel adapter applies request temperature metadata."
@@ -6236,7 +6289,14 @@
 (ert-deftest magent-test-tools-spawn-agent-creates-durable-job ()
   "Test spawn_agent records a child job and uses summary-only UI."
   (require 'magent-tools)
-  (let* ((parent-session (magent-session-create :id "parent"))
+  (let* ((gptel--known-backends nil)
+         (parent-backend
+          (gptel-make-openai
+           "parent" :key "key" :models '(parent-model)))
+         (parent-route
+          (magent-model-route-create
+           :backend parent-backend :model 'parent-model :source 'session))
+         (parent-session (magent-session-create :id "parent"))
          (parent-context (magent-request-context-create
                           :id "req-parent"
                           :scope "/tmp/project-parent"
@@ -6246,6 +6306,7 @@
                           :origin-context 'origin
                           :agent-depth 0
                           :project-root "/tmp/project-parent"
+                          :model-route parent-route
                           :model 'parent-model
                           :temperature 0.2
                           :top-p 0.9
@@ -6290,7 +6351,19 @@
                    (setq stopped context)))
                 ((symbol-function 'magent-agent-run-turn)
                  (lambda (&rest args)
-                   (let ((request-state (plist-get args :request-context)))
+                   (let* ((request-state (plist-get args :request-context))
+                          (route
+                           (magent-agent-resolve-model-route
+                            (plist-get args :agent)
+                            :parent-route
+                            (magent-request-context-parent-model-route
+                             request-state))))
+                   (setf (magent-request-context-model-route request-state)
+                         route
+                         (magent-request-context-model request-state)
+                         (magent-model-route-model route)
+                         (magent-request-context-backend request-state)
+                         (magent-model-route-backend route))
                    (setq captured
                          (list :prompt (plist-get args :prompt)
                                :agent (plist-get args :agent)
@@ -6349,6 +6422,8 @@
       (should (equal (magent-request-context-project-root child-state) "/tmp/project-parent"))
       (should (= (magent-request-context-agent-depth child-state) 1))
       (should (eq (magent-request-context-model child-state) 'parent-model))
+      (should (eq (magent-request-context-parent-model-route child-state)
+                  parent-route))
       (should (= (magent-request-context-temperature child-state) 0.2))
       (should (= (magent-request-context-top-p child-state) 0.9))
       (should (eq (magent-request-context-effort child-state) 'xhigh))
@@ -11942,12 +12017,124 @@
 (ert-deftest magent-test-acp-models-use-model-id ()
   "Test ACP available model entries expose modelId for agent-shell."
   (require 'magent-acp)
-  (let* ((gptel-model 'test-model)
+  (let* ((gptel--known-backends nil)
+         (gptel-backend
+          (gptel-make-openai "Test" :key "key" :models '(test-model)))
+         (gptel-model 'test-model)
          (models (magent-acp--models))
          (available (map-elt models 'availableModels))
          (entry (aref available 0)))
-    (should (equal (map-elt entry 'modelId) "test-model"))
+    (should (equal (map-elt entry 'modelId)
+                   "gptel/Test/test-model"))
+    (should (equal (map-elt entry 'name) "Test:test-model"))
     (should-not (assq 'id entry))))
+
+(ert-deftest magent-test-acp-models-tolerate-unselected-registered-backends ()
+  "ACP initialization remains usable before gptel defaults are selected."
+  (require 'magent-acp)
+  (let* ((gptel--known-backends nil)
+         (_backend
+          (gptel-make-openai "Configured" :key "key" :models '(model-a)))
+         (gptel-backend nil)
+         (gptel-model nil)
+         (models (magent-acp--models)))
+    (should (equal (map-elt models 'currentModelId) "unconfigured"))
+    (should (= (length (map-elt models 'availableModels)) 1))))
+
+(ert-deftest magent-test-gptel-model-catalog-distinguishes-providers ()
+  "Identical provider model names receive distinct opaque ACP ids."
+  (require 'magent-llm-gptel)
+  (let* ((gptel--known-backends nil)
+         (_first
+          (gptel-make-openai "First Provider" :key "key"
+                             :models '(shared-model)))
+         (_second
+          (gptel-make-openai "Second/Provider" :key "key"
+                             :models '(shared-model)))
+         (catalog (magent-llm-gptel-model-catalog))
+         (ids (mapcar #'magent-model-descriptor-id catalog))
+         (names (mapcar #'magent-model-descriptor-name catalog)))
+    (should (= (length catalog) 2))
+    (should (= (length (delete-dups (copy-sequence ids))) 2))
+    (should (equal (sort names #'string<)
+                   '("First Provider:shared-model"
+                     "Second/Provider:shared-model")))
+    (should (member "gptel/Second%2FProvider/shared-model" ids))))
+
+(ert-deftest magent-test-model-route-resolver-preserves-priority-and-phase-seam ()
+  "Session, agent, parent, and gptel routes resolve in documented order."
+  (require 'magent-agent)
+  (let* ((gptel--known-backends nil)
+         (backend-a
+          (gptel-make-openai
+           "A" :key "key" :models '(default-a agent-a)))
+         (backend-b
+          (gptel-make-openai
+           "B" :key "key" :models '(session-b parent-b)))
+         (gptel-backend backend-a)
+         (gptel-model 'default-a)
+         (explicit
+          (magent-model-route-create
+           :backend backend-b :model 'session-b :source 'session))
+         (parent
+          (magent-model-route-create
+           :backend backend-b :model 'parent-b :source 'request))
+         (profile-agent
+          (magent-agent-info-create
+           :name "explore" :mode 'subagent
+           :model (cons backend-a 'agent-a)))
+         (plain-agent
+          (magent-agent-info-create :name "plain" :mode 'subagent))
+         (primary
+          (magent-agent-resolve-model-route
+           profile-agent :explicit-route explicit :phase 'execute))
+         (profile-child
+          (magent-agent-resolve-model-route
+           profile-agent :parent-route parent :phase 'explore))
+         (inherited-child
+          (magent-agent-resolve-model-route plain-agent :parent-route parent))
+         (automatic
+          (magent-agent-resolve-model-route plain-agent)))
+    (should (eq (magent-model-route-backend primary) backend-b))
+    (should (eq (magent-model-route-model primary) 'session-b))
+    (should (eq (magent-model-route-source primary) 'session))
+    (should (eq (magent-model-route-phase primary) 'execute))
+    (should (eq (magent-model-route-model profile-child) 'agent-a))
+    (should (eq (magent-model-route-source profile-child) 'agent))
+    (should (eq (magent-model-route-phase profile-child) 'explore))
+    (should (eq (magent-model-route-model inherited-child) 'parent-b))
+    (should (eq (magent-model-route-source inherited-child) 'parent))
+    (should (eq (magent-model-route-model automatic) 'default-a))
+    (should (eq (magent-model-route-source automatic) 'gptel))))
+
+(ert-deftest magent-test-gptel-model-route-capabilities-and-removal-fail-loud ()
+  "Known tool limits and removed registered routes are enforced."
+  (require 'magent-llm-gptel)
+  (let* ((gptel--known-backends nil)
+         (backend
+          (gptel-make-openai
+           "Capabilities" :key "key"
+           :models '((magent-tool-model :capabilities (tool-use json))
+                     (magent-no-tool-model :capabilities (json))
+                     magent-unknown-tool-model)))
+         (supported
+          (magent-model-route-create
+           :backend backend :model 'magent-tool-model))
+         (unsupported
+          (magent-model-route-create
+           :backend backend :model 'magent-no-tool-model))
+         (unknown
+          (magent-model-route-create
+           :backend backend :model 'magent-unknown-tool-model)))
+    (should (eq (magent-llm-gptel-route-tool-capability supported)
+                'supported))
+    (should (eq (magent-llm-gptel-route-tool-capability unsupported)
+                'unsupported))
+    (should (eq (magent-llm-gptel-route-tool-capability unknown)
+                'unknown))
+    (setq gptel--known-backends nil)
+    (should-error (magent-llm-gptel-validate-route supported)
+                  :type 'error)))
 
 (ert-deftest magent-test-acp-session-response-advertises-effort-config ()
   "Test ACP session responses advertise thought level options."
@@ -12893,12 +13080,26 @@
         :option-id "allow_once")))
     (should (equal captured '("req-1" allow-once)))))
 
-(ert-deftest magent-test-acp-set-model-accepts-current-gptel-model ()
-  "Test ACP session/set_model works for agent-shell bootstrap."
+(ert-deftest magent-test-acp-set-model-switches-provider-without-global-mutation ()
+  "ACP model selection stores a cross-provider session route only."
   (require 'magent-acp)
-  (let* ((gptel-model 'test-model)
+  (let* ((gptel--known-backends nil)
+         (backend-a
+          (gptel-make-openai "Provider A" :key "key" :models '(model-a)))
+         (backend-b
+          (gptel-make-openai "Provider B" :key "key" :models '(model-b)))
+         (gptel-backend backend-a)
+         (gptel-model 'model-a)
          (magent-default-agent "build")
-         (runtime-session (magent-runtime-session-create :id "session-1"))
+         (agent (magent-agent-info-create
+                 :name "build" :mode 'primary :description "Build"))
+         (runtime-session
+          (magent-runtime-session-create
+           :id "session-1"
+           :magent-session (magent-session-create :agent agent)))
+         (descriptor-b
+          (cl-find backend-b (magent-llm-gptel-model-catalog)
+                   :key #'magent-model-descriptor-backend))
          response)
     (cl-letf (((symbol-function 'magent-acp--runtime-session-by-id)
                (lambda (session-id _scope)
@@ -12907,17 +13108,63 @@
               ((symbol-function 'magent-runtime-session-agent-name)
                (lambda (_session) "build"))
               ((symbol-function 'magent-agent-registry-primary-agents)
-               (lambda ()
-                 (list (magent-agent-info-create
-                        :name "build"
-                        :description "Build")))))
+               (lambda () (list agent))))
       (setq response
             (magent-acp--handle-set-model
              '((sessionId . "session-1")
-               (modelId . "test-model"))))
+               (modelId . "gptel/Provider%20B/model-b"))))
       (should (equal (map-nested-elt response '(models currentModelId))
-                     "test-model"))
-      (should (equal (map-elt response 'sessionId) "session-1")))))
+                     (magent-model-descriptor-id descriptor-b)))
+      (should (eq (magent-model-route-backend
+                   (magent-runtime-session-model-route-option runtime-session))
+                  backend-b))
+      (should (eq (magent-model-route-model
+                   (magent-runtime-session-model-route-option runtime-session))
+                  'model-b))
+      (should (eq gptel-backend backend-a))
+      (should (eq gptel-model 'model-a)))))
+
+(ert-deftest magent-test-acp-model-auto-clears-route-and-shows-effective-model ()
+  "The model config Auto value clears only the session override."
+  (require 'magent-acp)
+  (let* ((gptel--known-backends nil)
+         (backend-a
+          (gptel-make-openai "Provider A" :key "key" :models '(model-a)))
+         (backend-b
+          (gptel-make-openai "Provider B" :key "key" :models '(model-b)))
+         (gptel-backend backend-a)
+         (gptel-model 'model-a)
+         (agent (magent-agent-info-create :name "build" :mode 'primary))
+         (runtime-session
+          (magent-runtime-session-create
+           :id "session-auto"
+           :magent-session (magent-session-create :agent agent)))
+         (route-b
+          (magent-model-route-create :backend backend-b :model 'model-b))
+         response)
+    (magent-runtime-session-set-model-route runtime-session route-b)
+    (cl-letf (((symbol-function 'magent-acp--runtime-session-by-id)
+               (lambda (_id _scope) runtime-session))
+              ((symbol-function 'magent-agent-registry-primary-agents)
+               (lambda () (list agent))))
+      (setq response
+            (magent-acp--handle-set-config-option
+             '((sessionId . "session-auto")
+               (configId . "model")
+               (value . "auto")))))
+    (should-not
+     (magent-runtime-session-model-route-option runtime-session))
+    (should (equal (map-nested-elt response '(models currentModelId))
+                   "gptel/Provider%20A/model-a"))
+    (let* ((options (append (map-elt response 'configOptions) nil))
+           (model-option
+            (cl-find "model" options :key (lambda (option)
+                                             (map-elt option 'id))
+                     :test #'equal))
+           (auto-entry (aref (map-elt model-option 'options) 0)))
+      (should (equal (map-elt model-option 'currentValue) "auto"))
+      (should (equal (map-elt auto-entry 'name)
+                     "Auto → Provider A:model-a")))))
 
 (ert-deftest magent-test-acp-set-config-option-updates-effort ()
   "Test ACP session/set_config_option updates Magent effort."
@@ -12979,6 +13226,7 @@
                             (current-buffer)))))
     (should (eq identifier 'magent))
     (should (eq (map-elt config :identifier) 'magent))
+    (should-not (map-elt config :default-model-id))
     (should (eq (car agent-shell-agent-configs)
                 #'magent-agent-shell-make-config))
     (should (eq (cadr agent-shell-agent-configs) other-maker))
@@ -13524,6 +13772,50 @@
     (should (equal (magent-thread-scope
                     (magent-session-thread-ledger session))
                    "/tmp/project"))))
+
+(ert-deftest magent-test-runtime-submit-freezes-cross-provider-route ()
+  "Queued submissions retain the effective route from submission time."
+  (require 'magent-runtime-api)
+  (let* ((gptel--known-backends nil)
+         (backend-a
+          (gptel-make-openai "Freeze A" :key "key" :models '(model-a)))
+         (backend-b
+          (gptel-make-openai "Freeze B" :key "key" :models '(model-b)))
+         (gptel-backend backend-a)
+         (gptel-model 'model-a)
+         (magent-runtime-queue--active nil)
+         (magent-runtime-queue--pending nil)
+         (magent-runtime-queue--arbiter-active nil)
+         (magent-runtime-queue--arbiter-pending nil)
+         (magent-runtime-queue--arbiter-ticket-adapters
+          (make-hash-table :test #'eq))
+         (agent (magent-agent-info-create :name "build" :mode 'primary))
+         (runtime-session
+          (magent-runtime-session-create
+           :id "freeze-session" :scope 'global
+           :magent-session (magent-session-create :agent agent)))
+         (blocker (magent-runtime-submission-create :id "blocker")))
+    (magent-runtime-queue-submit blocker #'ignore)
+    (cl-letf (((symbol-function 'magent-session-save-deferred-for-session)
+               #'ignore))
+      (magent-runtime-session-set-model-route
+       runtime-session
+       (magent-model-route-create :backend backend-a :model 'model-a))
+      (magent-runtime-submit runtime-session "first")
+      (magent-runtime-session-set-model-route
+       runtime-session
+       (magent-model-route-create :backend backend-b :model 'model-b))
+      (magent-runtime-submit runtime-session "second"))
+    (let* ((queued magent-runtime-queue--pending)
+           (first-route
+            (magent-runtime-submission-model-route (nth 0 queued)))
+           (second-route
+            (magent-runtime-submission-model-route (nth 1 queued))))
+      (should (= (length queued) 2))
+      (should (eq (magent-model-route-backend first-route) backend-a))
+      (should (eq (magent-model-route-model first-route) 'model-a))
+      (should (eq (magent-model-route-backend second-route) backend-b))
+      (should (eq (magent-model-route-model second-route) 'model-b)))))
 
 (ert-deftest magent-test-runtime-submit-carries-exact-tool-names ()
   "Explicit runtime tool names reach the request context unchanged."
@@ -16458,6 +16750,9 @@
          (magent-tool-result-model-preview-length 20)
          (payload (make-string 200 ?f))
          (agent (magent-agent-info-create :name "build" :mode 'primary))
+         (model-route
+          (magent-model-route-create
+           :backend 'test-backend :model 'test-model :source 'session))
          (source
           (magent-session-create :id "fork-source" :agent agent
                                  :approval-overrides '((bash . allow))
@@ -16465,6 +16760,7 @@
          (source-runtime
           (magent-runtime-session-create
            :id "fork-source" :scope 'global :magent-session source
+           :model-route model-route
            :effort 'xhigh :pending-skills '(one-shot)
            :metadata '(:capabilities-enabled nil))))
     (unwind-protect
@@ -16490,6 +16786,8 @@
                    (magent-session--scope-storage-directory 'global))))
             (should (eq (magent-session-get-if-present 'global) source))
             (should (eq (magent-runtime-session-effort fork-runtime) 'xhigh))
+            (should (eq (magent-runtime-session-model-route fork-runtime)
+                        model-route))
             (should-not
              (magent-runtime-session-capabilities-enabled-p fork-runtime))
             (should-not (magent-runtime-session-pending-skills fork-runtime))
@@ -16643,9 +16941,9 @@
   "Runtime structs expose the current request and submission contract."
   (require 'magent-agent-loop)
   (should (= (length (magent-lifecycle-events-context-create)) 6))
-  (should (= (length (magent-request-context-create)) 29))
+  (should (= (length (magent-request-context-create)) 31))
   (should (= (length (magent-agent-loop-create)) 23))
-  (should (= (length (magent-runtime-submission-create)) 23)))
+  (should (= (length (magent-runtime-submission-create)) 24)))
 
 (provide 'magent-test)
 ;;; magent-test.el ends here


### PR DESCRIPTION
## Summary

- expose every gptel-registered provider and model through the ACP native model configuration
- keep model routes session-local, snapshot them per submission, and let Auto restore agent or gptel resolution
- preserve child-agent override and inheritance semantics while leaving a profile and phase routing seam
- preflight known tool incompatibilities and report removed explicit routes clearly
- document the behavior and add coverage for ACP, queueing, forks, inheritance, and cross-provider switching

## Testing

- make -B EMACS=/Users/jamie/opt/emacs-src/src/emacs compile
- make EMACS=/Users/jamie/opt/emacs-src/src/emacs lint
- main ERT suite: 614 tests passed
- isolated Emacs daemon live smoke: 3 tests passed
- isolated live cross-provider catalog, switch, Auto, and global-state assertions passed
- git diff --check