### PR TITLE
fix(doctor): preserve active routing and show live progress

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -49,6 +49,12 @@ intentional tagged release is planned as ~v0.2.0~.
 
 ** Fixed
 
+- Show a live ~*Magent Doctor*~ progress buffer for
+  ~M-x magent-action-run-doctor~, retaining the terminal diagnosis or failure
+  instead of leaving interactive Doctor runs silent until completion.
+- Make ~/doctor~ analyze through the originating session's effective model
+  route and the same streaming gptel path as ordinary Magent turns, avoiding
+  empty diagnoses caused by an unrelated global route or non-stream response.
 - Accept both ~tool~ and ~tool-use~ capability markers from gptel model
   metadata, preventing tool-capable providers such as DeepSeek from being
   rejected before sampling.

--- a/docs/DOCTOR.org
+++ b/docs/DOCTOR.org
@@ -10,6 +10,11 @@ and current-project state without giving an LLM general Emacs or shell access.
 Both entry points execute the same Action and create an isolated Action session
 under ~magent-session-directory/actions/doctor~.
 
+The M-x entry point immediately displays a ~*Magent Doctor*~ buffer.  It keeps
+the local probe and provider-analysis progress visible, then retains the final
+diagnosis or failure in that buffer instead of running silently in the
+background.
+
 Use ~/doctor select~ or a prefix argument with the M-x command to review the
 applicable probe selection. Core runtime diagnostics are always included.
 
@@ -23,6 +28,9 @@ Doctor uses two phases:
 The provider request has no tools and does not enter the normal Magent agent
 loop or runtime queue.  It may run concurrently with an ordinary conversation,
 but it does not install its Action session as the user's current session.
+~/doctor~ follows the originating runtime session's effective model route;
+the M-x entry point falls back to the current gptel defaults.  Sampling uses
+gptel's streaming path while Doctor exposes only the completed diagnosis.
 
 Doctor never intentionally collects a gptel backend object, API keys,
 ~auth-source~, environment variables, HTTP headers, or raw ~*gptel-log*~

--- a/docs/DOCTOR.zh.org
+++ b/docs/DOCTOR.zh.org
@@ -9,6 +9,9 @@
 和当前项目状态，但不会把通用 Emacs 或 shell 工具交给 LLM。两个入口执行同一个
 Action，并在 ~magent-session-directory/actions/doctor~ 下创建独立 Action session。
 
+M-x 入口启动后会立即显示 ~*Magent Doctor*~ buffer，持续展示本地 probe 和
+provider 分析进度，并在同一个 buffer 中保留最终诊断或失败信息，不再静默后台运行。
+
 使用 ~/doctor select~ 或给 M-x 命令传递 prefix argument，可以在 minibuffer 中
 审查适用的 probes；
 core runtime probe 始终保留。
@@ -22,7 +25,9 @@ Doctor 分为两个阶段：
 
 Provider request 不包含工具，也不进入普通 Magent agent loop 或 runtime
 queue。它可以和普通对话并发，但不会把 Action session 安装成用户当前
-session。
+session。~/doctor~ 使用发起请求的 runtime session 的有效 model route；M-x
+入口回退到当前 gptel defaults。Sampling 使用 gptel streaming 路径，但 Doctor
+只公开完成后的诊断结果。
 
 Doctor 不会主动采集 gptel backend 对象、API key、~auth-source~、环境变量、
 HTTP headers 或原始 ~*gptel-log*~。绝对路径会被规范化为 ~$PROJECT~、

--- a/lisp/magent-action-builtin-doctor.el
+++ b/lisp/magent-action-builtin-doctor.el
@@ -40,6 +40,8 @@
 (declare-function magent-agent-info-name "magent-agent-info" t t)
 (declare-function magent-approval-pending-count "magent-approval")
 (declare-function magent-runtime-pending-count "magent-runtime-api")
+(declare-function magent-runtime-session-effective-model-route
+                  "magent-runtime-api" t t)
 (declare-function magent-runtime-queue-active-submission
                   "magent-runtime-queue")
 (declare-function magent-runtime-submission-id
@@ -88,6 +90,90 @@
   '("* Diagnosis" "** Summary" "** Findings"
     "** Recommended Actions" "** Limitations")
   "Required headings in a structured doctor response.")
+
+(defvar-local magent-doctor--interactive-status "Starting"
+  "Status shown in the current interactive Doctor buffer.")
+
+(defvar-local magent-doctor--interactive-progress nil
+  "Progress messages shown in the current interactive Doctor buffer.")
+
+(defvar-local magent-doctor--interactive-result ""
+  "Result text shown in the current interactive Doctor buffer.")
+
+(defvar-local magent-doctor--interactive-session-id nil
+  "Isolated Action session id shown in the current Doctor buffer.")
+
+(defun magent-doctor--interactive-render (buffer)
+  "Render the current interactive Doctor state in BUFFER."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert "Magent Doctor\n\n")
+        (insert (format "Status: %s\n" magent-doctor--interactive-status))
+        (when magent-doctor--interactive-session-id
+          (insert (format "Session: %s\n"
+                          magent-doctor--interactive-session-id)))
+        (insert "\nThis diagnostic runs in an isolated Action session.\n")
+        (if magent-doctor--interactive-progress
+            (progn
+              (insert "\nProgress\n")
+              (dolist (message (reverse magent-doctor--interactive-progress))
+                (insert "- " message "\n")))
+          (insert "\nStarting local diagnostic collection...\n"))
+        (unless (string-empty-p magent-doctor--interactive-result)
+          (insert "\nResult\n\n" magent-doctor--interactive-result)
+          (unless (string-suffix-p "\n" magent-doctor--interactive-result)
+            (insert "\n")))
+        (insert "\nUse M-x magent-action-cancel to cancel an active run.\n")
+        (goto-char (point-min))))))
+
+(defun magent-doctor--interactive-buffer ()
+  "Create, initialize, and display a buffer for an interactive Doctor run."
+  (let ((buffer (generate-new-buffer "*Magent Doctor*")))
+    (with-current-buffer buffer
+      (special-mode)
+      (setq-local magent-doctor--interactive-status "Starting"
+                  magent-doctor--interactive-progress nil
+                  magent-doctor--interactive-result ""
+                  magent-doctor--interactive-session-id nil)
+      (magent-doctor--interactive-render buffer))
+    (display-buffer buffer)
+    buffer))
+
+(defun magent-doctor--interactive-status-label (status)
+  "Return a display label for terminal Doctor STATUS."
+  (pcase status
+    ('completed "Completed")
+    ('cancelled "Cancelled")
+    ('failed "Failed")
+    (_ (capitalize (format "%s" status)))))
+
+(defun magent-doctor--interactive-observe (buffer event)
+  "Project Doctor EVENT into the interactive Doctor BUFFER."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (pcase (plist-get event :type)
+        ('action-progress
+         (setq magent-doctor--interactive-status "Running")
+         (when-let* ((text (plist-get event :text)))
+           (unless (member text magent-doctor--interactive-progress)
+             (push text magent-doctor--interactive-progress))))
+        ('assistant-delta
+         (setq magent-doctor--interactive-status "Finishing")
+         (when-let* ((text (plist-get event :text)))
+           (setq magent-doctor--interactive-result
+                 (concat magent-doctor--interactive-result text))))
+        ('action-completed
+         (setq magent-doctor--interactive-status
+               (magent-doctor--interactive-status-label
+                (plist-get event :status)))
+         (when (string-empty-p magent-doctor--interactive-result)
+           (when-let* ((result (plist-get event :result)))
+             (setq magent-doctor--interactive-result
+                   (or (magent-execution-result-content-string result) "")))))
+        (_ nil))
+      (magent-doctor--interactive-render buffer))))
 
 (defun magent-doctor--normalize-id (id)
   "Return ID as a stable probe registry key."
@@ -791,9 +877,22 @@ output data."
            state 'failed
            "Doctor analysis failed with a redacted error"))))))))
 
+(defun magent-doctor--analysis-route (context)
+  "Return the effective model route for Doctor CONTEXT.
+Slash invocations retain their originating runtime session as the Action's
+control session even though Doctor itself runs in an isolated session.  Use
+that route so Doctor follows the user's active model selection.  Interactive
+invocations without a control session use the current gptel defaults."
+  (if-let* ((runtime-session
+             (magent-action-invocation-control-session context)))
+      (magent-runtime-session-effective-model-route
+       runtime-session nil 'doctor)
+    (magent-sampling-gptel-default-route)))
+
 (defun magent-doctor--start-analysis (context state results)
   "Start one tool-free provider analysis for CONTEXT over RESULTS."
   (let* ((bundle (magent-doctor--bounded-bundle results))
+         (route (magent-doctor--analysis-route context))
          (prompt (concat (magent-prompt-read "internal/doctor-user.org")
                          "\n\n"
                          (magent-json-encode bundle)))
@@ -802,9 +901,9 @@ output data."
            :prompt prompt
            :system (magent-prompt-read "internal/doctor-system.org")
            :tools nil
-           :stream nil
-           :backend (and (boundp 'gptel-backend) gptel-backend)
-           :model (and (boundp 'gptel-model) gptel-model)
+           :stream t
+           :backend (magent-model-route-backend route)
+           :model (magent-model-route-model route)
            :metadata (list :temperature
                            (and (boundp 'gptel-temperature)
                                 gptel-temperature)
@@ -926,11 +1025,33 @@ output data."
   "Run Magent Doctor in an isolated Action session.
 With prefix argument SELECT-PROBES, review probe selection in the minibuffer."
   (interactive "P")
-  (let ((debug-on-error nil)
+  (let ((buffer (magent-doctor--interactive-buffer))
+        (debug-on-error nil)
         (debug-on-quit nil)
         (debug-on-signal nil))
-    (magent-action-run
-     "doctor" :options (list :select-probes (and select-probes t)))))
+    (condition-case err
+        (let ((invocation
+               (magent-action-run
+                "doctor"
+                :options (list :select-probes (and select-probes t))
+                :observer
+                (lambda (event)
+                  (magent-doctor--interactive-observe buffer event)))))
+          (when-let* (((magent-action-invocation-p invocation))
+                      (session (magent-action-invocation-session invocation)))
+            (with-current-buffer buffer
+              (setq magent-doctor--interactive-session-id
+                    (magent-session-get-id session))
+              (magent-doctor--interactive-render buffer)))
+          invocation)
+      (error
+       (magent-doctor--interactive-observe
+        buffer
+        (list :type 'action-completed
+              :status 'failed
+              :result (magent-execution-result-failed
+                       (error-message-string err))))
+       (signal (car err) (cdr err))))))
 
 (magent-doctor--register-builtins)
 

--- a/lisp/magent-action.el
+++ b/lisp/magent-action.el
@@ -1644,8 +1644,9 @@ SOURCE-START is the absolute position corresponding to the start of TEXT."
       :submission-adapter submission-adapter))))
 
 (cl-defun magent-action-run
-    (action &key argument options on-complete)
-  "Run interactive-exposed ACTION from the current Emacs context."
+    (action &key argument options observer on-complete)
+  "Run interactive-exposed ACTION from the current Emacs context.
+OBSERVER receives Action lifecycle events when non-nil."
   (magent-runtime-ensure-initialized)
   (let* ((origin-buffer (current-buffer))
          (origin-directory default-directory)
@@ -1667,6 +1668,7 @@ SOURCE-START is the absolute position corresponding to the start of TEXT."
       :parent-session parent-session
       :argument argument
       :options options
+      :observer observer
       :on-complete on-complete
       :interactive-p t))))
 

--- a/lisp/magent-runtime.el
+++ b/lisp/magent-runtime.el
@@ -51,39 +51,39 @@ wins; when all functions return nil, scope is derived from
 
 (defconst magent-runtime--overlay-specs
   '((:name agents
-     :state-variable magent-agent-registry--agents
-     :static-feature magent-agent-registry
-     :static magent-agent-initialize-static
-     :load-project-feature magent-agent-file
-     :load-project magent-agent-file-load-project-scope
-     :unload-project-feature magent-agent-registry
-     :unload-project magent-agent-registry-remove-project-scope
-     :project-enabled magent-load-custom-agents)
+           :state-variable magent-agent-registry--agents
+           :static-feature magent-agent-registry
+           :static magent-agent-initialize-static
+           :load-project-feature magent-agent-file
+           :load-project magent-agent-file-load-project-scope
+           :unload-project-feature magent-agent-registry
+           :unload-project magent-agent-registry-remove-project-scope
+           :project-enabled magent-load-custom-agents)
     (:name skills
-     :state-variables (magent-skills--registry
-                       magent-skills--scope-catalog)
-     :static-feature magent-skills
-     :static magent-skills-initialize-static
-     :load-project-feature magent-skills
-     :load-project magent-skills-load-project-scope
-     :unload-project-feature magent-skills
-     :unload-project magent-skills-remove-project-scope)
+           :state-variables (magent-skills--registry
+                             magent-skills--scope-catalog)
+           :static-feature magent-skills
+           :static magent-skills-initialize-static
+           :load-project-feature magent-skills
+           :load-project magent-skills-load-project-scope
+           :unload-project-feature magent-skills
+           :unload-project magent-skills-remove-project-scope)
     (:name actions
-     :state-variable magent-action--registry
-     :static-feature magent-action
-     :static magent-action-initialize-static
-     :load-project-feature magent-action
-     :load-project magent-action-load-project-scope
-     :unload-project-feature magent-action
-     :unload-project magent-action-remove-project-scope)
+           :state-variable magent-action--registry
+           :static-feature magent-action
+           :static magent-action-initialize-static
+           :load-project-feature magent-action
+           :load-project magent-action-load-project-scope
+           :unload-project-feature magent-action
+           :unload-project magent-action-remove-project-scope)
     (:name capabilities
-     :state-variable magent-capability--registry
-     :static-feature magent-capability
-     :static magent-capability-initialize-static
-     :load-project-feature magent-capability
-     :load-project magent-capability-load-project-scope
-     :unload-project-feature magent-capability
-     :unload-project magent-capability-remove-project-scope))
+           :state-variable magent-capability--registry
+           :static-feature magent-capability
+           :static magent-capability-initialize-static
+           :load-project-feature magent-capability
+           :load-project magent-capability-load-project-scope
+           :unload-project-feature magent-capability
+           :unload-project magent-capability-remove-project-scope))
   "Ordered overlay pipeline for Magent runtime definitions.")
 
 (cl-defstruct (magent-request-context
@@ -137,7 +137,7 @@ wins; when all functions return nil, scope is derived from
 (defun magent-request-context-session-id (context)
   "Return CONTEXT's session id, if available."
   (when-let* ((session (and context
-                           (magent-request-context-session context))))
+                            (magent-request-context-session context))))
     (magent-session-get-id session)))
 
 (defun magent-request-context-audit-snapshot (context)
@@ -203,7 +203,7 @@ objects, and other live runtime state so lifecycle sinks and completed
 The observer receives a Magent-native plist event.  Observer errors are
 isolated so UI/backend rendering cannot break the active agent turn."
   (when-let* ((observer (and context
-                            (magent-request-context-observer context))))
+                             (magent-request-context-observer context))))
     (setf (magent-request-context-observer-seq context)
           (1+ (or (magent-request-context-observer-seq context) 0)))
     (let ((event (append
@@ -365,7 +365,7 @@ When FORCE is non-nil, reload the overlay even if SCOPE is unchanged."
            (setq magent-runtime--active-project-scope previous-scope)
            (signal (car err) (cdr err)))))))
   (when-let* ((session (and (not (eq scope 'global))
-                           (magent-session-get-if-present scope))))
+                            (magent-session-get-if-present scope))))
     (magent-session-refresh-agent session))
   (when (eq scope 'global)
     (when-let* ((session (magent-session-get-if-present 'global)))

--- a/lisp/magent-skills.el
+++ b/lisp/magent-skills.el
@@ -224,38 +224,14 @@ their overlays are inactive so live frontend sessions remain scope-correct.")
                      (magent-skill-name right))))))
 
 (defun magent-skills--rebase-project-catalogs ()
-  "Rebase cached project catalogs on the current global snapshot."
-  (let ((global-skills
-         (copy-sequence
-          (gethash nil magent-skills--scope-catalog))))
-    (maphash
-     (lambda (scope skills)
-       (when scope
-         (let* ((project-skills
-                 (cl-remove-if-not
-                  (lambda (skill)
-                    (equal
-                     scope
-                     (magent-session-canonical-scope
-                      (magent-skill-source-scope skill))))
-                  skills))
-                (project-names
-                 (mapcar #'magent-skill-name project-skills))
-                (rebased
-                 (append
-                  project-skills
-                  (cl-remove-if
-                   (lambda (skill)
-                     (member (magent-skill-name skill) project-names))
-                   global-skills))))
-           (puthash
-            scope
-            (sort rebased
-                  (lambda (left right)
-                    (string< (magent-skill-name left)
-                             (magent-skill-name right))))
-            magent-skills--scope-catalog))))
-     magent-skills--scope-catalog)))
+  "Rebase cached project catalogs on the current registry state."
+  (maphash
+   (lambda (scope _skills)
+     (when scope
+       (puthash scope
+                (magent-skills--registry-skills-for-scope scope)
+                magent-skills--scope-catalog)))
+   magent-skills--scope-catalog))
 
 (defun magent-skills--record-scope-catalog (&optional scope)
   "Record effective skills for SCOPE from the active registry."
@@ -465,8 +441,8 @@ names collide.  The final entry is the canonical installation target."
 
 (defconst magent-skills--frontmatter-keys
   '(:name :description :type :tools :requires-project
-    :capability :title :family :source :source-name :capability-skills
-    :modes :features :files :prompt-keywords :disclosure :risk)
+          :capability :title :family :source :source-name :capability-skills
+          :modes :features :files :prompt-keywords :disclosure :risk)
   "Supported SKILL.md frontmatter keys.")
 
 (defun magent-skills--validate-frontmatter (frontmatter)

--- a/test/magent-live-test.el
+++ b/test/magent-live-test.el
@@ -719,6 +719,55 @@ return that path."
        (when (file-directory-p magent-session-directory)
          (delete-directory magent-session-directory t)))))
 
+(ert-deftest magent-live-test-doctor-mx-shows-live-progress-buffer ()
+  "Run the Doctor M-x path with visible progress and a retained result."
+  :tags '(:magent-live-smoke)
+  (require 'magent)
+  (magent-live-test--with-isolated-runtime
+    (let ((diagnosis (concat "* Diagnosis\n** Summary\nHealthy\n"
+                             "** Findings\n- None\n"
+                             "** Recommended Actions\n- None\n"
+                             "** Limitations\n- Stub transport"))
+          (magent-bypass-permission t)
+          buffer)
+      (unwind-protect
+          (progn
+            (when-let* ((stale (get-buffer "*Magent Doctor*")))
+              (kill-buffer stale))
+            (cl-letf (((symbol-function 'magent-sampling-gptel-sample)
+                       (lambda (request)
+                         (run-at-time
+                          0.05 nil
+                          (lambda ()
+                            (funcall
+                             (magent-sampling-request-callback request)
+                             (magent-sampling-event-create
+                              'completed :text diagnosis))))
+                         nil)))
+              (should (commandp 'magent-action-run-doctor))
+              (magent-action-run-doctor)
+              (setq buffer (get-buffer "*Magent Doctor*"))
+              (should (buffer-live-p buffer))
+              (with-current-buffer buffer
+                (should (derived-mode-p 'special-mode))
+                (should buffer-read-only)
+                (goto-char (point-min))
+                (should (search-forward "Status: Running" nil t))
+                (should (search-forward "Running doctor probe" nil t)))
+              (magent-live-test--wait-until
+               (lambda ()
+                 (with-current-buffer buffer
+                   (goto-char (point-min))
+                   (search-forward "Status: Completed" nil t)))
+               5
+               "M-x Doctor did not complete in its progress buffer")
+              (with-current-buffer buffer
+                (goto-char (point-min))
+                (should (search-forward "* Diagnosis" nil t))
+                (should (search-forward "Healthy" nil t)))))
+        (when (buffer-live-p buffer)
+          (kill-buffer buffer))))))
+
 (ert-deftest magent-live-test-loop-runs-emacs-eval-and-continues ()
   "Run a live Magent turn through loop tool execution and continuation."
   :tags '(:magent-live-smoke)
@@ -996,6 +1045,29 @@ return that path."
       (magent-live-test--submit-prompt prompt)
       (let ((response (magent-live-test--wait-for-assistant 120)))
         (should (string-match-p "MAGENT_LIVE_OK" response))))))
+
+(ert-deftest magent-live-test-real-doctor-analysis ()
+  "Run Doctor through the active session route and real gptel provider."
+  :tags '(:magent-live)
+  (require 'magent)
+  (magent-live-test--require-real-gptel)
+  (magent-live-test--with-isolated-runtime
+    (let ((magent-bypass-permission t)
+          completion)
+      (magent-runtime-ensure-initialized)
+      (magent-action-invoke
+       "doctor" (magent-runtime-session-current)
+       :on-complete
+       (lambda (status result)
+         (setq completion (list status result))))
+      (magent-live-test--wait-until
+       (lambda () completion) 180 "Real Doctor analysis did not complete")
+      (ert-info ((format "Doctor completion: %S" completion))
+        (should (eq (car completion) 'completed)))
+      (let ((text (magent-execution-result-content-string
+                   (cadr completion))))
+        (should (string-match-p "^\\* Diagnosis$" text))
+        (should (string-match-p "^\\*\\* Limitations$" text))))))
 
 (ert-deftest magent-live-test-real-emacs-eval-tool ()
   "Send a real tool-use request through gptel and execute emacs_eval."

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -2740,7 +2740,9 @@
                             "** Findings\n- None\n"
                             "** Recommended Actions\n- None\n"
                             "** Limitations\n- Test transport"))
-         request events completion (sample-count 0))
+         (route (magent-model-route-create
+                 :backend 'doctor-backend :model 'doctor-model))
+         request route-args events completion (sample-count 0))
     (unwind-protect
         (progn
           (magent-session-install 'global parent)
@@ -2754,6 +2756,11 @@
                        (error "Doctor must not enter the runtime queue")))
                     ((symbol-function 'magent-session-save-deferred-for-session)
                      #'ignore)
+                    ((symbol-function
+                      'magent-runtime-session-effective-model-route)
+                     (lambda (&rest args)
+                       (setq route-args args)
+                       route))
                     ((symbol-function 'magent-sampling-gptel-sample)
                      (lambda (value)
                        (setq request value)
@@ -2770,7 +2777,12 @@
           (ert-info ((format "Doctor completion: %S" completion))
             (should (= sample-count 1)))
           (should-not (magent-sampling-request-tools request))
-          (should-not (magent-sampling-request-stream request))
+          (should (magent-sampling-request-stream request))
+          (should (eq (magent-sampling-request-backend request)
+                      'doctor-backend))
+          (should (eq (magent-sampling-request-model request)
+                      'doctor-model))
+          (should (equal route-args (list runtime nil 'doctor)))
           (should (eq (car completion) 'completed))
           (should (cl-find 'assistant-delta events
                            :key (lambda (event) (plist-get event :type))))
@@ -2831,6 +2843,8 @@
          (runtime (magent-runtime-session-create
                    :id "session-parent" :scope 'global
                    :magent-session parent))
+         (route (magent-model-route-create
+                 :backend 'doctor-backend :model 'doctor-model))
          (request-buffer (generate-new-buffer " *doctor-cancel-test*"))
          aborted invocation)
     (unwind-protect
@@ -2841,7 +2855,10 @@
            :required t)
           (let ((magent-action--allow-core-registration t))
             (magent-action-builtin-doctor-register))
-          (cl-letf (((symbol-function 'magent-sampling-gptel-sample)
+          (cl-letf (((symbol-function
+                      'magent-runtime-session-effective-model-route)
+                     (lambda (&rest _) route))
+                    ((symbol-function 'magent-sampling-gptel-sample)
                      (lambda (_request) request-buffer))
                     ((symbol-function 'gptel-abort)
                      (lambda (buffer) (setq aborted buffer)))
@@ -11636,13 +11653,42 @@
                      '("auto-skill"))))))
 
 (ert-deftest magent-test-action-run-doctor-dispatches-action ()
-  "Test the Doctor M-x wrapper dispatches through `magent-action-run'."
-  (let (captured)
-    (cl-letf (((symbol-function 'magent-action-run)
-               (lambda (name &rest args)
-                 (setq captured (cons name args)))))
-      (magent-action-run-doctor))
-    (should (equal (car captured) "doctor"))))
+  "Test the Doctor M-x wrapper dispatches and shows live buffer progress."
+  (let (captured displayed)
+    (unwind-protect
+        (cl-letf (((symbol-function 'display-buffer)
+                   (lambda (buffer &rest _)
+                     (setq displayed buffer)))
+                  ((symbol-function 'magent-action-run)
+                   (lambda (name &rest args)
+                     (setq captured (cons name args))
+                     (let ((observer (plist-get args :observer)))
+                       (funcall observer
+                                '(:type action-progress
+                                  :text "Running doctor probe test..."))
+                       (funcall observer
+                                (list :type 'assistant-delta
+                                      :text "* Diagnosis\nHealthy"))
+                       (funcall observer
+                                (list :type 'action-completed
+                                      :status 'completed
+                                      :result
+                                      (magent-execution-result-completed
+                                       "* Diagnosis\nHealthy"))))
+                     nil)))
+          (magent-action-run-doctor)
+          (should (equal (car captured) "doctor"))
+          (should (functionp (plist-get (cdr captured) :observer)))
+          (should (buffer-live-p displayed))
+          (with-current-buffer displayed
+            (should (derived-mode-p 'special-mode))
+            (should buffer-read-only)
+            (goto-char (point-min))
+            (should (search-forward "Status: Completed" nil t))
+            (should (search-forward "Running doctor probe test..." nil t))
+            (should (search-forward "* Diagnosis\nHealthy" nil t))))
+      (when (buffer-live-p displayed)
+        (kill-buffer displayed)))))
 
 (ert-deftest magent-test-acp-request-sender-initialize ()
   "Test in-process ACP request sender handles initialize."


### PR DESCRIPTION
## Summary

- route Doctor analysis through the originating runtime session and gptel streaming path to prevent empty diagnoses
- show live M-x Doctor progress and retain terminal results through Action observer plumbing
- rebuild cached project skill catalogs from registry state and add bilingual docs, unit tests, and live coverage