### PR TITLE
fix(agent): preserve turn usage and tool failure state

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -56,6 +56,10 @@ intentional tagged release is planned as ~v0.2.0~.
 
 ** Fixed
 
+- Persist provider-reported usage on completed ledger turns, preserve failed
+  tool status in ACP fallback notifications, and keep resource-identity race
+  failures as one structured tool result instead of nesting their printed
+  representation in model-visible output.
 - Show a live ~*Magent Doctor*~ progress buffer for
   ~M-x magent-action-run-doctor~, retaining the terminal diagnosis or failure
   instead of leaving interactive Doctor runs silent until completion.

--- a/lisp/magent-acp.el
+++ b/lisp/magent-acp.el
@@ -740,34 +740,35 @@ but omit the reason prefix from the ordinary tool-call UI."
                              (plist-get event :raw-input))))))
           ('tool-call-complete
            (reset-stream)
-           (condition-case err
-               (magent-acp--session-update
-                client session-id
-                `((sessionUpdate . "tool_call_update")
-                  (toolCallId . ,(or (plist-get event :tool-id) "unknown"))
-                  (status . ,(if (eq (plist-get event :status) 'failed)
-                                 "failed"
-                               "completed"))
-                  (content . ,(vector
-                               (magent-acp--tool-content
-                                (or (plist-get event :output-preview) ""))))))
-             (error
-              ;; If the full notification path crashes (e.g. due to
-              ;; agent-shell's alist merge tripping over plist data
-              ;; stored from the prior tool_call), send a minimal
-              ;; fallback so the tool-call status always transitions
-              ;; from in_progress/… to a terminal icon (✓/✗).
-              (magent-log "ERROR acp tool-call-complete failed, sending fallback: %s"
-                          (error-message-string err))
-              (condition-case nil
-                  (magent-acp--session-update
-                   client session-id
-                   `((sessionUpdate . "tool_call_update")
-                     (toolCallId . ,(or (plist-get event :tool-id) "unknown"))
-                     (title . "tool")
-                     (status . "completed")
-                     (content . [])))
-                (error nil)))))
+           (let ((status (if (eq (plist-get event :status) 'failed)
+                             "failed"
+                           "completed")))
+             (condition-case err
+                 (magent-acp--session-update
+                  client session-id
+                  `((sessionUpdate . "tool_call_update")
+                    (toolCallId . ,(or (plist-get event :tool-id) "unknown"))
+                    (status . ,status)
+                    (content . ,(vector
+                                 (magent-acp--tool-content
+                                  (or (plist-get event :output-preview) ""))))))
+               (error
+                ;; If the full notification path crashes (e.g. due to
+                ;; agent-shell's alist merge tripping over plist data
+                ;; stored from the prior tool_call), send a minimal
+                ;; fallback so the tool-call status always transitions
+                ;; from in_progress/… to a terminal icon (✓/✗).
+                (magent-log "ERROR acp tool-call-complete failed, sending fallback: %s"
+                            (error-message-string err))
+                (condition-case nil
+                    (magent-acp--session-update
+                     client session-id
+                     `((sessionUpdate . "tool_call_update")
+                       (toolCallId . ,(or (plist-get event :tool-id) "unknown"))
+                       (title . "tool")
+                       (status . ,status)
+                       (content . [])))
+                  (error nil))))))
           ('turn-error
            ;; The pending session/prompt request reports this through its
            ;; JSON-RPC error response.  Do not misrepresent transport/runtime

--- a/lisp/magent-agent-loop.el
+++ b/lisp/magent-agent-loop.el
@@ -480,10 +480,7 @@ across Magent's own serial tool queue without claiming OS-level isolation."
             (if-let* ((identity-error
                 (magent-agent-loop--resource-identity-error
                         resource-identity request-context fn-args)))
-                (complete
-                 (magent-tool-result-create
-                  :status 'failed :success nil
-                  :output identity-error :error identity-error))
+                (complete identity-error)
               (if async-p
                   (condition-case err
                       (apply fn #'complete fn-args)

--- a/lisp/magent-agent.el
+++ b/lisp/magent-agent.el
@@ -211,16 +211,16 @@ receives the same instruction-provenance and permission invariants."
                    (list skills-message runtime-policy)))
      "\n\n")))
 
-(defun magent-agent--execute-turn
-    (user-prompt &optional callback agent-info skill-names event-context
-                 request-context capability-resolution text-callback request-live-p
-                 request-state)
+(cl-defun magent-agent--execute-turn
+    (&key user-prompt callback agent-info skill-names event-context
+          dispatch-context capability-resolution text-callback request-live-p
+          request-state)
   "Execute USER-PROMPT through the Magent-owned agent loop.
 CALLBACK is called with one final `magent-execution-result'.
 AGENT-INFO is the agent to use (defaults to session agent or registry default).
 SKILL-NAMES is a list of skill name strings to activate for this request.
 EVENT-CONTEXT is an optional existing event context to reuse.
-REQUEST-CONTEXT is an optional structured context plist captured at
+DISPATCH-CONTEXT is an optional structured context plist captured at
 dispatch time.
 CAPABILITY-RESOLUTION is an optional precomputed capability resolver
 result for this turn.
@@ -298,525 +298,529 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
               (when (and request-state turn-id)
                 (setf (magent-request-context-turn-id request-state)
                       turn-id))))
-    (let* ((current-turn-id (and request-state
-                                 (magent-request-context-turn-id request-state)))
-           (prompt-list (magent-session-context-view
-                         session 'provider current-turn-id))
-           (agent-role-msg (magent-agent-info-prompt agent))
-           (request-project-root
-            (magent-agent--request-project-root request-context request-state))
-           (tools
-            (magent-tools-get-gptel-tools-for-permission
-             effective-permission
-             (if request-state
-                 (magent-request-context-tool-names request-state)
-               :all)))
-           (available-tool-names
-            (mapcar (lambda (tool) (intern (gptel-tool-name tool))) tools))
-           (explicit-skill-names
-            (magent-skills-dedupe-names
-             (append skill-names
-                     (and request-state
-                          (magent-request-context-skill-names
-                           request-state)))))
-           (_skill-tool-validation
-            (magent-agent--validate-explicit-skill-tools
-             explicit-skill-names available-tool-names))
-           (capability-resolution
-            (or capability-resolution
-                (when (and (magent-agent--capabilities-enabled-p request-context)
-                           (require 'magent-capability nil t))
-                  (magent-capability-resolve
-                   user-prompt request-context explicit-skill-names
-                   available-tool-names))))
-           (resolved-skill-names
-            (magent-skills-dedupe-names
-             (append
-              explicit-skill-names
-              (and capability-resolution
-                   (magent-capability-resolution-skill-names
-                    capability-resolution)))))
-           (skill-prompts (when (and (require 'magent-skills nil t)
-                                     resolved-skill-names)
-                            (magent-skills-get-instruction-prompts
-                             resolved-skill-names)))
-           (context-provider-messages
-            (magent-agent--context-provider-messages
-             user-prompt request-context request-project-root))
-           (project-instructions
-            (magent-project-instructions-system-message
-             request-project-root request-context))
-           (system-msg
-            (magent-agent--compose-system-message
-             magent-system-prompt agent-role-msg
-             request-project-root context-provider-messages skill-prompts
-             project-instructions)))
-      (when capability-resolution
-        (magent-lifecycle-events-emit
-         'capability-resolution
-         :context context
-         :resolution
-         (magent-capability-resolution-to-plist capability-resolution)))
-      (magent-agent-info-apply-gptel-overrides
-       agent
-       (lambda ()
-         (let* ((route
-                 (magent-agent-resolve-model-route
-                  agent
-                  :explicit-route
-                  (and request-state
-                       (magent-request-context-model-route request-state))
-                  :parent-route
-                  (and request-state
-                       (magent-request-context-parent-model-route
-                        request-state))))
-                (inherited-temperature
-                 (and request-state
-                      (magent-request-context-temperature request-state)))
-                (inherited-top-p
-                 (and request-state
-                      (magent-request-context-top-p request-state)))
-                (inherited-effort
-                 (and request-state
-                      (magent-request-context-effort request-state)))
-                (backend (magent-model-route-backend route))
-                (model (magent-model-route-model route))
-                (temperature (or inherited-temperature
-                                 (magent-agent-info-temperature agent)
-                                 (and (boundp 'gptel-temperature)
-                                      (default-value 'gptel-temperature))))
-                (top-p (or inherited-top-p
-                           (magent-agent-info-top-p agent)))
-                (effort-option (or inherited-effort
-                                   (magent-agent-info-effort agent)
-                                   (magent-effort-option-or-auto
-                                    magent-default-effort)))
-                (effort (magent-effort-effective effort-option)))
-           (when request-state
-             (setf (magent-request-context-project-root request-state)
-                   (or (magent-request-context-project-root request-state)
-                       request-project-root)
-                   (magent-request-context-model-route request-state)
-                   route
-                   (magent-request-context-model request-state)
-                   model
-                   (magent-request-context-backend request-state)
-                   backend
-                   (magent-request-context-temperature request-state)
-                   (or (magent-request-context-temperature request-state)
-                       temperature)
-                   (magent-request-context-top-p request-state)
-                   (or (magent-request-context-top-p request-state)
-                       top-p)
-                   (magent-request-context-effort request-state)
-                   (or (magent-request-context-effort request-state)
-                       effort-option)
-                   (magent-request-context-skill-names request-state)
-                   (copy-sequence resolved-skill-names)
-                   (magent-request-context-capability-context request-state)
-                   (or (magent-request-context-capability-context request-state)
-                       (and capability-resolution
-                            (magent-capability-resolution-to-plist
-                             capability-resolution))
-                       request-context)
-                   (magent-request-context-permission-profile request-state)
-                   effective-permission))
-           (magent-log "INFO agent=%s backend=%s model=%s route-source=%s tools=[%s]"
-                       (magent-agent-info-name agent)
-                       (gptel-backend-name backend)
-                       model
-                       (magent-model-route-source route)
-                       (mapconcat #'gptel-tool-name tools ", "))
-           (when resolved-skill-names
-             (magent-log "INFO active skills=[%s]"
-                         (mapconcat #'identity resolved-skill-names ", ")))
-           (let* ((gptel-backend backend)
-                  (gptel-model model)
-                  (gptel-temperature temperature)
-                  (request-tools
-                   (magent-agent-loop-tools-for-provider tools))
-                  (_tool-capability-preflight
-                   (when (and request-tools
-                              (eq (magent-sampling-gptel-route-tool-capability route)
-                                  'unsupported))
-                     (error
-                      "Magent model %s on backend %s does not support tools"
-                      model (gptel-backend-name backend))))
-                  (gptel-tools request-tools)
-                  (live-p (or request-live-p
-                              (and request-state
-                                   (magent-request-context-live-p
-                                    request-state))))
-                  (streaming-started nil)
-                  (text-delta-seen nil)
-                  (assistant-item nil)
-                  (reasoning-item nil)
-                  (sampling-count 0)
-                  (sample-assistant-content-before nil)
-                  loop)
-             (cl-labels
-                 ((current-turn-id
-                   ()
-                   (or (and request-state
-                            (magent-request-context-turn-id request-state))
-                       (and loop
-                            (magent-agent-loop-turn-id loop))
-                       (and (magent-thread-active-turn
-                             (magent-session-thread-ledger session))
-                            (magent-thread-turn-id
-                             (magent-thread-active-turn
-                              (magent-session-thread-ledger session))))))
-                  (ensure-assistant-item
-                   ()
-                   (or assistant-item
-                       (when-let* ((thread (magent-session-thread-ledger
-                                            session))
-                                   (turn-id (current-turn-id)))
-                         (setq assistant-item
-                               (magent-thread-ensure-message-item
-                                thread turn-id 'assistant nil
-                                (list :source 'streaming)))
-                         assistant-item)))
-                  (ensure-reasoning-item
-                   ()
-                   (or reasoning-item
-                       (when-let* ((thread (magent-session-thread-ledger
-                                            session))
-                                   (turn-id (current-turn-id)))
-                         (setq reasoning-item
-                               (magent-thread-start-item
-                                thread turn-id 'reasoning
-                                :metadata
-                                (list :source 'streaming
-                                      :include-reasoning
-                                      magent-include-reasoning)))
-                         reasoning-item)))
-                  (record-text-delta
-                   (text)
-                   (when-let* ((chunk (and (stringp text) text))
-                               (thread (magent-session-thread-ledger session))
-                               (item (ensure-assistant-item)))
-                     (magent-thread-append-item-content thread item chunk)
-                     (magent-session-save-deferred-for-session
-                      session request-scope)))
-                  (record-reasoning-delta
-                   (text)
-                   (when magent-include-reasoning
-                     (when-let* ((chunk (and (stringp text) text))
-                                 (thread (magent-session-thread-ledger session))
-                                 (item (ensure-reasoning-item)))
-                       (magent-thread-append-item-content thread item chunk)
-                       (magent-session-save-deferred-for-session
-                        session request-scope))))
-                  (finish-reasoning-item
-                   ()
-                   (when-let* ((thread (magent-session-thread-ledger session))
-                               (item reasoning-item))
-                     (unless (magent-thread-terminal-item-p item)
-                       (magent-thread-complete-item
-                        thread item
-                        :content (magent-thread-item-content item)
-                        :metadata (magent-thread-item-metadata item))
-                       (magent-session-save-deferred-for-session
-                        session request-scope))
-                     (setq reasoning-item nil)))
-                  (record-assistant-terminal
-                   (status response)
-                   (let* ((thread (magent-session-thread-ledger session))
-                          (turn-id (current-turn-id))
-                          (text (cond
-                                 ((stringp response) response)
-                                 ((null response) "")
-                                 (t (format "%S" response))))
-                          (transcript
-                           (if (eq status 'completed)
-                               (magent-agent-loop-transcript loop)
-                             text)))
-                     (if (and thread turn-id)
-                         (let ((item (or assistant-item
-                                         (magent-thread-ensure-message-item
-                                          thread turn-id 'assistant nil
-                                          (list :source 'terminal)))))
-                           (pcase status
-                             ('completed
+          (let* ((current-turn-id (and request-state
+                                       (magent-request-context-turn-id request-state)))
+                 (prompt-list (magent-session-context-view
+                               session 'provider current-turn-id))
+                 (agent-role-msg (magent-agent-info-prompt agent))
+                 (request-project-root
+                  (magent-agent--request-project-root
+                   dispatch-context request-state))
+                 (tools
+                  (magent-tools-get-gptel-tools-for-permission
+                   effective-permission
+                   (if request-state
+                       (magent-request-context-tool-names request-state)
+                     :all)))
+                 (available-tool-names
+                  (mapcar (lambda (tool) (intern (gptel-tool-name tool))) tools))
+                 (explicit-skill-names
+                  (magent-skills-dedupe-names
+                   (append skill-names
+                           (and request-state
+                                (magent-request-context-skill-names
+                                 request-state)))))
+                 (_skill-tool-validation
+                  (magent-agent--validate-explicit-skill-tools
+                   explicit-skill-names available-tool-names))
+                 (capability-resolution
+                  (or capability-resolution
+                      (when (and
+                             (magent-agent--capabilities-enabled-p
+                              dispatch-context)
+                             (require 'magent-capability nil t))
+                        (magent-capability-resolve
+                         user-prompt dispatch-context explicit-skill-names
+                         available-tool-names))))
+                 (resolved-skill-names
+                  (magent-skills-dedupe-names
+                   (append
+                    explicit-skill-names
+                    (and capability-resolution
+                         (magent-capability-resolution-skill-names
+                          capability-resolution)))))
+                 (skill-prompts (when (and (require 'magent-skills nil t)
+                                           resolved-skill-names)
+                                  (magent-skills-get-instruction-prompts
+                                   resolved-skill-names)))
+                 (context-provider-messages
+                  (magent-agent--context-provider-messages
+                   user-prompt dispatch-context request-project-root))
+                 (project-instructions
+                  (magent-project-instructions-system-message
+                   request-project-root dispatch-context))
+                 (system-msg
+                  (magent-agent--compose-system-message
+                   magent-system-prompt agent-role-msg
+                   request-project-root context-provider-messages skill-prompts
+                   project-instructions)))
+            (when capability-resolution
+              (magent-lifecycle-events-emit
+               'capability-resolution
+               :context context
+               :resolution
+               (magent-capability-resolution-to-plist capability-resolution)))
+            (magent-agent-info-apply-gptel-overrides
+             agent
+             (lambda ()
+               (let* ((route
+                       (magent-agent-resolve-model-route
+                        agent
+                        :explicit-route
+                        (and request-state
+                             (magent-request-context-model-route request-state))
+                        :parent-route
+                        (and request-state
+                             (magent-request-context-parent-model-route
+                              request-state))))
+                      (inherited-temperature
+                       (and request-state
+                            (magent-request-context-temperature request-state)))
+                      (inherited-top-p
+                       (and request-state
+                            (magent-request-context-top-p request-state)))
+                      (inherited-effort
+                       (and request-state
+                            (magent-request-context-effort request-state)))
+                      (backend (magent-model-route-backend route))
+                      (model (magent-model-route-model route))
+                      (temperature (or inherited-temperature
+                                       (magent-agent-info-temperature agent)
+                                       (and (boundp 'gptel-temperature)
+                                            (default-value 'gptel-temperature))))
+                      (top-p (or inherited-top-p
+                                 (magent-agent-info-top-p agent)))
+                      (effort-option (or inherited-effort
+                                         (magent-agent-info-effort agent)
+                                         (magent-effort-option-or-auto
+                                          magent-default-effort)))
+                      (effort (magent-effort-effective effort-option)))
+                 (when request-state
+                   (setf (magent-request-context-project-root request-state)
+                         (or (magent-request-context-project-root request-state)
+                             request-project-root)
+                         (magent-request-context-model-route request-state)
+                         route
+                         (magent-request-context-model request-state)
+                         model
+                         (magent-request-context-backend request-state)
+                         backend
+                         (magent-request-context-temperature request-state)
+                         (or (magent-request-context-temperature request-state)
+                             temperature)
+                         (magent-request-context-top-p request-state)
+                         (or (magent-request-context-top-p request-state)
+                             top-p)
+                         (magent-request-context-effort request-state)
+                         (or (magent-request-context-effort request-state)
+                             effort-option)
+                         (magent-request-context-skill-names request-state)
+                         (copy-sequence resolved-skill-names)
+                         (magent-request-context-capability-context request-state)
+                         (or (magent-request-context-capability-context request-state)
+                             (and capability-resolution
+                                  (magent-capability-resolution-to-plist
+                                   capability-resolution))
+                             dispatch-context)
+                         (magent-request-context-permission-profile request-state)
+                         effective-permission))
+                 (magent-log "INFO agent=%s backend=%s model=%s route-source=%s tools=[%s]"
+                             (magent-agent-info-name agent)
+                             (gptel-backend-name backend)
+                             model
+                             (magent-model-route-source route)
+                             (mapconcat #'gptel-tool-name tools ", "))
+                 (when resolved-skill-names
+                   (magent-log "INFO active skills=[%s]"
+                               (mapconcat #'identity resolved-skill-names ", ")))
+                 (let* ((gptel-backend backend)
+                        (gptel-model model)
+                        (gptel-temperature temperature)
+                        (request-tools
+                         (magent-agent-loop-tools-for-provider tools))
+                        (_tool-capability-preflight
+                         (when (and request-tools
+                                    (eq (magent-sampling-gptel-route-tool-capability route)
+                                        'unsupported))
+                           (error
+                            "Magent model %s on backend %s does not support tools"
+                            model (gptel-backend-name backend))))
+                        (gptel-tools request-tools)
+                        (live-p (or request-live-p
+                                    (and request-state
+                                         (magent-request-context-live-p
+                                          request-state))))
+                        (streaming-started nil)
+                        (text-delta-seen nil)
+                        (assistant-item nil)
+                        (reasoning-item nil)
+                        (sampling-count 0)
+                        (sample-assistant-content-before nil)
+                        loop)
+                   (cl-labels
+                       ((current-turn-id
+                          ()
+                          (or (and request-state
+                                   (magent-request-context-turn-id request-state))
+                              (and loop
+                                   (magent-agent-loop-turn-id loop))
+                              (and (magent-thread-active-turn
+                                    (magent-session-thread-ledger session))
+                                   (magent-thread-turn-id
+                                    (magent-thread-active-turn
+                                     (magent-session-thread-ledger session))))))
+                        (ensure-assistant-item
+                          ()
+                          (or assistant-item
+                              (when-let* ((thread (magent-session-thread-ledger
+                                                   session))
+                                          (turn-id (current-turn-id)))
+                                (setq assistant-item
+                                      (magent-thread-ensure-message-item
+                                       thread turn-id 'assistant nil
+                                       (list :source 'streaming)))
+                                assistant-item)))
+                        (ensure-reasoning-item
+                          ()
+                          (or reasoning-item
+                              (when-let* ((thread (magent-session-thread-ledger
+                                                   session))
+                                          (turn-id (current-turn-id)))
+                                (setq reasoning-item
+                                      (magent-thread-start-item
+                                       thread turn-id 'reasoning
+                                       :metadata
+                                       (list :source 'streaming
+                                             :include-reasoning
+                                             magent-include-reasoning)))
+                                reasoning-item)))
+                        (record-text-delta
+                          (text)
+                          (when-let* ((chunk (and (stringp text) text))
+                                      (thread (magent-session-thread-ledger session))
+                                      (item (ensure-assistant-item)))
+                            (magent-thread-append-item-content thread item chunk)
+                            (magent-session-save-deferred-for-session
+                             session request-scope)))
+                        (record-reasoning-delta
+                          (text)
+                          (when magent-include-reasoning
+                            (when-let* ((chunk (and (stringp text) text))
+                                        (thread (magent-session-thread-ledger session))
+                                        (item (ensure-reasoning-item)))
+                              (magent-thread-append-item-content thread item chunk)
+                              (magent-session-save-deferred-for-session
+                               session request-scope))))
+                        (finish-reasoning-item
+                          ()
+                          (when-let* ((thread (magent-session-thread-ledger session))
+                                      (item reasoning-item))
+                            (unless (magent-thread-terminal-item-p item)
                               (magent-thread-complete-item
                                thread item
-                               :role 'assistant
-                               :content transcript)
-                              (magent-thread-complete-turn
-                               thread turn-id))
-                             (_
-                              (let ((message
-                                     (if (string-prefix-p "Error:" text)
-                                         text
-                                       (concat "Error: " text))))
-                                (magent-thread-fail-item
-                                 thread item message
-                                 :role 'assistant
-                                 :content message)
-                                (magent-thread-fail-turn
-                                 thread turn-id message))))
-                           (setq assistant-item item)
-                           (condition-case err
-                               (magent-session-save-for-session
-                                session request-scope)
-                             (error
-                              (magent-log
-                               "ERROR immediate session save failed: %s"
-                               (error-message-string err)))))
-                       (error "Turn %s is missing from its session ledger"
-                              turn-id))))
-                  (emit-request-start
-                   ()
-                   (magent-lifecycle-events-emit
-                    'llm-request-start
-                    :context context
-                    :backend (and backend (gptel-backend-name backend))
-                    :model (format "%s" model)
-                    :prompt-count
-                    (length
-                     (magent-sampling-request-prompt
-                      (magent-agent-loop-request loop)))
-                    :tool-count
-                    (length
-                     (magent-sampling-request-tools
-                      (magent-agent-loop-request loop)))
-                    :system-prompt-length (length (or system-msg ""))))
-                  (close-reasoning
-                   ()
-                   (finish-reasoning-item))
-                  (prepare-sample
-                   ()
-                   (setq sample-assistant-content-before
-                         (and assistant-item
-                              (copy-tree
-                               (magent-thread-item-content assistant-item)))
-                         streaming-started nil
-                         text-delta-seen nil)
-                   (magent-agent-loop-begin-sample loop))
-                  (sample
-                   ()
-                   (prepare-sample)
-                   (cl-incf sampling-count)
-                   (emit-request-start)
-                   (magent-agent-loop-start loop))
-                  (request-for-current-session
-                   ()
-                   (let ((request
-                          (magent-agent-loop-request-for-current-session
-                           loop)))
-                     (magent-sampling-request-create
-                      :prompt (magent-sampling-request-prompt request)
-                      :system (magent-sampling-request-system request)
-                      :tools request-tools
-                      :model (magent-sampling-request-model request)
-                      :backend (magent-sampling-request-backend request)
-                      :stream t
-                      :callback (magent-sampling-request-callback request)
-                      :metadata (magent-sampling-request-metadata request))))
-                  (rollback-current-sample-text
-                   ()
-                   (magent-agent-loop-discard-sample-text loop)
-                   (when assistant-item
-                     (setf (magent-thread-item-content assistant-item)
-                           (copy-tree sample-assistant-content-before))
-                     (magent-session-save-deferred-for-session
-                      session request-scope)))
-                  (continue-turn
-                   (outcome)
-                   (if (and (numberp magent-max-sampling-requests)
-                            (> magent-max-sampling-requests 0)
-                            (>= sampling-count
-                                magent-max-sampling-requests))
-                       (let ((failure-message
-                              (format
-                               "Maximum sampling requests reached for this turn (%d)"
-                               magent-max-sampling-requests)))
-                         (magent-agent-loop-set-tool-continuation loop nil)
-                         (finish-turn
-                          'failed failure-message
-                          (list :reason 'sampling-limit
-                                :sampling-count sampling-count
-                                :continuation-reason
-                                (plist-get outcome :reason))))
-                     (let ((continuation
-                            (magent-agent-loop-tool-continuation loop)))
-                       (magent-log
-                        "INFO continuing model response: reason=%s count=%d"
-                        (plist-get outcome :reason)
-                        (1+ sampling-count))
-                       (if (functionp continuation)
-                           (progn
-                             (magent-agent-loop-set-tool-continuation loop nil)
-                             (prepare-sample)
-                             (cl-incf sampling-count)
-                             (emit-request-start)
-                             (condition-case err
-                                 (funcall continuation)
-                               (error
+                               :content (magent-thread-item-content item)
+                               :metadata (magent-thread-item-metadata item))
+                              (magent-session-save-deferred-for-session
+                               session request-scope))
+                            (setq reasoning-item nil)))
+                        (record-assistant-terminal
+                          (status response)
+                          (let* ((thread (magent-session-thread-ledger session))
+                                 (turn-id (current-turn-id))
+                                 (text (cond
+                                        ((stringp response) response)
+                                        ((null response) "")
+                                        (t (format "%S" response))))
+                                 (transcript
+                                  (if (eq status 'completed)
+                                      (magent-agent-loop-transcript loop)
+                                    text)))
+                            (if (and thread turn-id)
+                                (let ((item (or assistant-item
+                                                (magent-thread-ensure-message-item
+                                                 thread turn-id 'assistant nil
+                                                 (list :source 'terminal)))))
+                                  (pcase status
+                                    ('completed
+                                     (magent-thread-complete-item
+                                      thread item
+                                      :role 'assistant
+                                      :content transcript)
+                                     (magent-thread-complete-turn
+                                      thread turn-id
+                                      (magent-agent-loop-usage loop)))
+                                    (_
+                                     (let ((message
+                                            (if (string-prefix-p "Error:" text)
+                                                text
+                                              (concat "Error: " text))))
+                                       (magent-thread-fail-item
+                                        thread item message
+                                        :role 'assistant
+                                        :content message)
+                                       (magent-thread-fail-turn
+                                        thread turn-id message))))
+                                  (setq assistant-item item)
+                                  (condition-case err
+                                      (magent-session-save-for-session
+                                       session request-scope)
+                                    (error
+                                     (magent-log
+                                      "ERROR immediate session save failed: %s"
+                                      (error-message-string err)))))
+                              (error "Turn %s is missing from its session ledger"
+                                     turn-id))))
+                        (emit-request-start
+                          ()
+                          (magent-lifecycle-events-emit
+                           'llm-request-start
+                           :context context
+                           :backend (and backend (gptel-backend-name backend))
+                           :model (format "%s" model)
+                           :prompt-count
+                           (length
+                            (magent-sampling-request-prompt
+                             (magent-agent-loop-request loop)))
+                           :tool-count
+                           (length
+                            (magent-sampling-request-tools
+                             (magent-agent-loop-request loop)))
+                           :system-prompt-length (length (or system-msg ""))))
+                        (close-reasoning
+                          ()
+                          (finish-reasoning-item))
+                        (prepare-sample
+                          ()
+                          (setq sample-assistant-content-before
+                                (and assistant-item
+                                     (copy-tree
+                                      (magent-thread-item-content assistant-item)))
+                                streaming-started nil
+                                text-delta-seen nil)
+                          (magent-agent-loop-begin-sample loop))
+                        (sample
+                          ()
+                          (prepare-sample)
+                          (cl-incf sampling-count)
+                          (emit-request-start)
+                          (magent-agent-loop-start loop))
+                        (request-for-current-session
+                          ()
+                          (let ((request
+                                 (magent-agent-loop-request-for-current-session
+                                  loop)))
+                            (magent-sampling-request-create
+                             :prompt (magent-sampling-request-prompt request)
+                             :system (magent-sampling-request-system request)
+                             :tools request-tools
+                             :model (magent-sampling-request-model request)
+                             :backend (magent-sampling-request-backend request)
+                             :stream t
+                             :callback (magent-sampling-request-callback request)
+                             :metadata (magent-sampling-request-metadata request))))
+                        (rollback-current-sample-text
+                          ()
+                          (magent-agent-loop-discard-sample-text loop)
+                          (when assistant-item
+                            (setf (magent-thread-item-content assistant-item)
+                                  (copy-tree sample-assistant-content-before))
+                            (magent-session-save-deferred-for-session
+                             session request-scope)))
+                        (continue-turn
+                          (outcome)
+                          (if (and (numberp magent-max-sampling-requests)
+                                   (> magent-max-sampling-requests 0)
+                                   (>= sampling-count
+                                       magent-max-sampling-requests))
+                              (let ((failure-message
+                                     (format
+                                      "Maximum sampling requests reached for this turn (%d)"
+                                      magent-max-sampling-requests)))
+                                (magent-agent-loop-set-tool-continuation loop nil)
                                 (finish-turn
-                                 'failed
-                                 (format "Provider continuation failed: %s"
-                                         (error-message-string err))))))
-                         (setf (magent-agent-loop-request loop)
-                               (request-for-current-session))
-                         (sample)))))
-                  (finish-streaming
-                   ()
-                   (close-reasoning))
-                  (finish-turn
-                   (status response &optional metadata)
-                   (finish-streaming)
-                   (magent-lifecycle-events-emit
-                    'llm-request-end
-                    :context context
-                    :status status
-                    :backend (and backend (gptel-backend-name backend))
-                    :model (format "%s" model))
-                   (when owns-context
-                     (magent-lifecycle-events-end-turn context status))
-                   (record-assistant-terminal status response)
-                   (when callback
-                     (funcall callback
-                              (if (eq status 'completed)
-                                  (magent-execution-result-completed
-                                   response metadata)
-                                (magent-execution-result-failed
-                                 response metadata)))))
-                  (start-streaming
-                   ()
-                   (close-reasoning)
-                   (setq streaming-started t))
-                  (handle-completed-event
-                   (event)
-                   (let ((observer-text
-                          (magent-agent--completion-callback-text
-                           loop event text-delta-seen))
-                         (callback-text
-                          (magent-agent--completion-callback-text
-                           loop event streaming-started)))
-                     (when (and (stringp observer-text)
-                                (not (string-empty-p observer-text)))
-                       (magent-request-context-notify
-                        request-state 'assistant-delta
-                        :text observer-text))
-                     (when (and (stringp callback-text)
-                                (not (string-empty-p callback-text)))
-                       (start-streaming)
-                       (when (and text-callback
-                                  (magent-agent--ui-visible-p request-state))
-                         (funcall text-callback callback-text))))
-                   (let* ((result (or (magent-agent-loop-result loop) ""))
-                          (empty-p (string-empty-p result))
-                          (metadata (and empty-p
-                                         (list :reason 'empty-completion))))
-                     (when empty-p
-                       (magent-log "WARN provider completed without assistant text"))
-                     (magent-request-context-notify
-                      request-state 'assistant-complete
-                      :text result
-                      :empty empty-p)
-                     (finish-turn 'completed result metadata)))
-                  (handle-event
-                   (event)
-                   (when (magent-agent--request-live-p live-p)
-                     (let ((event-type (magent-sampling-event-type event)))
-                       (pcase event-type
-                       ('text-delta
-                        (start-streaming)
-                        (magent-lifecycle-events-emit
-                         'text-delta
-                         :context context
-                         :text (magent-sampling-event-text event))
-                        (unless (string-empty-p
-                                 (or (magent-sampling-event-text event) ""))
-                          (setq text-delta-seen t))
-                        (magent-request-context-notify
-                         request-state 'assistant-delta
-                         :text (magent-sampling-event-text event))
-                        (record-text-delta (magent-sampling-event-text event))
-                        (when (and text-callback
-                                   (magent-agent--ui-visible-p request-state))
-                          (funcall text-callback
-                                   (magent-sampling-event-text event))))
-                       ('reasoning-delta
-                        (magent-request-context-notify
-                         request-state 'reasoning-delta
-                         :text (magent-sampling-event-text event))
-                        (record-reasoning-delta
-                         (magent-sampling-event-text event)))
-                       ('reasoning-end
-                        (magent-request-context-notify
-                         request-state 'reasoning-complete)
-                        (close-reasoning))
-                       ('tool-call
-                        (close-reasoning)
-                        (magent-request-context-notify
-                         request-state 'tool-call-detected
-                         :tool-id (magent-sampling-event-id event)
-                         :name (magent-sampling-event-name event)
-                         :arguments (magent-sampling-event-arguments event)))
-                       ('tool-call-batch-end
-                        (close-reasoning)
-                        (when (eq (plist-get (magent-sampling-event-metadata event)
-                                             :source)
-                                  'textual-dsml)
-                          (rollback-current-sample-text))
-                        (magent-lifecycle-events-emit
-                         'llm-request-end
-                         :context context
-                         :status 'tool-calls
-                         :backend (and backend (gptel-backend-name backend))
-                         :model (format "%s" model))
-                        (magent-agent-loop-dispatch-tool-calls
-                         loop
-                         (magent-agent-loop-create-orchestrator
-                          loop
-                          effective-permission
-                          request-state)
-                         (lambda (outcome)
-                           (if (and (eq (magent-agent-loop-status loop)
-                                        'failed)
-                                    (stringp (plist-get outcome :result)))
-                               (finish-turn 'failed
-                                            (plist-get outcome :result))
-                             (continue-turn outcome)))))
-                       ('completed
-                        (handle-completed-event event))
-                      ('error
-                       (magent-request-context-notify
-                        request-state 'turn-error
-                        :message (magent-sampling-event-message event)
-                        :metadata (magent-sampling-event-metadata event))
-                       (finish-turn 'failed
-                                    (magent-sampling-event-message event)
-                                    (magent-sampling-event-metadata event))))))))
-               (setq loop
-                     (magent-agent-loop-create
-                      :session session
-                      :request
-                     (magent-sampling-request-create
-                      :prompt prompt-list
-                      :system system-msg
-                      :tools request-tools
-                      :model model
-                      :backend backend
-                      :stream t
-                      :metadata (append
-                                 (list :temperature temperature
-                                       :top-p top-p)
-                                 (when effort
-                                   (list :effort effort)))
-                      :callback #'handle-event)
-                      :request-context request-state
-                      :event-context context
-                      :owns-event-context-p owns-context
-                      :turn-id (and request-state
-                                    (magent-request-context-turn-id
-                                     request-state))
-                      :sampler #'magent-sampling-gptel-sample))
-               (sample)
-               loop)))))))
+                                 'failed failure-message
+                                 (list :reason 'sampling-limit
+                                       :sampling-count sampling-count
+                                       :continuation-reason
+                                       (plist-get outcome :reason))))
+                            (let ((continuation
+                                   (magent-agent-loop-tool-continuation loop)))
+                              (magent-log
+                               "INFO continuing model response: reason=%s count=%d"
+                               (plist-get outcome :reason)
+                               (1+ sampling-count))
+                              (if (functionp continuation)
+                                  (progn
+                                    (magent-agent-loop-set-tool-continuation loop nil)
+                                    (prepare-sample)
+                                    (cl-incf sampling-count)
+                                    (emit-request-start)
+                                    (condition-case err
+                                        (funcall continuation)
+                                      (error
+                                       (finish-turn
+                                        'failed
+                                        (format "Provider continuation failed: %s"
+                                                (error-message-string err))))))
+                                (setf (magent-agent-loop-request loop)
+                                      (request-for-current-session))
+                                (sample)))))
+                        (finish-streaming
+                          ()
+                          (close-reasoning))
+                        (finish-turn
+                          (status response &optional metadata)
+                          (finish-streaming)
+                          (magent-lifecycle-events-emit
+                           'llm-request-end
+                           :context context
+                           :status status
+                           :backend (and backend (gptel-backend-name backend))
+                           :model (format "%s" model))
+                          (when owns-context
+                            (magent-lifecycle-events-end-turn context status))
+                          (record-assistant-terminal status response)
+                          (when callback
+                            (funcall callback
+                                     (if (eq status 'completed)
+                                         (magent-execution-result-completed
+                                          response metadata)
+                                       (magent-execution-result-failed
+                                        response metadata)))))
+                        (start-streaming
+                          ()
+                          (close-reasoning)
+                          (setq streaming-started t))
+                        (handle-completed-event
+                          (event)
+                          (let ((observer-text
+                                 (magent-agent--completion-callback-text
+                                  loop event text-delta-seen))
+                                (callback-text
+                                 (magent-agent--completion-callback-text
+                                  loop event streaming-started)))
+                            (when (and (stringp observer-text)
+                                       (not (string-empty-p observer-text)))
+                              (magent-request-context-notify
+                               request-state 'assistant-delta
+                               :text observer-text))
+                            (when (and (stringp callback-text)
+                                       (not (string-empty-p callback-text)))
+                              (start-streaming)
+                              (when (and text-callback
+                                         (magent-agent--ui-visible-p request-state))
+                                (funcall text-callback callback-text))))
+                          (let* ((result (or (magent-agent-loop-result loop) ""))
+                                 (empty-p (string-empty-p result))
+                                 (metadata (and empty-p
+                                                (list :reason 'empty-completion))))
+                            (when empty-p
+                              (magent-log "WARN provider completed without assistant text"))
+                            (magent-request-context-notify
+                             request-state 'assistant-complete
+                             :text result
+                             :empty empty-p)
+                            (finish-turn 'completed result metadata)))
+                        (handle-event
+                          (event)
+                          (when (magent-agent--request-live-p live-p)
+                            (let ((event-type (magent-sampling-event-type event)))
+                              (pcase event-type
+                                ('text-delta
+                                 (start-streaming)
+                                 (magent-lifecycle-events-emit
+                                  'text-delta
+                                  :context context
+                                  :text (magent-sampling-event-text event))
+                                 (unless (string-empty-p
+                                          (or (magent-sampling-event-text event) ""))
+                                   (setq text-delta-seen t))
+                                 (magent-request-context-notify
+                                  request-state 'assistant-delta
+                                  :text (magent-sampling-event-text event))
+                                 (record-text-delta (magent-sampling-event-text event))
+                                 (when (and text-callback
+                                            (magent-agent--ui-visible-p request-state))
+                                   (funcall text-callback
+                                            (magent-sampling-event-text event))))
+                                ('reasoning-delta
+                                 (magent-request-context-notify
+                                  request-state 'reasoning-delta
+                                  :text (magent-sampling-event-text event))
+                                 (record-reasoning-delta
+                                  (magent-sampling-event-text event)))
+                                ('reasoning-end
+                                 (magent-request-context-notify
+                                  request-state 'reasoning-complete)
+                                 (close-reasoning))
+                                ('tool-call
+                                 (close-reasoning)
+                                 (magent-request-context-notify
+                                  request-state 'tool-call-detected
+                                  :tool-id (magent-sampling-event-id event)
+                                  :name (magent-sampling-event-name event)
+                                  :arguments (magent-sampling-event-arguments event)))
+                                ('tool-call-batch-end
+                                 (close-reasoning)
+                                 (when (eq (plist-get (magent-sampling-event-metadata event)
+                                                      :source)
+                                           'textual-dsml)
+                                   (rollback-current-sample-text))
+                                 (magent-lifecycle-events-emit
+                                  'llm-request-end
+                                  :context context
+                                  :status 'tool-calls
+                                  :backend (and backend (gptel-backend-name backend))
+                                  :model (format "%s" model))
+                                 (magent-agent-loop-dispatch-tool-calls
+                                  loop
+                                  (magent-agent-loop-create-orchestrator
+                                   loop
+                                   effective-permission
+                                   request-state)
+                                  (lambda (outcome)
+                                    (if (and (eq (magent-agent-loop-status loop)
+                                                 'failed)
+                                             (stringp (plist-get outcome :result)))
+                                        (finish-turn 'failed
+                                                     (plist-get outcome :result))
+                                      (continue-turn outcome)))))
+                                ('completed
+                                 (handle-completed-event event))
+                                ('error
+                                 (magent-request-context-notify
+                                  request-state 'turn-error
+                                  :message (magent-sampling-event-message event)
+                                  :metadata (magent-sampling-event-metadata event))
+                                 (finish-turn 'failed
+                                              (magent-sampling-event-message event)
+                                              (magent-sampling-event-metadata event))))))))
+                     (setq loop
+                           (magent-agent-loop-create
+                            :session session
+                            :request
+                            (magent-sampling-request-create
+                             :prompt prompt-list
+                             :system system-msg
+                             :tools request-tools
+                             :model model
+                             :backend backend
+                             :stream t
+                             :metadata (append
+                                        (list :temperature temperature
+                                              :top-p top-p)
+                                        (when effort
+                                          (list :effort effort)))
+                             :callback #'handle-event)
+                            :request-context request-state
+                            :event-context context
+                            :owns-event-context-p owns-context
+                            :turn-id (and request-state
+                                          (magent-request-context-turn-id
+                                           request-state))
+                            :sampler #'magent-sampling-gptel-sample))
+                     (sample)
+                     loop)))))))
       (error
        (let ((message (error-message-string err)))
          (magent-agent--fail-request-turn
@@ -824,6 +828,31 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
          (when owns-context
            (magent-lifecycle-events-end-turn context 'failed message)))
        (signal (car err) (cdr err))))))
+
+(cl-defun magent-agent--prepare-request-state
+    (&key session request-state context observer approval-provider request-live-p)
+  "Return REQUEST-STATE configured for one SESSION turn.
+Existing request-state values retain precedence for CONTEXT, OBSERVER, and
+APPROVAL-PROVIDER.  REQUEST-LIVE-P can force the request to remain live."
+  (let ((request-state
+         (or request-state
+             (magent-request-context-create
+              :session session
+              :ui-visibility 'none))))
+    (setf (magent-request-context-session request-state) session
+          (magent-request-context-origin-context request-state)
+          (or (magent-request-context-origin-context request-state) context)
+          (magent-request-context-observer request-state)
+          (or (magent-request-context-observer request-state) observer)
+          (magent-request-context-approval-provider request-state)
+          (or (magent-request-context-approval-provider request-state)
+              approval-provider)
+          (magent-request-context-ui-visibility request-state)
+          (or (magent-request-context-ui-visibility request-state) 'none)
+          (magent-request-context-live-p request-state)
+          (or request-live-p
+              (magent-request-context-live-p request-state)))
+    request-state))
 
 (cl-defun magent-agent-run-turn
     (&key session prompt agent skills context observer request-context
@@ -836,38 +865,23 @@ called with one final `magent-execution-result'."
     (error ":session is required"))
   (unless prompt
     (error ":prompt is required"))
-  (let* ((request-context
-          (or request-context
-              (magent-request-context-create
-               :session session
-               :ui-visibility 'none)))
-         (live-p (or request-live-p
-                     (magent-request-context-live-p request-context))))
-    (setf (magent-request-context-session request-context) session
-          (magent-request-context-origin-context request-context)
-          (or (magent-request-context-origin-context request-context)
-              context)
-          (magent-request-context-observer request-context)
-          (or (magent-request-context-observer request-context)
-              observer)
-          (magent-request-context-approval-provider request-context)
-          (or (magent-request-context-approval-provider request-context)
-              approval-provider)
-          (magent-request-context-ui-visibility request-context)
-          (or (magent-request-context-ui-visibility request-context)
-              'none)
-          (magent-request-context-live-p request-context) live-p)
+  (let ((request-state
+         (magent-agent--prepare-request-state
+          :session session
+          :request-state request-context
+          :context context
+          :observer observer
+          :approval-provider approval-provider
+          :request-live-p request-live-p)))
     (magent-agent--execute-turn
-     prompt
-     on-complete
-     agent
-     skills
-     nil
-     context
-     capability-resolution
-     nil
-     live-p
-     request-context)))
+     :user-prompt prompt
+     :callback on-complete
+     :agent-info agent
+     :skill-names skills
+     :dispatch-context context
+     :capability-resolution capability-resolution
+     :request-live-p (magent-request-context-live-p request-state)
+     :request-state request-state)))
 
 (provide 'magent-agent)
 ;;; magent-agent.el ends here

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -646,6 +646,25 @@
           (should (eq (magent-test--transcript-role assistant-msg) 'assistant))
           (should (equal (magent-test--transcript-content assistant-msg) "AI response")))))))
 
+(ert-deftest magent-test-agent-run-turn-persists-provider-usage ()
+  "Test completed turns retain provider usage reported by sampling."
+  (let ((gptel-backend (gptel-make-openai "test" :key "test-key"))
+        (gptel-model 'gpt-4o-mini)
+        (gptel-tools nil)
+        (gptel-use-tools nil)
+        (usage '(:input 7 :output 3 :total 10)))
+    (cl-letf (((symbol-function 'gptel-request)
+               (lambda (_prompt &rest kwargs)
+                 (funcall (plist-get kwargs :callback)
+                          t
+                          (list :content "Done" :tokens usage)))))
+      (magent-session-reset)
+      (magent-test--run-turn "Count usage" #'ignore))
+    (let* ((thread (magent-session-thread-ledger (magent-session-get)))
+           (turn (car (magent-thread-turns thread))))
+      (should (eq (magent-thread-turn-status turn) 'completed))
+      (should (equal (magent-thread-turn-usage turn) usage)))))
+
 (ert-deftest magent-test-agent-run-turn-renders-completed-delta-after-stream-prefix ()
   "Test final completion text after streamed prefix is still rendered."
   (let ((gptel-backend (gptel-make-openai "test" :key "test-key"))
@@ -12683,6 +12702,29 @@
       (should (equal (map-elt content-block 'type) "text"))
       (should (equal (map-elt content-block 'text) "done")))))
 
+(ert-deftest magent-test-acp-tool-result-fallback-preserves-failed-status ()
+  "Test minimal ACP tool fallback preserves the original failed status."
+  (require 'magent-acp)
+  (let ((calls 0)
+        fallback)
+    (cl-letf (((symbol-function 'magent-acp--session-update)
+               (lambda (_client _session-id update)
+                 (cl-incf calls)
+                 (if (= calls 1)
+                     (error "Primary tool update failed")
+                   (setq fallback update))))
+              ((symbol-function 'magent-log) #'ignore))
+      (funcall (magent-acp--observer nil "session-1")
+               '(:type tool-call-complete
+                 :tool-id "tool-1"
+                 :name "write_file"
+                 :status failed
+                 :output-preview "write failed")))
+    (should (= calls 2))
+    (should (equal (map-elt fallback 'sessionUpdate)
+                   "tool_call_update"))
+    (should (equal (map-elt fallback 'status) "failed"))))
+
 (ert-deftest magent-test-acp-observer-preserves-factual-tool-title-on-completion ()
   "Test tool UI omits model reason while completion preserves its title."
   (require 'magent-acp)
@@ -14598,7 +14640,12 @@
           (make-symbolic-link outside (expand-file-name "new" project))
           (setf (magent-agent-loop-tool-queue-busy queue) nil)
           (magent-agent-loop-tool-queue-run queue)
-          (should (string-match-p "resource identity changed" result))
+          (should
+           (equal result
+                  (concat
+                   "[Tool result: status=failed; exit-code=unavailable]\n"
+                   "Error: resource identity changed after permission evaluation")))
+          (should-not (string-match-p "#s(magent-tool-result" result))
           (should (equal (with-temp-buffer
                            (insert-file-contents outside)
                            (buffer-string))


### PR DESCRIPTION
## Summary

- persist provider-reported usage on completed ledger turns
- preserve failed ACP fallback status and avoid nested identity-race tool results
- make request-state preparation and turn execution calls self-describing
- add regression coverage for the corrected paths