### PR TITLE
feat(doctor): add structured Org diagnostics and resumable cancellation

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -56,13 +56,21 @@ intentional tagged release is planned as ~v0.2.0~.
 
 ** Fixed
 
+- Render interactive Doctor preflight, runtime and model-route metadata,
+  structured ~TODO~ / ~DONE~ / ~FAIL~ / ~KILL~ tasks, persisted-session and
+  related-buffer links, and results in one read-only Org buffer.  Persisted
+  sessions use standard Org links so Org-aware actions can follow them.  Retain
+  content-level startup visibility while focusing Preflight during confirmation
+  and Diagnosis at completion; group debug metadata under Environment, keep
+  unstarted failure-path tasks distinct from failed work, and keep successful
+  isolated-Action completion messages to one concise line.
+- Preserve the user side of interrupted turns in provider context so follow-up
+  prompts such as "continue" can recover a request after cancellation without
+  replaying an incomplete assistant response.
 - Persist provider-reported usage on completed ledger turns, preserve failed
   tool status in ACP fallback notifications, and keep resource-identity race
   failures as one structured tool result instead of nesting their printed
   representation in model-visible output.
-- Show a live ~*Magent Doctor*~ progress buffer for
-  ~M-x magent-action-run-doctor~, retaining the terminal diagnosis or failure
-  instead of leaving interactive Doctor runs silent until completion.
 - Make ~/doctor~ analyze through the originating session's effective model
   route and the same streaming gptel path as ordinary Magent turns, avoiding
   empty diagnoses caused by an unrelated global route or non-stream response.

--- a/docs/AGENT_WORKFLOW.org
+++ b/docs/AGENT_WORKFLOW.org
@@ -176,8 +176,9 @@ is a bounded recovery tail. The two are not interchangeable.
     default.  When enabled, reaching the limit fails the turn directly.
 
 Prompt reconstruction is ledger-driven.  When a current turn id is known,
-Magent includes completed history plus that turn only, preventing later
-queued user submissions from leaking into the active model request.
+Magent includes completed history, the user side of interrupted turns, and the
+current turn, so a follow-up can recover cancelled request context without
+letting later queued user submissions leak into the active model request.
 
 * UI Projection
 

--- a/docs/AGENT_WORKFLOW.zh.org
+++ b/docs/AGENT_WORKFLOW.zh.org
@@ -123,7 +123,7 @@ Replay 语义：
 12. Abort、failure 和 dropped queued submissions 分别把 turn 转成 ~interrupted~ 、 ~failed~ 或 ~dropped~ ；aborted turn 下的 in-progress items 标记为 ~cancelled~ 。
 13. ~magent-max-sampling-requests~ 是可选 safety guard，默认关闭；启用后，到达上限会直接使本轮失败。
 
-Prompt reconstruction 是 ledger-driven。知道 current turn id 时，Magent 只包含 completed history 和该 turn，避免后续 queued user submissions 泄漏进 active model request。
+Prompt reconstruction 是 ledger-driven。知道 current turn id 时，Magent 会包含 completed history、interrupted turn 的 user 侧以及该 turn，使后续请求能恢复已取消请求的上下文，同时避免后续 queued user submissions 泄漏进 active model request。
 
 * UI 投影
 

--- a/docs/DOCTOR.org
+++ b/docs/DOCTOR.org
@@ -10,10 +10,21 @@ and current-project state without giving an LLM general Emacs or shell access.
 Both entry points execute the same Action and create an isolated Action session
 under ~magent-session-directory/actions/doctor~.
 
-The M-x entry point immediately displays a ~*Magent Doctor*~ buffer.  It keeps
-the local probe and provider-analysis progress visible, then retains the final
-diagnosis or failure in that buffer instead of running silently in the
-background.
+The M-x entry point immediately displays one read-only Org
+~*Magent Doctor*~ buffer.  The same buffer retains preflight, runtime/package
+versions, the effective Doctor model route, structured probe tasks, and the
+final diagnosis.  Probe headings move through ~TODO~, ~DONE~, ~FAIL~, or
+~KILL~.  Probe results are bounded and redacted before analysis; tasks call out
+only omissions and failures.  When a probe reads information already shown in
+a live Emacs buffer, the task links to that buffer instead of copying its
+potentially noisy contents.  Once the isolated session has been saved, its id
+is a standard Org link to the read-only Action session viewer, so Org-aware
+commands such as ~embark-dwim~ can follow it.
+
+The buffer retains ~#+startup: content~.  Tasks and Diagnosis remain the main
+top-level sections, while Runtime and Doctor model details live under
+Environment and Preflight remains available at the end.  Preflight opens while
+confirmation is pending, and Diagnosis opens automatically when the run ends.
 
 Use ~/doctor select~ or a prefix argument with the M-x command to review the
 applicable probe selection. Core runtime diagnostics are always included.
@@ -46,8 +57,9 @@ closed before any provider request is made.
 
 * Built-In Probes
 
-- ~core-runtime~: Magent source, mode, session, queue, approvals, provider name,
-  and model name.  It never serializes the provider backend object.
+- ~core-runtime~: Magent, gptel, agent-shell, ACP, and Emacs versions; Magent
+  source, mode, session, queue, approvals; and the safe Doctor model-route
+  metadata.  It never serializes the provider backend object.
 - ~current-buffer~: buffer metadata without contents.
 - ~project~: project indicators and a read-only Git status when available.
 - ~diagnostics~: existing Flymake, Flycheck, and Eglot state.
@@ -95,10 +107,14 @@ Use ~M-x magent-action-list-sessions~ to inspect results.  The viewer shows
 the final diagnosis first and folds probe activity by default; ~TAB~ toggles a
 section and ~S-TAB~ toggles all activity details.
 
-Use ~M-x magent-action-cancel~ to cancel an active Doctor request.
-Cancellation terminates an active probe process or aborts the direct gptel
-request, marks the Action session cancelled, and leaves the user's current
-session unchanged.
+Use ~M-x magent-action-cancel~ to cancel an active Doctor request.  In the
+interactive Doctor buffer, ~C-c C-t~ on a nonterminal task marks that heading
+~KILL~ and requests the same whole-Doctor cancellation; it does not skip only
+that probe.  Cancellation terminates an active probe process or aborts the
+direct gptel request, marks the Action session cancelled, and leaves the user's
+current session unchanged.  Built-in Elisp probes are short synchronous reads,
+so task cancellation is normally actionable during an external probe process
+or provider analysis.
 
 * Configuration
 

--- a/docs/DOCTOR.zh.org
+++ b/docs/DOCTOR.zh.org
@@ -9,8 +9,18 @@
 和当前项目状态，但不会把通用 Emacs 或 shell 工具交给 LLM。两个入口执行同一个
 Action，并在 ~magent-session-directory/actions/doctor~ 下创建独立 Action session。
 
-M-x 入口启动后会立即显示 ~*Magent Doctor*~ buffer，持续展示本地 probe 和
-provider 分析进度，并在同一个 buffer 中保留最终诊断或失败信息，不再静默后台运行。
+M-x 入口启动后会立即显示一个只读 Org ~*Magent Doctor*~ buffer。持续保留的 Preflight、
+runtime/package 版本、Doctor 实际使用的 model route、结构化 probe tasks 和最终
+诊断都显示在同一个 buffer 中。Probe heading 会在 ~TODO~、~DONE~、~FAIL~ 和
+~KILL~ 之间变化。Probe 结果在分析前会限长并脱敏；task 只额外标记 omitted 和
+failure。如果 probe 读取的内容已经显示在某个 live Emacs buffer 中，task 会链接到
+该 buffer，而不复制冗长内容。独立 session 落盘后，其 session id 会链接到只读
+Action session viewer；该链接使用标准 Org link 语义，因此 ~embark-dwim~ 等
+Org-aware 命令也能打开它。
+
+Buffer 保留 ~#+startup: content~。Tasks 和 Diagnosis 是主要一级章节；Runtime
+和 Doctor model 归入 Environment，Preflight 保留在末尾。等待确认时自动展开
+Preflight，运行结束时自动展开 Diagnosis。
 
 使用 ~/doctor select~ 或给 M-x 命令传递 prefix argument，可以在 minibuffer 中
 审查适用的 probes；
@@ -41,8 +51,9 @@ HTTP headers 或原始 ~*gptel-log*~。绝对路径会被规范化为 ~$PROJECT~
 
 * 内置 Probes
 
-- ~core-runtime~：Magent source、mode、session、queue、approval、provider
-  名称和 model 名称；不会序列化 provider backend 对象。
+- ~core-runtime~：Magent、gptel、agent-shell、ACP 和 Emacs 版本，Magent
+  source、mode、session、queue、approval，以及安全的 Doctor model-route
+  metadata；不会序列化 provider backend 对象。
 - ~current-buffer~：不含 buffer 内容的 metadata。
 - ~project~：项目标识文件和只读 Git status。
 - ~diagnostics~：已有 Flymake、Flycheck 和 Eglot 状态。
@@ -86,9 +97,12 @@ build、test、编辑或以其他方式修改项目。
 使用 ~M-x magent-action-list-sessions~ 查看结果。Viewer 会优先显示最终诊断，
 默认折叠 probe activity；~TAB~ 切换当前 section，~S-TAB~ 切换全部 activity。
 
-使用 ~M-x magent-action-cancel~ 取消活动 Doctor。取消会终止 probe
-process 或 abort 直接 gptel request，将 Action session 标记为 cancelled，
-并保持用户当前 session 不变。
+使用 ~M-x magent-action-cancel~ 取消活动 Doctor。在交互式 Doctor buffer 中，
+也可以在未结束的 task 上按 ~C-c C-t~：该 heading 会标为 ~KILL~，并请求取消
+整个 Doctor，而不是只跳过该 probe。取消会终止活动 probe process 或 abort
+直接 gptel request，将 Action session 标记为 cancelled，并保持用户当前
+session 不变。内置 Elisp probes 是短时同步读取，因此 task 取消通常在外部 probe
+process 或 provider 分析阶段真正可操作。
 
 * 配置
 

--- a/lisp/magent-action-builtin-doctor.el
+++ b/lisp/magent-action-builtin-doctor.el
@@ -548,7 +548,9 @@ When BACKEND is nil, use the current global gptel backend."
                         located))
               ((file-readable-p source)))
     (condition-case nil
-        (lm-package-version source)
+        (lm-with-file source
+          (or (lm-header "package-version")
+              (lm-header "version")))
       (file-error nil))))
 
 (defun magent-doctor--bound-version (symbol library)

--- a/lisp/magent-action-builtin-doctor.el
+++ b/lisp/magent-action-builtin-doctor.el
@@ -14,6 +14,8 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'button)
+(require 'lisp-mnt)
 (require 'seq)
 (require 'subr-x)
 (require 'gptel-request)
@@ -38,6 +40,7 @@
 (declare-function flycheck-error-line "ext:flycheck" t t)
 (declare-function flycheck-error-message "ext:flycheck" t t)
 (declare-function magent-agent-info-name "magent-agent-info" t t)
+(declare-function magent-action-open-session "magent-action-session-view" t t)
 (declare-function magent-approval-pending-count "magent-approval")
 (declare-function magent-runtime-pending-count "magent-runtime-api")
 (declare-function magent-runtime-session-effective-model-route
@@ -50,11 +53,22 @@
                   "magent-runtime-queue" t t)
 (declare-function magent-runtime-submission-status
                   "magent-runtime-queue" t t)
+(declare-function org-back-to-heading "org" (&optional invisible-ok))
+(declare-function org-cycle-content "org-cycle" (&optional arg))
+(declare-function org-fold-show-entry "org-fold" (&optional hide-drawers))
+(declare-function org-fold-show-subtree "org-fold")
+(declare-function org-link-make-string "ol" (link &optional description))
+(declare-function org-link-set-parameters "ol" (type &rest parameters))
+(declare-function org-mode "org")
 
+(defvar acp-package-version)
+(defvar agent-shell--version)
 (defvar flycheck-current-errors)
 (defvar gptel-backend)
 (defvar gptel-model)
 (defvar gptel-temperature)
+(defvar gptel-version)
+(defvar org-todo-keywords)
 
 (define-error 'magent-doctor-probe-timeout "Doctor probe timed out")
 (define-error 'magent-doctor-security-error "Doctor data failed validation")
@@ -76,6 +90,7 @@
                (:copier nil))
   context
   project-root
+  route
   deadline
   current-process
   request-handle
@@ -91,11 +106,24 @@
     "** Recommended Actions" "** Limitations")
   "Required headings in a structured doctor response.")
 
+(defconst magent-doctor--interactive-todo-keywords
+  '((sequence "TODO" "|" "DONE" "FAIL" "KILL"))
+  "Buffer-local task states used by the interactive Doctor view.")
+
 (defvar-local magent-doctor--interactive-status "Starting"
   "Status shown in the current interactive Doctor buffer.")
 
-(defvar-local magent-doctor--interactive-progress nil
-  "Progress messages shown in the current interactive Doctor buffer.")
+(defvar-local magent-doctor--interactive-preflight ""
+  "Preflight disclosure retained in the current Doctor buffer.")
+
+(defvar-local magent-doctor--interactive-tasks nil
+  "Structured tasks shown in the current interactive Doctor buffer.")
+
+(defvar-local magent-doctor--interactive-runtime-info nil
+  "Runtime version information shown in the current Doctor buffer.")
+
+(defvar-local magent-doctor--interactive-model-info nil
+  "Safe model route information shown in the current Doctor buffer.")
 
 (defvar-local magent-doctor--interactive-result ""
   "Result text shown in the current interactive Doctor buffer.")
@@ -103,43 +131,292 @@
 (defvar-local magent-doctor--interactive-session-id nil
   "Isolated Action session id shown in the current Doctor buffer.")
 
-(defun magent-doctor--interactive-render (buffer)
-  "Render the current interactive Doctor state in BUFFER."
+(defvar-local magent-doctor--interactive-invocation nil
+  "Active Action invocation controlled by the current Doctor buffer.")
+
+(defun magent-doctor--interactive-format-value (value)
+  "Return a concise display string for Doctor metadata VALUE."
+  (cond
+   ((null value) "unavailable")
+   ((eq value :json-false) "no")
+   ((eq value t) "yes")
+   ((vectorp value)
+    (mapconcat #'magent-doctor--interactive-format-value
+               (append value nil) ", "))
+   ((and (listp value) (not (stringp value)))
+    (mapconcat #'magent-doctor--interactive-format-value value ", "))
+   (t (format "%s" value))))
+
+(defun magent-doctor--interactive-task-keyword (status)
+  "Return the Org keyword representing Doctor task STATUS."
+  (pcase status
+    ((or 'completed 'done) "DONE")
+    ((or 'failed 'fail) "FAIL")
+    ((or 'cancelled 'killed 'kill) "KILL")
+    (_ "TODO")))
+
+(defun magent-doctor--interactive-task-terminal-p (status)
+  "Return non-nil when Doctor task STATUS is terminal."
+  (memq status '(completed done failed fail cancelled killed kill)))
+
+(defun magent-doctor--interactive-status-text ()
+  "Return the Doctor status with task completion counts when available."
+  (let ((total (length magent-doctor--interactive-tasks)))
+    (if (zerop total)
+        magent-doctor--interactive-status
+      (format "%s (%d/%d)"
+              magent-doctor--interactive-status
+              (cl-count-if
+               (lambda (task)
+                 (magent-doctor--interactive-task-terminal-p
+                  (plist-get task :status)))
+               magent-doctor--interactive-tasks)
+              total))))
+
+(defun magent-doctor--interactive-insert-info (heading values)
+  "Insert Doctor info HEADING followed by alist VALUES."
+  (insert (format "** %s\n" heading))
+  (dolist (entry values)
+    (insert (format "- %s: %s\n"
+                    (car entry)
+                    (magent-doctor--interactive-format-value (cdr entry))))))
+
+(defun magent-doctor--interactive-insert-task (task)
+  "Insert one structured Doctor TASK in the current buffer."
+  (let* ((id (plist-get task :id))
+         (status (plist-get task :status))
+         (keyword (magent-doctor--interactive-task-keyword status))
+         (heading-start (point)))
+    (insert (format "** %s %s\n" keyword (plist-get task :title)))
+    (add-text-properties
+     heading-start (1- (point))
+     (list 'magent-doctor-task-id id
+           'rear-nonsticky '(magent-doctor-task-id)))
+    (when-let* ((description (plist-get task :description)))
+      (insert description "\n"))
+    (when (eq (plist-get task :llm-state) 'omitted)
+      (insert "- Analysis: omitted because the total size limit was reached.\n"))
+    (when-let* ((buffers (plist-get task :related-buffers)))
+      (insert "- Related buffers: ")
+      (let ((first t))
+        (dolist (name buffers)
+          (when (get-buffer name)
+            (unless first
+              (insert ", "))
+            (setq first nil)
+            (insert-text-button
+             name
+             'follow-link t
+             'help-echo (format "Open buffer %s" name)
+             'magent-doctor-buffer-name name
+             'action #'magent-doctor--interactive-open-related-buffer)))
+        (when first
+          (insert "none currently live")))
+      (insert "\n"))
+    (when-let* ((note (plist-get task :note)))
+      (insert "- " note "\n"))))
+
+(defun magent-doctor--interactive-open-related-buffer (button)
+  "Open the live Doctor-related buffer named by BUTTON."
+  (let* ((name (button-get button 'magent-doctor-buffer-name))
+         (buffer (and (stringp name) (get-buffer name))))
+    (unless (buffer-live-p buffer)
+      (user-error "Doctor-related buffer is no longer live: %s" name))
+    (pop-to-buffer buffer)))
+
+(defun magent-doctor--interactive-session-file (&optional session-id)
+  "Return the persisted file for Doctor SESSION-ID, or nil.
+SESSION-ID defaults to the session shown in the current Doctor buffer."
+  (let ((id (or session-id magent-doctor--interactive-session-id)))
+    (when (stringp id)
+      (magent-session-validate-id id)
+      (let ((file
+             (expand-file-name
+              (concat id ".json")
+              (magent-session-action-directory "doctor"))))
+        (and (file-exists-p file) file)))))
+
+(defun magent-doctor--interactive-open-session-link (session-id arg)
+  "Open the persisted Doctor Action session named by SESSION-ID.
+ARG is accepted for the Org custom-link follow protocol."
+  (ignore arg)
+  (let ((file (magent-doctor--interactive-session-file session-id)))
+    (unless file
+      (user-error "Persisted Doctor session is no longer available"))
+    (require 'magent-action-session-view)
+    (magent-action-open-session file)))
+
+(defun magent-doctor--interactive-register-session-link ()
+  "Register the Org link used for persisted Doctor sessions."
+  (org-link-set-parameters
+   "magent-session"
+   :follow #'magent-doctor--interactive-open-session-link))
+
+(defun magent-doctor--interactive-update-task (update)
+  "Apply one structured Doctor task UPDATE to the current buffer state."
+  (let ((id (plist-get update :id)))
+    (setq magent-doctor--interactive-tasks
+          (mapcar
+           (lambda (task)
+             (if (not (equal (plist-get task :id) id))
+                 task
+               (let ((updated (copy-tree task)))
+                 (dolist (key '(:status :llm-state :note))
+                   (when (plist-member update key)
+                     (setq updated
+                           (plist-put updated key (plist-get update key)))))
+                 updated)))
+           magent-doctor--interactive-tasks))))
+
+(defun magent-doctor--interactive-finish-pending-tasks (action-status)
+  "Finish nonterminal Doctor tasks according to ACTION-STATUS.
+On failure, mark the running task failed and tasks not yet started cancelled."
+  (setq magent-doctor--interactive-tasks
+        (mapcar
+         (lambda (task)
+           (let ((status (plist-get task :status)))
+             (if (magent-doctor--interactive-task-terminal-p status)
+                 task
+               (plist-put
+                (copy-tree task) :status
+                (pcase action-status
+                  ('completed 'completed)
+                  ('cancelled 'cancelled)
+                  (_ (if (eq status 'running) 'failed 'cancelled)))))))
+         magent-doctor--interactive-tasks)))
+
+(defun magent-doctor--interactive-render (buffer &optional focus)
+  "Render the current interactive Doctor state in BUFFER.
+FOCUS may name a top-level section to reveal and move point to."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
-      (let ((inhibit-read-only t))
+      (let ((inhibit-read-only t)
+            (previous-point (point)))
         (erase-buffer)
-        (insert "Magent Doctor\n\n")
-        (insert (format "Status: %s\n" magent-doctor--interactive-status))
+        (insert "#+title: Magent Doctor\n#+startup: content\n\n")
+        (insert (format "Status: %s\n"
+                        (magent-doctor--interactive-status-text)))
         (when magent-doctor--interactive-session-id
-          (insert (format "Session: %s\n"
-                          magent-doctor--interactive-session-id)))
-        (insert "\nThis diagnostic runs in an isolated Action session.\n")
-        (if magent-doctor--interactive-progress
-            (progn
-              (insert "\nProgress\n")
-              (dolist (message (reverse magent-doctor--interactive-progress))
-                (insert "- " message "\n")))
-          (insert "\nStarting local diagnostic collection...\n"))
-        (unless (string-empty-p magent-doctor--interactive-result)
-          (insert "\nResult\n\n" magent-doctor--interactive-result)
+          (insert "Session: ")
+          (if (magent-doctor--interactive-session-file)
+              (insert
+               (org-link-make-string
+                (concat "magent-session:"
+                        magent-doctor--interactive-session-id)
+                magent-doctor--interactive-session-id))
+            (insert magent-doctor--interactive-session-id))
+          (insert "\n"))
+        (insert "Mode: isolated Action; provider tools disabled.\n")
+        (when (member magent-doctor--interactive-status
+                      '("Running" "Finishing"))
+          (insert (concat "Cancel: C-c C-t on a TODO task (marks KILL), "
+                          "or M-x magent-action-cancel.\n")))
+        (insert "\n* Tasks\n")
+        (insert (concat "Probe results are bounded and redacted before "
+                        "analysis unless marked omitted.\n"))
+        (if magent-doctor--interactive-tasks
+            (dolist (task magent-doctor--interactive-tasks)
+              (magent-doctor--interactive-insert-task task))
+          (insert "** TODO Preparing Doctor task plan\n"))
+        (insert "\n")
+        (if (string-empty-p magent-doctor--interactive-result)
+            (insert "* Diagnosis\n")
+          (unless (string-match-p
+                   "\\`\\* Diagnosis[ \t]*\\(?:\n\\|\\'\\)"
+                   magent-doctor--interactive-result)
+            (insert "* Diagnosis\n"))
+          (insert magent-doctor--interactive-result)
           (unless (string-suffix-p "\n" magent-doctor--interactive-result)
             (insert "\n")))
-        (insert "\nUse M-x magent-action-cancel to cancel an active run.\n")
-        (goto-char (point-min))))))
+        (insert "\n* Environment\n")
+        (magent-doctor--interactive-insert-info
+         "Runtime" magent-doctor--interactive-runtime-info)
+        (insert "\n")
+        (magent-doctor--interactive-insert-info
+         "Doctor model" magent-doctor--interactive-model-info)
+        (unless (string-empty-p magent-doctor--interactive-preflight)
+          (insert "\n* Preflight\n#+begin_example\n"
+                  magent-doctor--interactive-preflight)
+          (unless (string-suffix-p
+                   "\n" magent-doctor--interactive-preflight)
+            (insert "\n"))
+          (insert "#+end_example\n"))
+        (org-cycle-content)
+        (if (and focus
+                 (progn
+                   (goto-char (point-min))
+                   (re-search-forward
+                    (format "^\\* %s[ \t]*$" (regexp-quote focus)) nil t)))
+            (progn
+              (beginning-of-line)
+              (pcase focus
+                ("Tasks" (org-fold-show-entry))
+                ((or "Diagnosis" "Preflight")
+                 (org-fold-show-subtree))))
+          (goto-char (min previous-point (point-max))))))))
 
 (defun magent-doctor--interactive-buffer ()
   "Create, initialize, and display a buffer for an interactive Doctor run."
   (let ((buffer (generate-new-buffer "*Magent Doctor*")))
     (with-current-buffer buffer
-      (special-mode)
+      (require 'org)
+      (magent-doctor--interactive-register-session-link)
+      (let ((org-todo-keywords magent-doctor--interactive-todo-keywords))
+        (org-mode))
+      (local-set-key (kbd "C-c C-t") #'magent-doctor-task-kill)
+      (setq buffer-read-only t)
       (setq-local magent-doctor--interactive-status "Starting"
-                  magent-doctor--interactive-progress nil
+                  magent-doctor--interactive-preflight ""
+                  magent-doctor--interactive-tasks nil
+                  magent-doctor--interactive-runtime-info
+                  (magent-doctor--runtime-info)
+                  magent-doctor--interactive-model-info
+                  '(("Status" . "Resolving route"))
                   magent-doctor--interactive-result ""
-                  magent-doctor--interactive-session-id nil)
+                  magent-doctor--interactive-session-id nil
+                  magent-doctor--interactive-invocation nil)
       (magent-doctor--interactive-render buffer))
     (display-buffer buffer)
     buffer))
+
+(defun magent-doctor--interactive-show-preflight (buffer text)
+  "Show Doctor preflight TEXT in BUFFER."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (setq magent-doctor--interactive-status "Awaiting confirmation"
+            magent-doctor--interactive-preflight text)
+      (magent-doctor--interactive-render buffer "Preflight"))))
+
+(defun magent-doctor-task-kill ()
+  "Mark the Doctor task at point KILL and cancel its Action invocation."
+  (interactive)
+  (unless (magent-action-invocation-p magent-doctor--interactive-invocation)
+    (user-error "No active Doctor invocation is attached to this buffer"))
+  (unless (eq (magent-action-invocation-status
+               magent-doctor--interactive-invocation)
+              'active)
+    (user-error "The Doctor invocation is no longer active"))
+  (let ((id
+         (save-excursion
+           (org-back-to-heading t)
+           (get-text-property (line-beginning-position)
+                              'magent-doctor-task-id))))
+    (unless id
+      (user-error "Point is not on a Doctor task"))
+    (let ((task (cl-find id magent-doctor--interactive-tasks
+                         :key (lambda (item) (plist-get item :id))
+                         :test #'equal)))
+      (unless (and task
+                   (memq (plist-get task :status)
+                         '(pending running todo)))
+        (user-error "Doctor task %s is already terminal" id)))
+    (magent-doctor--interactive-update-task
+     (list :id id :status 'cancelled
+           :note "Cancelled by the user; the Doctor run is stopping."))
+    (magent-doctor--interactive-render (current-buffer))
+    (magent-action-cancel
+     magent-doctor--interactive-invocation
+     (format "Doctor task %s killed by user" id))))
 
 (defun magent-doctor--interactive-status-label (status)
   "Return a display label for terminal Doctor STATUS."
@@ -153,27 +430,37 @@
   "Project Doctor EVENT into the interactive Doctor BUFFER."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
-      (pcase (plist-get event :type)
-        ('action-progress
-         (setq magent-doctor--interactive-status "Running")
-         (when-let* ((text (plist-get event :text)))
-           (unless (member text magent-doctor--interactive-progress)
-             (push text magent-doctor--interactive-progress))))
-        ('assistant-delta
-         (setq magent-doctor--interactive-status "Finishing")
-         (when-let* ((text (plist-get event :text)))
-           (setq magent-doctor--interactive-result
-                 (concat magent-doctor--interactive-result text))))
-        ('action-completed
-         (setq magent-doctor--interactive-status
-               (magent-doctor--interactive-status-label
-                (plist-get event :status)))
-         (when (string-empty-p magent-doctor--interactive-result)
-           (when-let* ((result (plist-get event :result)))
+      (let (focus)
+        (pcase (plist-get event :type)
+          ('action-progress
+           (setq magent-doctor--interactive-status "Running")
+           (when-let* ((update (plist-get event :doctor-update)))
+             (pcase (plist-get update :kind)
+               ('plan
+                (setq magent-doctor--interactive-tasks
+                      (copy-tree (plist-get update :tasks))
+                      magent-doctor--interactive-model-info
+                      (copy-tree (plist-get update :model-info))
+                      focus "Tasks"))
+               ('task
+                (magent-doctor--interactive-update-task update)))))
+          ('assistant-delta
+           (setq magent-doctor--interactive-status "Finishing")
+           (when-let* ((text (plist-get event :text)))
              (setq magent-doctor--interactive-result
-                   (or (magent-execution-result-content-string result) "")))))
-        (_ nil))
-      (magent-doctor--interactive-render buffer))))
+                   (concat magent-doctor--interactive-result text))))
+          ('action-completed
+           (let ((status (plist-get event :status)))
+             (setq magent-doctor--interactive-status
+                   (magent-doctor--interactive-status-label status))
+             (magent-doctor--interactive-finish-pending-tasks status))
+           (when (string-empty-p magent-doctor--interactive-result)
+             (when-let* ((result (plist-get event :result)))
+               (setq magent-doctor--interactive-result
+                     (or (magent-execution-result-content-string result) ""))))
+           (setq focus "Diagnosis"))
+          (_ nil))
+        (magent-doctor--interactive-render buffer focus)))))
 
 (defun magent-doctor--normalize-id (id)
   "Return ID as a stable probe registry key."
@@ -236,29 +523,100 @@ values.  Custom probes execute as trusted Emacs Lisp and are not sandboxed."
   "Return VALUE as a JSON boolean sentinel."
   (if value t :json-false))
 
-(defun magent-doctor--safe-provider-name ()
-  "Return the current provider name without printing its backend object."
-  (or (and (boundp 'gptel-backend)
-           gptel-backend
+(defun magent-doctor--safe-provider-name (&optional backend)
+  "Return BACKEND's provider name without printing its live object.
+When BACKEND is nil, use the current global gptel backend."
+  (let ((selected (or backend
+                      (and (boundp 'gptel-backend) gptel-backend))))
+    (or (and selected
            (fboundp 'gptel-backend-p)
-           (gptel-backend-p gptel-backend)
+           (gptel-backend-p selected)
            (fboundp 'gptel-backend-name)
-           (gptel-backend-name gptel-backend))
-      "gptel"))
+           (gptel-backend-name selected))
+        "gptel")))
 
 (defun magent-doctor--feature-source (feature)
   "Return the library path for FEATURE, or nil."
   (and (symbolp feature)
        (locate-library (symbol-name feature))))
 
-(defun magent-doctor--core-collector (context _state)
+(defun magent-doctor--library-version (library)
+  "Return the package header version for LIBRARY, or nil."
+  (when-let* ((located (locate-library library))
+              (source (if (string-suffix-p ".elc" located)
+                          (string-remove-suffix "c" located)
+                        located))
+              ((file-readable-p source)))
+    (condition-case nil
+        (lm-package-version source)
+      (file-error nil))))
+
+(defun magent-doctor--bound-version (symbol library)
+  "Return version variable SYMBOL or LIBRARY's package header version."
+  (or (and (boundp symbol)
+           (let ((value (symbol-value symbol)))
+             (and value (format "%s" value))))
+      (magent-doctor--library-version library)
+      "unavailable"))
+
+(defun magent-doctor--runtime-info ()
+  "Return safe runtime version information for Doctor display and probes."
+  `(("Magent version" . ,(or (magent-doctor--library-version "magent")
+                              "unavailable"))
+    ("gptel version" . ,(magent-doctor--bound-version
+                          'gptel-version "gptel"))
+    ("agent-shell version" . ,(magent-doctor--bound-version
+                                'agent-shell--version "agent-shell"))
+    ("ACP version" . ,(magent-doctor--bound-version
+                        'acp-package-version "acp"))
+    ("Emacs version" . ,emacs-version)
+    ("System" . ,system-type)))
+
+(defun magent-doctor--model-info (route)
+  "Return safe detailed Doctor model metadata for ROUTE."
+  (if (not (magent-model-route-p route))
+      '(("Status" . "No model route"))
+    (let* ((backend (magent-model-route-backend route))
+           (model (magent-model-route-model route))
+           (description (and (symbolp model) (get model :description)))
+           (capabilities (and (symbolp model) (get model :capabilities)))
+           (capability-list
+            (cond
+             ((vectorp capabilities) (append capabilities nil))
+             ((listp capabilities) capabilities)
+             (capabilities (list capabilities))))
+           (context-window (and (symbolp model) (get model :context-window))))
+      `(("Backend" . ,(magent-doctor--safe-provider-name backend))
+        ("Backend type" . ,(format "%s" (type-of backend)))
+        ("Model" . ,(format "%s" model))
+        ("Description" . ,(and description
+                                (magent-doctor--truncate
+                                 (format "%s" description) 500)))
+        ("Capabilities" . ,(and capability-list
+                                 (vconcat
+                                  (mapcar (lambda (item) (format "%s" item))
+                                          capability-list))))
+        ("Context window" . ,context-window)
+        ("Route source" . ,(magent-model-route-source route))
+        ("Route phase" . ,(magent-model-route-phase route))
+        ("Temperature" . ,(and (boundp 'gptel-temperature)
+                                gptel-temperature))
+        ("Streaming" . t)
+        ("Provider tools" . "disabled")
+        ("Reasoning" . "disabled")
+        ("Request timeout seconds" . ,magent-request-timeout)))))
+
+(defun magent-doctor--core-collector (context state)
   "Collect bounded Magent runtime facts for CONTEXT."
   (let* ((parent (magent-action-invocation-parent-session context))
          (thread (and parent (magent-session-thread-ledger parent)))
          (agent (and parent (magent-session-agent parent)))
          (active (and (fboundp 'magent-runtime-queue-active-submission)
                       (magent-runtime-queue-active-submission))))
-    `((emacs-version . ,emacs-version)
+    `((runtime-versions . ,(magent-doctor--runtime-info))
+      (doctor-model . ,(magent-doctor--model-info
+                        (magent-doctor-state-route state)))
+      (emacs-version . ,emacs-version)
       (system-type . ,system-type)
       (origin-scope . ,(magent-action-invocation-origin-scope context))
       (parent-session-id
@@ -628,9 +986,10 @@ Return nil when either path is unavailable or cannot be inspected."
                 (line-number-at-pos)
                 magent-doctor-source-context-max-chars)))))
 
-(defun magent-doctor--preflight-text (context probes)
-  "Return a local-only preflight disclosure for CONTEXT and PROBES."
+(defun magent-doctor--preflight-text (context probes route)
+  "Return a local-only preflight disclosure for CONTEXT, PROBES, and ROUTE."
   (let* ((root (magent-doctor--project-root context))
+         (model-info (magent-doctor--model-info route))
          (source-selected
           (cl-find "source-context" probes
                    :key #'magent-doctor-probe-id :test #'equal))
@@ -640,11 +999,8 @@ Return nil when either path is unavailable or cannot be inspected."
                   (mapcar #'magent-doctor-probe-data-categories probes)))))
     (string-join
      (append
-      (list "Magent Doctor Preflight"
-            ""
-            (format "Provider: %s" (magent-doctor--safe-provider-name))
-            (format "Model: %s"
-                    (if (boundp 'gptel-model) gptel-model "default"))
+      (list (format "Provider: %s" (cdr (assoc "Backend" model-info)))
+            (format "Model: %s" (cdr (assoc "Model" model-info)))
             (format "Project root: %s" (or root "none"))
             ""
             "Probes:")
@@ -669,13 +1025,85 @@ Return nil when either path is unavailable or cannot be inspected."
             "No provider tools are enabled."))
      "\n")))
 
-(defun magent-doctor--confirm (context probes)
-  "Confirm the doctor collection plan for CONTEXT and PROBES."
+(defun magent-doctor--confirm (context probes route)
+  "Confirm the doctor collection plan for CONTEXT, PROBES, and ROUTE."
   (if magent-bypass-permission
       t
-    (magent--with-display-buffer "*Magent Doctor Preflight*"
-      (insert (magent-doctor--preflight-text context probes)))
+    (let ((buffer
+           (or (let ((candidate
+                      (plist-get (magent-action-invocation-options context)
+                                 :interactive-buffer)))
+                 (and (buffer-live-p candidate) candidate))
+               (magent-doctor--interactive-buffer))))
+      (magent-doctor--interactive-show-preflight
+       buffer (magent-doctor--preflight-text context probes route)))
     (yes-or-no-p "Run Magent Doctor with these probes? ")))
+
+(defun magent-doctor--task-related-buffers (context probe)
+  "Return existing local buffer names relevant to CONTEXT and PROBE."
+  (let ((id (magent-doctor-probe-id probe)))
+    (pcase id
+      ((or "current-buffer" "diagnostics" "source-context")
+       (when-let* ((buffer (magent-doctor--origin-buffer context)))
+         (list (buffer-name buffer))))
+      ("magent-logs"
+       (seq-filter #'get-buffer
+                   '("*magent-log*" "*Warnings*" "*Messages*")))
+      ("compilation"
+       (when-let* ((root (magent-doctor--project-root context)))
+         (seq-take
+          (delq nil
+                (mapcar
+                 (lambda (buffer)
+                   (with-current-buffer buffer
+                     (and (derived-mode-p 'compilation-mode)
+                          (magent-doctor--directory-in-project-p
+                           default-directory root)
+                          (buffer-name buffer))))
+                 (buffer-list)))
+          3))))))
+
+(defun magent-doctor--task-plan (context probes)
+  "Return interactive Doctor tasks for CONTEXT, PROBES, and final analysis."
+  (append
+   (mapcar
+    (lambda (probe)
+      (list :id (magent-doctor-probe-id probe)
+            :kind 'probe
+            :title (format "probe %s" (magent-doctor-probe-id probe))
+            :description (magent-doctor-probe-description probe)
+            :related-buffers
+            (magent-doctor--task-related-buffers context probe)
+            :status 'pending
+            :llm-state 'pending
+            :note nil))
+    probes)
+   (list
+    (list :id "analysis"
+          :kind 'analysis
+          :title "Analyze collected results"
+          :description
+          "Ask the selected Doctor model to analyze bounded, redacted probe results."
+          :status 'pending
+          :llm-state nil
+          :note nil))))
+
+(defun magent-doctor--report-plan (context probes route)
+  "Report the structured Doctor task plan for CONTEXT, PROBES, and ROUTE."
+  (magent-action-progress
+   context "Prepared Doctor task plan."
+   :doctor-update
+   (list :kind 'plan
+         :tasks (magent-doctor--task-plan context probes)
+         :model-info (magent-doctor--model-info route))))
+
+(defun magent-doctor--report-task (context id status &rest properties)
+  "Report Doctor task ID with STATUS and optional PROPERTIES for CONTEXT."
+  (magent-action-progress
+   context
+   (format "Doctor task %s %s." id status)
+   :doctor-update
+   (append (list :kind 'task :id id :status status) properties)))
 
 (defun magent-doctor--truncate (string limit)
   "Return STRING capped to LIMIT characters."
@@ -731,7 +1159,7 @@ Return nil when either path is unavailable or cannot be inspected."
                    (remaining remaining)
                    (t nil)))
          (id (magent-doctor-probe-id probe)))
-    (magent-action-progress context (format "Running doctor probe %s..." id))
+    (magent-doctor--report-task context id 'running)
     (condition-case err
         (let* ((raw
                 (if timeout
@@ -764,7 +1192,13 @@ Return nil when either path is unavailable or cannot be inspected."
     (dolist (probe probes (nreverse results))
       (when (magent-doctor-state-cancelled-p state)
         (signal 'quit nil))
-      (push (magent-doctor--run-probe probe context state) results))))
+      (let* ((result (magent-doctor--run-probe probe context state))
+             (status (if (equal (cdr (assq 'status result)) "completed")
+                         'completed
+                       'failed)))
+        (magent-doctor--report-task
+         context (magent-doctor-probe-id probe) status)
+        (push result results)))))
 
 (defun magent-doctor--bounded-bundle (results)
   "Return RESULTS capped to `magent-doctor-max-diagnostic-chars'."
@@ -781,6 +1215,22 @@ Return nil when either path is unavailable or cannot be inspected."
     `((probes . ,(vconcat (nreverse included)))
       (omitted-probes . ,(vconcat (nreverse omitted)))
       (truncated . ,(magent-doctor--json-bool omitted)))))
+
+(defun magent-doctor--report-bundle-membership (context results bundle)
+  "Report which sanitized RESULTS enter Doctor BUNDLE for CONTEXT."
+  (let ((omitted (append (cdr (assq 'omitted-probes bundle)) nil)))
+    (dolist (result results)
+      (let* ((id (cdr (assq 'id result)))
+             (status (if (equal (cdr (assq 'status result)) "completed")
+                         'completed
+                       'failed)))
+        (if (member id omitted)
+            (magent-doctor--report-task
+             context id status
+             :llm-state 'omitted)
+          (magent-doctor--report-task
+           context id status
+           :llm-state 'included))))))
 
 (defun magent-doctor--structured-output-p (text)
   "Return non-nil when TEXT contains the required headings in order."
@@ -905,10 +1355,11 @@ invocations without a control session use the current gptel defaults."
 (defun magent-doctor--start-analysis (context state results)
   "Start one tool-free provider analysis for CONTEXT over RESULTS."
   (let* ((bundle (magent-doctor--bounded-bundle results))
-         (route (magent-doctor--analysis-route context))
+         (bundle-json (magent-json-encode bundle))
+         (route (magent-doctor-state-route state))
          (prompt (concat (magent-prompt-read "internal/doctor-user.org")
                          "\n\n"
-                         (magent-json-encode bundle)))
+                         bundle-json))
          (request
           (magent-sampling-request-create
            :prompt prompt
@@ -926,7 +1377,12 @@ invocations without a control session use the current gptel defaults."
            :callback
            (lambda (event)
              (magent-doctor--request-callback context state event)))))
-    (magent-action-progress context "Analyzing sanitized diagnostics...")
+    (magent-doctor--report-bundle-membership context results bundle)
+    (magent-doctor--report-task
+     context "analysis" 'running
+     :note (format (concat "Sending %d characters of bounded, redacted probe "
+                           "results; provider tools are disabled.")
+                   (length bundle-json)))
     (let ((handle (magent-sampling-gptel-sample request)))
       (if (or (magent-doctor-state-cancelled-p state)
               (not (eq (magent-action-invocation-status context) 'active)))
@@ -952,17 +1408,20 @@ invocations without a control session use the current gptel defaults."
                   '("" "select"))
     (user-error "Usage: /doctor [select]"))
   (let* ((probes (magent-doctor--select-probes context))
+         (route (magent-doctor--analysis-route context))
          (state
           (magent-doctor-state-create
            :context context
            :done done
+           :route route
            :project-root (magent-doctor--project-root context))))
     (magent-session-set-metadata-value
      (magent-action-invocation-session context)
      'selected-probes
      (vconcat (mapcar #'magent-doctor-probe-id probes)))
-    (if (not (magent-doctor--confirm context probes))
+    (if (not (magent-doctor--confirm context probes route))
         (magent-doctor--done state 'cancelled "Doctor cancelled")
+      (magent-doctor--report-plan context probes route)
       (setf (magent-doctor-state-deadline state)
             (and (> magent-doctor-total-timeout 0)
                  (+ (float-time) magent-doctor-total-timeout)))
@@ -1046,10 +1505,14 @@ With prefix argument SELECT-PROBES, review probe selection in the minibuffer."
         (let ((invocation
                (magent-action-run
                 "doctor"
-                :options (list :select-probes (and select-probes t))
+                :options (list :select-probes (and select-probes t)
+                               :interactive-buffer buffer)
                 :observer
                 (lambda (event)
                   (magent-doctor--interactive-observe buffer event)))))
+          (when (magent-action-invocation-p invocation)
+            (with-current-buffer buffer
+              (setq magent-doctor--interactive-invocation invocation)))
           (when-let* (((magent-action-invocation-p invocation))
                       (session (magent-action-invocation-session invocation)))
             (with-current-buffer buffer

--- a/lisp/magent-action-session.el
+++ b/lisp/magent-action-session.el
@@ -333,11 +333,15 @@ When CANCELLABLE-ONLY is non-nil, omit invocations without owned work."
     (magent-action-session--record-parent-breadcrumb invocation status message)
     (magent-action-session-untrack invocation)
     (when (magent-action-invocation-interactive-p invocation)
-      (message "Magent %s %s: %s"
-               (magent-action-spec-name
-                (magent-action-invocation-spec invocation))
-               (magent-action-session--status-string status)
-               (or message (magent-action-session--session-id invocation))))
+      (let ((name (magent-action-spec-name
+                   (magent-action-invocation-spec invocation)))
+            (status-text (magent-action-session--status-string status)))
+        (if (eq status 'completed)
+            (message "Magent %s %s" name status-text)
+          (message "Magent %s %s: %s"
+                   name status-text
+                   (or message
+                       (magent-action-session--session-id invocation))))))
     fallback))
 
 (defun magent-action-session-untrack (invocation)

--- a/lisp/magent-action.el
+++ b/lisp/magent-action.el
@@ -973,11 +973,16 @@ Project Action files are not currently supported."
        (magent-log "ERROR Action observer failed: %s"
                    (error-message-string err))))))
 
-(defun magent-action-progress (invocation message)
-  "Report progress MESSAGE for active Action INVOCATION."
+(defun magent-action-progress (invocation message &rest properties)
+  "Report progress MESSAGE with PROPERTIES for active Action INVOCATION.
+PROPERTIES is an optional keyword plist appended to the observer event."
   (unless (eq (magent-action-invocation-status invocation) 'active)
     (error "Magent Action invocation is no longer active"))
-  (magent-action--notify invocation 'action-progress :text message)
+  (unless (magent-action--plist-p properties)
+    (error "Expected Magent Action progress properties plist, got: %S"
+           properties))
+  (apply #'magent-action--notify invocation 'action-progress
+         :text message properties)
   invocation)
 
 (defun magent-action--record-message

--- a/lisp/magent-session.el
+++ b/lisp/magent-session.el
@@ -1269,7 +1269,7 @@ message boundary."
                (equal (magent-thread-turn-id turn) current-turn-id))))
     (and (not workflow-control)
          (or (not workflow-activity) current-p)
-         (or (eq status 'completed)
+         (or (memq status '(completed interrupted))
              (and current-p (memq status '(queued in-progress)))))))
 
 (defun magent-session--compaction-turn-p (turn)
@@ -1300,10 +1300,12 @@ Returns a list in gptel's advanced format:
 Structured tool result messages are emitted as `(tool . PLIST)' entries so
 gptel can serialize historical tool calls/results for the active backend.
 
-Only completed turns are reused.  When an assistant reply is empty or a
-synthetic error string, Magent drops both that reply and its paired user
-prompt from future prompt reuse.  The final pending user prompt is still
-included so the current turn is preserved.
+Completed turns are reused in full.  Interrupted turns retain their user
+prompt and completed tool results, but discard any partial assistant reply so
+a follow-up such as \"continue\" can recover the cancelled request context.
+When a completed assistant reply is empty or a synthetic error string, Magent
+drops both that reply and its paired user prompt from future prompt reuse.  The
+final pending user prompt is still included so the current turn is preserved.
 
 When CURRENT-TURN-ID is non-nil, prompt generation stops after that turn.
 This prevents later queued user submissions from leaking into the active

--- a/test/magent-live-test.el
+++ b/test/magent-live-test.el
@@ -749,22 +749,33 @@ return that path."
               (setq buffer (get-buffer "*Magent Doctor*"))
               (should (buffer-live-p buffer))
               (with-current-buffer buffer
-                (should (derived-mode-p 'special-mode))
+                (should (derived-mode-p 'org-mode))
                 (should buffer-read-only)
                 (goto-char (point-min))
                 (should (search-forward "Status: Running" nil t))
-                (should (search-forward "Running doctor probe" nil t)))
+                (should (search-forward "* Environment\n** Runtime" nil t))
+                (should (search-forward "Magent version" nil t))
+                (should (search-forward "** Doctor model" nil t))
+                (goto-char (point-min))
+                (should (search-forward "* Tasks" nil t))
+                (should (search-forward
+                         "Probe results are bounded and redacted" nil t))
+                (should (search-forward "** DONE probe" nil t))
+                (should-not (search-forward "Used in diagnosis:" nil t)))
               (magent-live-test--wait-until
                (lambda ()
                  (with-current-buffer buffer
-                   (goto-char (point-min))
-                   (search-forward "Status: Completed" nil t)))
+                   (save-excursion
+                     (goto-char (point-min))
+                     (search-forward "Status: Completed" nil t))))
                5
                "M-x Doctor did not complete in its progress buffer")
               (with-current-buffer buffer
+                (should (looking-at-p "\\* Diagnosis"))
                 (goto-char (point-min))
                 (should (search-forward "* Diagnosis" nil t))
-                (should (search-forward "Healthy" nil t)))))
+                (should (search-forward "Healthy" nil t))
+                (should-not (invisible-p (1- (point)))))))
         (when (buffer-live-p buffer)
           (kill-buffer buffer))))))
 

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -1715,6 +1715,31 @@
                      (response . "A text editor.")
                      (prompt . "Tell me more."))))))
 
+(ert-deftest magent-test-session-provider-context-keeps-interrupted-user-turns ()
+  "Test a follow-up can recover an interrupted turn's user context."
+  (require 'magent-session)
+  (let* ((session (magent-session-create))
+         (thread (magent-session-thread-ledger session))
+         (interrupted (magent-thread-create-turn thread "Original request"))
+         (interrupted-id (magent-thread-turn-id interrupted))
+         (partial-assistant
+          (magent-thread-ensure-message-item
+           thread interrupted-id 'assistant)))
+    (magent-thread-record-user-message-if-needed
+     thread interrupted-id "Original request")
+    (magent-thread-append-item-content
+     thread partial-assistant "Incomplete response")
+    (magent-thread-cancel-item thread partial-assistant "Cancelled")
+    (magent-thread-interrupt-turn thread interrupted-id "Cancelled")
+    (let* ((current (magent-thread-create-turn thread "Continue"))
+           (current-id (magent-thread-turn-id current)))
+      (magent-thread-record-user-message-if-needed
+       thread current-id "Continue")
+      (should
+       (equal (magent-test--provider-context session current-id)
+              '((prompt . "Original request")
+                (prompt . "Continue")))))))
+
 (ert-deftest magent-test-session-get-id ()
   "Test session ID generation."
   (require 'magent-session)
@@ -2426,7 +2451,7 @@
          (magent-session--scoped-sessions (make-hash-table :test #'equal))
          (parent (magent-session-create :id "session-parent"))
          (new-current (magent-session-create :id "session-new"))
-         captured finish)
+         captured finish messages)
     (unwind-protect
         (progn
           (magent-session-install 'global parent)
@@ -2450,13 +2475,17 @@
                     ((symbol-function 'magent-runtime-prepare-context)
                      #'ignore)
                     ((symbol-function 'magent-session-save-deferred-for-session)
-                     #'ignore))
+                     #'ignore)
+                    ((symbol-function 'message)
+                     (lambda (format-string &rest args)
+                       (push (apply #'format format-string args) messages))))
             (magent-action-run "async-test")
             (magent-session-install "/tmp/magent-other-project" new-current)
             (funcall finish 'completed "Async test complete"))
           (should (eq magent--current-session new-current))
           (should (equal magent-session--current-scope
                          "/tmp/magent-other-project"))
+          (should (equal messages '("Magent async-test completed")))
           (should-not (magent-action-session-active-invocations)))
       (delete-directory magent-session-directory t))))
 
@@ -2572,6 +2601,28 @@
           (should (eq (magent-sampling-request-model request)
                       'doctor-model))
           (should (equal route-args (list runtime nil 'doctor)))
+          (let* ((plan-event
+                  (cl-find-if
+                   (lambda (event)
+                     (eq (plist-get (plist-get event :doctor-update) :kind)
+                         'plan))
+                   events))
+                 (membership-event
+                  (cl-find-if
+                   (lambda (event)
+                     (let ((update (plist-get event :doctor-update)))
+                       (and (equal (plist-get update :id) "safe")
+                            (eq (plist-get update :llm-state) 'included))))
+                   events))
+                 (prompt (magent-sampling-request-prompt request)))
+            (should plan-event)
+            (should membership-event)
+            (should-not
+             (plist-member (plist-get membership-event :doctor-update)
+                           :llm-input))
+            (should (string-match-p
+                     (regexp-quote "\\\"ok\\\":true")
+                     prompt)))
           (should (eq (car completion) 'completed))
           (should (cl-find 'assistant-delta events
                            :key (lambda (event) (plist-get event :type))))
@@ -2579,6 +2630,76 @@
                  (meta (magent-session--read-file-metadata-cached file)))
             (should (equal (plist-get meta :status) "completed"))))
       (delete-directory magent-session-directory t))))
+
+(ert-deftest magent-test-doctor-confirm-reuses-interactive-buffer ()
+  "Doctor preflight shares the interactive Org buffer with progress."
+  (require 'magent-action-builtin-doctor)
+  (let ((magent-bypass-permission nil)
+        (magent-doctor--registry (make-hash-table :test #'equal))
+        buffer)
+    (unwind-protect
+        (progn
+          (magent-doctor--register-builtins)
+          (cl-letf (((symbol-function 'display-buffer)
+                     (lambda (value &rest _) value)))
+            (setq buffer (magent-doctor--interactive-buffer)))
+          (let ((context
+                 (magent-action-invocation-create
+                  :options (list :interactive-buffer buffer)
+                  :origin-buffer (current-buffer)
+                  :origin-directory default-directory))
+                (route (magent-model-route-create
+                        :backend 'test-backend
+                        :model 'test-model
+                        :source 'test
+                        :phase 'doctor)))
+            (cl-letf (((symbol-function 'yes-or-no-p) (lambda (&rest _) t)))
+              (should
+               (magent-doctor--confirm
+                context (list (gethash "core-runtime"
+                                       magent-doctor--registry))
+                route)))
+            (with-current-buffer buffer
+              (goto-char (point-min))
+              (should-not (search-forward "Magent Doctor Preflight" nil t))
+              (should (search-forward "* Preflight" nil t))
+              (should (search-forward "Provider: " nil t))
+              (should-not (invisible-p (1- (point)))))
+            (magent-doctor--interactive-observe
+             buffer
+             '(:type action-progress
+               :text "Prepared Doctor task plan."
+               :doctor-update
+               (:kind plan
+                :tasks ((:id "core-runtime"
+                         :kind probe
+                         :title "probe core-runtime"
+                         :description "Core runtime facts."
+                         :status pending
+                         :llm-state pending))
+                :model-info (("Model" . "test-model"))))))
+          (should-not (get-buffer "*Magent Doctor Preflight*"))
+          (with-current-buffer buffer
+            (should (derived-mode-p 'org-mode))
+            (should buffer-read-only)
+            (goto-char (point-min))
+            (should
+             (looking-at-p
+              (regexp-quote
+               "#+title: Magent Doctor\n#+startup: content\n")))
+            (should-not (search-forward "* Magent Doctor" nil t))
+            (goto-char (point-min))
+            (let ((tasks (search-forward "* Tasks" nil t))
+                  (diagnosis (search-forward "* Diagnosis" nil t))
+                  (environment (search-forward "* Environment" nil t))
+                  (preflight (search-forward "* Preflight" nil t)))
+              (should (< tasks diagnosis environment preflight)))
+            (goto-char (point-min))
+            (should (search-forward "* Environment\n** Runtime" nil t))
+            (goto-char (point-min))
+            (should (search-forward "** TODO probe core-runtime" nil t))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
 
 (ert-deftest magent-test-doctor-action-unsafe-probe-fails-before-sampling ()
   "Doctor rejects unsafe probe values before provider sampling."
@@ -4380,7 +4501,7 @@
      :workflow
      (iter-lambda (value)
        (setq invocation value)
-       (magent-action-progress value "phase one")
+       (magent-action-progress value "phase one" :phase-id "one")
        (magent-workflow-callback
            "Wait" (lambda (callback) (setq done callback) #'ignore))))
     (magent-test--without-action-step-ledger
@@ -4390,8 +4511,11 @@
        :on-complete
        (lambda (status result) (setq completion (list status result))))
       (should (eq (magent-action-invocation-status invocation) 'active))
-      (should (cl-find 'action-progress events
-                       :key (lambda (e) (plist-get e :type))))
+      (let ((progress
+             (cl-find 'action-progress events
+                      :key (lambda (e) (plist-get e :type)))))
+        (should progress)
+        (should (equal (plist-get progress :phase-id) "one")))
       (funcall done 'completed "finished"))
     (should (eq (car completion) 'completed))
     (should (equal (magent-execution-result-content-string (cadr completion))
@@ -11413,7 +11537,30 @@
                      (let ((observer (plist-get args :observer)))
                        (funcall observer
                                 '(:type action-progress
-                                  :text "Running doctor probe test..."))
+                                  :text "Prepared Doctor task plan."
+                                  :doctor-update
+                                  (:kind plan
+                                   :tasks
+                                   ((:id "test"
+                                     :kind probe
+                                     :title "probe test"
+                                     :description
+                                     "A bounded test probe."
+                                     :related-buffers ("*Messages*")
+                                     :status pending
+                                     :llm-state pending))
+                                   :model-info
+                                   (("Backend" . "Test Provider")
+                                    ("Model" . "test-model")
+                                    ("Provider tools" . "disabled")))))
+                       (funcall observer
+                                '(:type action-progress
+                                  :text "Doctor task test completed."
+                                  :doctor-update
+                                  (:kind task
+                                   :id "test"
+                                   :status completed
+                                   :llm-state included)))
                        (funcall observer
                                 (list :type 'assistant-delta
                                       :text "* Diagnosis\nHealthy"))
@@ -11428,15 +11575,158 @@
           (should (equal (car captured) "doctor"))
           (should (functionp (plist-get (cdr captured) :observer)))
           (should (buffer-live-p displayed))
+          (should
+           (eq (plist-get (plist-get (cdr captured) :options)
+                          :interactive-buffer)
+               displayed))
           (with-current-buffer displayed
-            (should (derived-mode-p 'special-mode))
+            (should (derived-mode-p 'org-mode))
             (should buffer-read-only)
+            (should (looking-at-p "\\* Diagnosis"))
             (goto-char (point-min))
             (should (search-forward "Status: Completed" nil t))
-            (should (search-forward "Running doctor probe test..." nil t))
-            (should (search-forward "* Diagnosis\nHealthy" nil t))))
+            (should (search-forward "* Environment\n** Runtime" nil t))
+            (should (search-forward "Magent version" nil t))
+            (should (search-forward "** Doctor model" nil t))
+            (should (search-forward "Test Provider" nil t))
+            (goto-char (point-min))
+            (should (search-forward
+                     "Probe results are bounded and redacted" nil t))
+            (should (search-forward "** DONE probe test" nil t))
+            (should-not (search-forward "Used in diagnosis:" nil t))
+            (goto-char (point-min))
+            (should (search-forward "Related buffers: *Messages*" nil t))
+            (let ((button (button-at (1- (point)))))
+              (should (markerp button))
+              (should (equal (button-get button 'magent-doctor-buffer-name)
+                             "*Messages*")))
+            (goto-char (point-min))
+            (should-not (search-forward "Cancel: " nil t))
+            (goto-char (point-min))
+            (should (search-forward "* Diagnosis\nHealthy" nil t))
+            (should-not (invisible-p (1- (point))))))
       (when (buffer-live-p displayed)
         (kill-buffer displayed)))))
+
+(ert-deftest magent-test-doctor-task-kill-cancels-whole-invocation ()
+  "KILL on a pending Doctor task cancels the attached Doctor invocation."
+  (require 'magent-action-builtin-doctor)
+  (let* ((spec (magent-action-spec-create :name "doctor"))
+         (invocation (magent-action-invocation-create
+                      :id "doctor-kill-test"
+                      :spec spec))
+         buffer cancelled)
+    (unwind-protect
+        (progn
+          (cl-letf (((symbol-function 'display-buffer)
+                     (lambda (value &rest _) value)))
+            (setq buffer (magent-doctor--interactive-buffer)))
+          (with-current-buffer buffer
+            (setq magent-doctor--interactive-invocation invocation)
+            (magent-doctor--interactive-observe
+             buffer
+             '(:type action-progress
+               :text "Prepared Doctor task plan."
+               :doctor-update
+               (:kind plan
+                :tasks ((:id "probe-one"
+                         :kind probe
+                         :title "probe probe-one"
+                         :description "Read-only test probe."
+                         :status pending
+                         :llm-state pending))
+                :model-info (("Model" . "test-model")))))
+            (goto-char (point-min))
+            (should (search-forward
+                     "Mode: isolated Action; provider tools disabled.\n"
+                     nil t))
+            (should (search-forward
+                     "Cancel: C-c C-t on a TODO task (marks KILL), " nil t))
+            (should (search-forward "* Tasks" nil t))
+            (goto-char (point-min))
+            (should (search-forward "** TODO probe probe-one" nil t))
+            (cl-letf (((symbol-function 'magent-action-cancel)
+                       (lambda (value reason)
+                         (setq cancelled (list value reason)))))
+              (magent-doctor-task-kill))
+            (goto-char (point-min))
+            (should (search-forward "** KILL probe probe-one" nil t)))
+          (should (eq (car cancelled) invocation))
+          (should (string-match-p "probe-one" (cadr cancelled))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest magent-test-doctor-failure-keeps-task-outcomes-truthful ()
+  "A failed Doctor run distinguishes failed work from unstarted work."
+  (require 'magent-action-builtin-doctor)
+  (let (buffer)
+    (unwind-protect
+        (progn
+          (cl-letf (((symbol-function 'display-buffer)
+                     (lambda (value &rest _) value)))
+            (setq buffer (magent-doctor--interactive-buffer)))
+          (with-current-buffer buffer
+            (setq magent-doctor--interactive-tasks
+                  '((:id "done" :kind probe :title "probe done"
+                     :status completed :llm-state included)
+                    (:id "running" :kind probe :title "probe running"
+                     :status running :llm-state pending)
+                    (:id "pending" :kind probe :title "probe pending"
+                     :status pending :llm-state pending)))
+            (magent-doctor--interactive-observe
+             buffer
+             (list :type 'action-completed
+                   :status 'failed
+                   :result (magent-execution-result-failed
+                            "Analysis failed")))
+            (should (looking-at-p "\\* Diagnosis"))
+            (goto-char (point-min))
+            (should (search-forward "Status: Failed (3/3)" nil t))
+            (should (search-forward "** DONE probe done" nil t))
+            (should (search-forward "** FAIL probe running" nil t))
+            (should (search-forward "** KILL probe pending" nil t))
+            (goto-char (point-min))
+            (should (search-forward "* Diagnosis\nAnalysis failed" nil t))
+            (should-not (invisible-p (1- (point))))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest magent-test-doctor-session-id-is-followable-org-link ()
+  "The Doctor session id is an Org link to its persisted Action session."
+  (require 'magent-action-builtin-doctor)
+  (require 'magent-action-session-view)
+  (let* ((magent-session-directory (make-temp-file "magent-doctor-link-" t))
+         (magent-action-session-directory nil)
+         (id "session-doctor-link")
+         (directory (magent-session-action-directory "doctor"))
+         (file (expand-file-name (concat id ".json") directory))
+         buffer opened)
+    (unwind-protect
+        (progn
+          (make-directory directory t)
+          (with-temp-file file
+            (insert "{}"))
+          (cl-letf (((symbol-function 'display-buffer)
+                     (lambda (value &rest _) value)))
+            (setq buffer (magent-doctor--interactive-buffer)))
+          (with-current-buffer buffer
+            (setq magent-doctor--interactive-session-id id)
+            (magent-doctor--interactive-render buffer)
+            (goto-char (point-min))
+            (let* ((link (format "[[magent-session:%s][%s]]" id id))
+                   (start (search-forward link nil t)))
+              (should start)
+              (goto-char (- start (length id) 2))
+              (should (equal
+                       (org-link-get-parameter "magent-session" :follow)
+                       #'magent-doctor--interactive-open-session-link))
+              (cl-letf (((symbol-function 'magent-action-open-session)
+                         (lambda (value) (setq opened value))))
+                (org-open-at-point))))
+          (should (equal opened file)))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer))
+      (delete-directory magent-session-directory t))))
 
 (ert-deftest magent-test-acp-request-sender-initialize ()
   "Test in-process ACP request sender handles initialize."

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -11608,6 +11608,23 @@
       (when (buffer-live-p displayed)
         (kill-buffer displayed)))))
 
+(ert-deftest magent-test-doctor-library-version-uses-emacs-29-api ()
+  "Doctor reads Package-Version without newer `lisp-mnt' helpers."
+  (require 'magent-action-builtin-doctor)
+  (let ((source (make-temp-file "magent-doctor-version-" nil ".el")))
+    (unwind-protect
+        (progn
+          (with-temp-file source
+            (insert ";;; example.el --- Example\n"
+                    ";; Package-Version: 1.2.3\n"
+                    ";;; example.el ends here\n"))
+          (cl-letf (((symbol-function 'locate-library)
+                     (lambda (_library) source))
+                    ((symbol-function 'lm-package-version) nil))
+            (should (equal (magent-doctor--library-version "example")
+                           "1.2.3"))))
+      (delete-file source))))
+
 (ert-deftest magent-test-doctor-task-kill-cancels-whole-invocation ()
   "KILL on a pending Doctor task cancels the attached Doctor invocation."
   (require 'magent-action-builtin-doctor)


### PR DESCRIPTION
## Summary

- Render Doctor preflight, structured task state, runtime/model metadata, and diagnosis in one read-only Org buffer.
- Add cancellable task headings, related-buffer navigation, and a followable persisted-session Org link while keeping provider input bounded and hidden.
- Preserve interrupted user prompts for follow-up recovery and shorten successful isolated Action completion messages.
- Validate with compilation, declaration/package lint, 616 unit tests, and isolated live Emacs smoke tests.