### PR TITLE
refactor!: simplify request context and project scope resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ magent.el (package entry point and lazy runtime bootstrap)
   ├─ magent-config.el            (UI-neutral runtime and feature defcustoms)
   ├─ magent-json.el              (JSON-safe serialization helpers)
   ├─ magent-redaction.el         (fail-closed Magent-owned outbound redaction)
-  ├─ magent-runtime.el           (static init + project overlay activation)
+  ├─ magent-runtime.el           (static init + retained project definition loading)
   ├─ magent-protocol.el          (wire protocol types and event normalization)
   ├─ magent-lifecycle-events.el  (lifecycle event sinks and context helpers)
   ├─ magent-ledger.el            (thread/turn/item state machine, journal, snapshot)
@@ -132,13 +132,13 @@ magent.el (package entry point and lazy runtime bootstrap)
   ├─ magent-agent.el             (magent-agent-run-turn: builds prompts and starts the Magent loop)
   ├─ magent-agent-info.el        (agent metadata struct and helpers)
   ├─ magent-agent-builtins.el    (7 built-in agent definitions)
-  ├─ magent-agent-registry.el    (hash-table registry and project overlays)
+  ├─ magent-agent-registry.el    (scope-aware registry and project definitions)
   ├─ magent-agent-file.el        (loads custom agents from .magent/agent/*.md)
   ├─ magent-permission.el        (rule-based tool access control per agent)
   ├─ magent-acp.el               (in-process ACP adapter for agent-shell)
   ├─ magent-agent-shell.el       (agent-shell config and isolated context compatibility)
   ├─ magent-file-loader.el       (shared file-backed definition loader and frontmatter parser)
-  ├─ magent-skills.el            (skill registry, built-in definitions, overlays, and descriptors)
+  ├─ magent-skills.el            (scope-aware skill registry, definitions, and descriptors)
   └─ magent-skill-manager.el     (lazy user skill discovery, installation, and deletion)
 ```
 
@@ -146,7 +146,7 @@ magent.el (package entry point and lazy runtime bootstrap)
 
 1. **Entry point** (`magent.el`, `magent-agent-shell.el`): `magent.el` loads the package; supported interaction starts with the compatibility command `magent-start` or Magent selected from `agent-shell`. Static initialization is **lazy** — triggered on the first supported command.
 
-2. **Runtime** (`magent-runtime.el`): Owns the ordered initialization pipeline for agents, skills, slash commands, and capabilities. Static bundled definitions load once; project-local overlays under `.magent/` are activated and unloaded as session scope changes.
+2. **Runtime** (`magent-runtime.el`): Owns the ordered initialization pipeline for agents, skills, slash commands, and capabilities. Static bundled definitions load once. Project-local definitions under `.magent/` remain registered by canonical project scope; request paths resolve agents, skills, capabilities, and Actions against the runtime session's exact scope instead of unloading another project's definitions when the interactive context changes.
 
 3. **Actions** (`magent-action.el`, `magent-action-builtins.el`, `magent-action-session.el`, `magent-action-session-view.el`): Elisp-native Actions are registered through `magent-action-register`; slash commands and interactive commands are frontend projections. `:exposure` selects the projections, while `:session-policy` selects the current conversation or an isolated durable Action session. One deep Action module owns the generator Workflow DSL, managed Step runtime, layered registry, and Invocation lifecycle. Trusted Elisp owns control flow while managed agent, Answer, argv process, and callback Steps provide asynchronous suspension, exact-submission cancellation, and ledger activity. Elisp feature dependencies are declared with `:requires`; an agent Step's `:tools` is its exact provider allowlist, and Actions have no project-workspace requirement. Definitions resolve by `core > project > user > package > builtin`, and core names are reserved. ACP resolves slash discovery and dispatch against each runtime session's exact scope. Terminal results are claimed before cleanup, and finalization errors remain terminal failures.
 
@@ -154,13 +154,14 @@ magent.el (package entry point and lazy runtime bootstrap)
 
 5. **Supported frontend boundary** (`magent-agent-shell.el`, `magent-acp.el`, `magent-runtime-api.el`): `magent-agent-shell.el` supplies the agent-shell config, the sole compatibility command `magent-start`, and one isolated private context-compatibility block; it does not own buffer selection, prompt submission, queues, skills, Actions, busy-state recovery, or interruption. The config uses an in-process ACP client implemented by `magent-acp.el`. ACP routes registered slash input through `magent-action.el`, submits model turns through `magent-runtime-api.el`, and converts runtime observer events to ACP `session/update` messages. ACP prompt requests remain pending until the corresponding command invocation or ordinary Magent turn completes, fails, or is cancelled.
    - `magent-runtime-queue.el` owns the global single-execution queue and session-scoped cancellation
+   - `magent-runtime-api.el` freezes one `magent-request-context` per submission before queueing; the queue stores only lifecycle state and that context
    - Runtime emits Magent-native observer events; ACP conversion is isolated in `magent-acp.el`
    - ACP text/resource blocks are stored as structured turn metadata and reconstructed as user-role prompt context; local `file://` resources also provide scoped request paths
    - ACP session config exposes a per-session `Automatic capabilities` switch
    - `magent-agent-run-turn` is the backend entry point
    - See `docs/UI_BACKENDS.org` for the boundary contract
 
-6. **Agent processing** (`magent-agent.el`): `magent-agent-run-turn` is the UI-neutral entry point for runtime backends. Its internal execution path builds a gptel prompt list from the session, discovers applicable `AGENTS.md` files from project root toward request-local resources within a bounded project scope, collects ordered trusted request context from `magent-context-provider-functions`, applies per-agent overrides (model, temperature via `default-value` — intentionally avoids buffer-local gptel settings), resolves the request's exact tool names through the canonical catalog and agent permissions, then starts `magent-agent-loop`.
+6. **Agent processing** (`magent-agent.el`): `magent-agent-run-turn` is the UI-neutral entry point and accepts one canonical `magent-request-context`. Its internal execution path builds a gptel prompt list from the captured session, discovers applicable `AGENTS.md` files from project root toward request-local resources within a bounded project scope, collects ordered trusted request context from `magent-context-provider-functions`, applies per-agent overrides (model, temperature via `default-value` — intentionally avoids buffer-local gptel settings), resolves the request's exact tool names through the canonical catalog and agent permissions, then starts `magent-agent-loop`.
 
 7. **Tools** (`magent-tools.el`): one canonical catalog owns 16 `gptel-tool` structs, their names, permission keys, approval policies, and locality (`local`, `tramp-file`, or `project-process`) — `read_file`, `write_file`, `edit_file`, `grep`, `glob`, `bash`, `emacs_read`, `emacs_eval`, `emacs_eval_live`, `read_tool_output`, `spawn_agent`, `send_agent_message`, `wait_agent`, `list_agents`, `close_agent`, `web_search`. The control plane remains local for TRAMP projects. File tools use local Emacs file APIs through TRAMP; only `bash` and `grep` may start project-host processes, through the explicit project-process launcher, with no local-host fallback. Search prefers ripgrep and falls back on the same host to `git grep --no-index --exclude-standard`; it fails explicitly when neither exists. `read_file` requires `source=disk|live-buffer` and emits a revision; writes require the expected revision. `emacs_eval` uses a fresh local child Emacs and passes a remote project root as data, `emacs_read` provides fixed live queries, and `emacs_eval_live` is the explicit dangerous live escape hatch. Both arbitrary eval tools require once-only approval. Oversized results spill to session-private storage and are paged through `read_tool_output`. All implementations and persisted tool items use `magent-tool-result`; unstructured strings are rejected. `glob` traverses in bounded event-loop slices without following directory symlinks. Child-agent tools share `agent`; their runtime registry and event-driven wait observers live in `magent-agent-job.el`, and parent persistence is deferred. `web_search` uses DuckDuckGo via `url-retrieve` + `libxml-parse-html-region` (requires Emacs built with `--with-xml2`).
 
@@ -168,11 +169,11 @@ magent.el (package entry point and lazy runtime bootstrap)
 
 9. **Permissions** (`magent-permission.el`): Rules map tool names to `allow`/`deny`/`ask`, with optional file-pattern sub-rules (glob syntax). Resolution: exact tool match → file-pattern rules → wildcard (`*`) fallback → **default allow**. File-pattern rules are order-dependent (first match wins); more specific patterns must come before less specific ones.
 
-10. **Capabilities** (`magent-capability.el`): File-backed capability definitions score the current request context and attach matching instruction skills. Automatic activation requires a word-bounded prompt-keyword intent match in addition to context score; context-only matches remain suggested, and linked skills are filtered against the selected agent's exposed tools. Bundled, user, and project-local capability overlays all feed the same resolver.
+10. **Capabilities** (`magent-capability.el`): File-backed capability definitions score the current request context and attach matching instruction skills. Automatic activation requires a word-bounded prompt-keyword intent match in addition to context score; context-only matches remain suggested, and linked skills are filtered against the selected agent's exposed tools. Bundled, user, and scoped project-local capability definitions all feed the same resolver.
 
 11. **Session and workflow ledger** (`magent-ledger.el`, `magent-session.el`): The canonical agent workflow state is an explicit thread/turn/item ledger. Thread statuses are `not-loaded`, `idle`, `active`, `system-error`, and `closed`; turn statuses are `queued`, `in-progress`, `completed`, `interrupted`, `failed`, and `dropped`; item statuses are `pending`, `in-progress`, `completed`, `failed`, and `cancelled`. Tool call/result is one `tool` item lifecycle keyed by call id. Session JSON schema v6 is atomically replaced with a materialized `snapshot` and a bounded journal tail; other schemas and unknown fields are rejected. Consumers select explicit `ledger`, `transcript`, `provider`, `compaction`, or `audit` views. `agent-jobs` stores durable child-agent metadata. Action turns retain Action metadata. Isolated Action sessions are persisted under `actions/` and excluded from normal conversation listings.
 
-12. **Skills** (`magent-skills.el`): Skills are instruction-only Markdown injected into the system prompt. Executable extensions belong in trusted Elisp Actions or first-class catalog tools; skills are never converted into Action adapters, and companion Elisp next to `SKILL.md` is not loaded. The module contains the registry, built-in `skill-creator`, file-based loading, and interactive inspection commands. Skills load in priority order from (1) built-in `skills/`, (2) user directory `~/.emacs.d/magent/skills/<name>/SKILL.md`, and (3) project-local `.magent/skills/<name>/SKILL.md`.
+12. **Skills** (`magent-skills.el`): Skills are instruction-only Markdown injected into the system prompt. Executable extensions belong in trusted Elisp Actions or first-class catalog tools; skills are never converted into Action adapters, and companion Elisp next to `SKILL.md` is not loaded. The module contains the registry, built-in `skill-creator`, file-based loading, and interactive inspection commands. Skills load in priority order from (1) built-in `skills/`, (2) user directories `~/.agents/skills/<name>/SKILL.md` then `~/.emacs.d/magent/skills/<name>/SKILL.md`, and (3) project-local `.agents/skills/<name>/SKILL.md` then `.magent/skills/<name>/SKILL.md`.
 
 ### Gotchas
 
@@ -198,11 +199,13 @@ Custom agents: `.magent/agent/*.md` files with YAML frontmatter + markdown body 
 name: skill-name
 description: Brief description
 tools: [bash, read_file]
-type: instruction        # the only supported type
+type: instruction        # optional; the only supported explicit type
 requires-project: true   # optional: reject use from a global session
 ---
 
-Markdown body: system-prompt instructions. `type` must be `instruction`.
+Markdown body: system-prompt instructions. `name` and `description` are
+required. Omitted `type` defaults to `instruction`; an explicit `type` must be
+`instruction`. Known Codex host metadata is accepted but remains passive.
 ```
 
 ### Configuration

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -28,6 +28,15 @@ intentional tagged release is planned as ~v0.2.0~.
 
 ** Changed
 
+- Runtime submissions now contain only queue lifecycle state and one canonical
+  request context.  Prompt, request-local agent, tools, skills, model route,
+  effort, approvals, observer, and turn identity are frozen once in that
+  context, which is the sole input to ~magent-agent-run-turn~.
+- Project-local agent, skill, capability, and Action definitions now remain
+  keyed by canonical project scope. Request execution resolves the exact
+  runtime session scope, eliminating active-overlay registry swaps and the
+  parallel skill descriptor cache while allowing concurrent project sessions
+  to coexist safely.
 - Replaced the Emacs-profile-specific prompt dependency with the generic
   ~magent-context-provider-functions~ extension point. Trusted local providers
   contribute ordered request context without making optional failures fatal to
@@ -56,6 +65,18 @@ intentional tagged release is planned as ~v0.2.0~.
 
 ** Fixed
 
+- Classify synchronous Doctor provider-start failures at the direct sampling
+  boundary. Invalid nil text from gptel configuration now points to the
+  selected backend's API key/auth-source callback or proxy configuration
+  instead of surfacing only ~Wrong type argument: stringp, nil~.
+- Accept Codex-compatible ~SKILL.md~ frontmatter with only ~name~ and
+  ~description~, default omitted ~type~ to ~instruction~, tolerate known
+  host-only metadata without granting it Magent semantics, and discover both
+  user and project-local ~.agents/skills~ roots alongside Magent's native
+  skill directories.
+- Attribute tool and approval audit records to the request-local agent instead
+  of the session's selected agent when Actions, compaction, or child execution
+  choose a different agent for one turn.
 - Render interactive Doctor preflight, runtime and model-route metadata,
   structured ~TODO~ / ~DONE~ / ~FAIL~ / ~KILL~ tasks, persisted-session and
   related-buffer links, and results in one read-only Org buffer.  Persisted

--- a/README.org
+++ b/README.org
@@ -307,6 +307,11 @@ workflow associates sessions with the current project:
 - Outside any project, Magent falls back to the global session behavior and saves directly under ~magent-session-directory~.
 - Permission decisions and sensitive tools are audited only in the live ~*magent-audit*~ buffer by default. Set ~magent-audit~ to nil to disable recording or to a file path to append JSONL records.
 
+Project-local agent, skill, capability, and Action definitions remain keyed by
+canonical project scope. Each request resolves definitions against its exact
+runtime session scope, so preparing another project does not rewrite the
+meaning of an already queued or active request.
+
 ** Slash Commands And Skills
 
 Instruction skills can be selected as one-shot context for the next request.
@@ -347,6 +352,14 @@ All skills are instruction-only and data-only. For executable extensions, use
 a trusted Elisp command or add a first-class tool to Magent's canonical tool
 catalog; companion Elisp next to ~SKILL.md~ is never loaded.
 
+Magent accepts the Codex skill contract: ~name~ and ~description~ are required,
+while an omitted ~type~ defaults to ~instruction~. Known host-only fields such
+as ~license~, ~metadata~, and ~disable-model-invocation~ are accepted as passive
+compatibility metadata and do not change Magent behavior. User skills are read
+from ~~/.agents/skills/~ before ~~/.emacs.d/magent/skills/~; project skills are
+read from ~.agents/skills/~ before ~.magent/skills/~. Later roots take
+precedence when names collide.
+
 ** User Skill Management
 
 Use ~M-x magent-find-skill~ to search skills.sh.  The finder shows the ten
@@ -362,11 +375,11 @@ execute copied scripts, and records provenance in ~.magent-install.json~.
 one ~y/n~ confirmation.  These commands never manage project-local
 ~.magent/skills/~ or ~~/.agents/skills/~.
 
-~magent-skill-directories~ is ordered: later directories take precedence when
-skill names collide, and its final entry is the installation target used by the
-skill manager.  Append a custom directory to retain the default roots while
-making the custom directory the highest-priority source and installation
-target:
+~magent-skill-directories~ contains user-level roots and is ordered: later
+directories take precedence when skill names collide, and its final entry is
+the installation target used by the skill manager.  Append a custom directory
+to retain the default roots while making the custom directory the
+highest-priority source and installation target:
 
 #+begin_src elisp
 (add-to-list 'magent-skill-directories "/path/to/skills" t)

--- a/docs/AGENT_WORKFLOW.org
+++ b/docs/AGENT_WORKFLOW.org
@@ -147,8 +147,9 @@ is a bounded recovery tail. The two are not interchangeable.
 * Loop Flow
 
 1. UI submission enters ~magent-runtime-api.el~.
-2. ~magent-runtime-api.el~ creates a queued ledger turn and records the completed
-   user message item immediately.
+2. ~magent-runtime-api.el~ creates a queued ledger turn, records the completed
+   user message item, and freezes prompt, agent, tools, skills, route, effort,
+   observer, approval, and turn identity in one ~magent-request-context~.
 3. When the submission actually starts, ~magent-runtime-api.el~ transitions the
    turn to ~in-progress~.
 4. ~magent-agent-run-turn~ reuses that turn/user item idempotently instead
@@ -192,10 +193,11 @@ runtime API.  The runtime emits Magent-native observer events;
 ~magent-acp.el~ converts those events to ACP ~session/update~ messages.
 
 ~magent-runtime-queue.el~ owns queued/active turn state.  The first
-implementation uses one global active turn at a time, but submissions are
-tagged by runtime session id so cancellation is session-scoped: cancelling one
-ACP session removes that session's queued work and aborts its active turn
-without dropping other sessions' queued turns.
+implementation uses one global active turn at a time.  Each submission captures
+the exact runtime session wrapper plus its canonical request context, so
+cancellation is identity-scoped: cancelling one ACP session removes that
+session's queued work and aborts its active turn without dropping other
+sessions' queued turns.
 
 This agent-shell + ACP path is the complete conversational UI projection and
 slash-command surface.  Explicit ~M-x~ wrappers enter the same

--- a/docs/AGENT_WORKFLOW.zh.org
+++ b/docs/AGENT_WORKFLOW.zh.org
@@ -110,7 +110,7 @@ Replay 语义：
 * Loop Flow
 
 1. UI submission 进入 ~magent-runtime-api.el~ 。
-2. ~magent-runtime-api.el~ 创建 queued ledger turn，并立即记录 completed user message item。
+2. ~magent-runtime-api.el~ 创建 queued ledger turn、立即记录 completed user message item，并把 prompt、agent、tools、skills、route、effort、observer、approval 与 turn identity 一次冻结到唯一的 ~magent-request-context~ 中。
 3. submission 真正开始时， ~magent-runtime-api.el~ 把 turn 转成 ~in-progress~ 。
 4. ~magent-agent-run-turn~ 幂等复用该 turn/user item，不重复写用户消息。
 5. ~magent-agent-loop~ 消费 normalized LLM events。
@@ -129,7 +129,7 @@ Prompt reconstruction 是 ledger-driven。知道 current turn id 时，Magent �
 
 受支持的 frontend 是 agent-shell。 ~magent-agent-shell.el~ 创建由 ~magent-acp.el~ 实现的 in-process ACP client。ACP session/prompt request 把 registered slash command 分派给 ~magent-action.el~ ，普通 prompt 则直接提交 ~magent-runtime-api.el~ ；request 会保持 pending，直到对应 command invocation 或普通 runtime turn completed、failed 或 cancelled。Command-owned turn 和 workflow step 使用同一个 runtime API。Runtime 发出 Magent-native observer events； ~magent-acp.el~ 转换为 ACP ~session/update~ 消息。
 
-~magent-runtime-queue.el~ 负责 queued/active turn state。当前实现一次只有一个全局 active turn，但 submission 都带 runtime session id，所以 cancellation 是 session-scoped：取消一个 ACP session 会移除该 session 的 queued work 并 abort 该 session 的 active turn，不会丢掉其他 session 的 queued turns。
+~magent-runtime-queue.el~ 负责 queued/active turn state。当前实现一次只有一个全局 active turn。每个 submission 捕获精确 runtime session wrapper 和唯一 request context，因此 cancellation 按对象 identity 隔离：取消一个 ACP session 会移除该 session 的 queued work 并 abort 该 session 的 active turn，不会丢掉其他 session 的 queued turns。
 
 agent-shell + ACP 路径是完整的会话式 UI projection 和 slash-command surface。显式
 ~M-x~ wrapper 进入同一个 ~magent-action~ invocation lifecycle，不会形成另一套会话

--- a/docs/ARCHITECTURE.org
+++ b/docs/ARCHITECTURE.org
@@ -179,9 +179,14 @@ This catalog intentionally has no compatibility aliases:
 1. A user prompt enters through agent-shell as an ACP ~session/prompt~ request.
 2. ACP resolves a registered slash command projection against the runtime session's exact scope. Unknown slash input remains an ordinary prompt.
 3. The registered Action enters ~magent-action.el~ for argument handling, feature preflight, and session-policy setup, then starts its generator-backed Workflow. Process and callback Steps run outside the agent queue. Agent and terminal Answer Steps enter ~magent-runtime-api.el~; a plain prompt enters the same API directly.
-4. ~magent-runtime-api.el~ resolves the request-local agent and exact tool set, then records a queued turn and a completed user item.
+4. ~magent-runtime-api.el~ resolves the request-local agent and exact tool set,
+   freezes all execution inputs in one ~magent-request-context~, then records a
+   queued turn and a completed user item.  The submission itself retains only
+   queue lifecycle state, the exact runtime session, and that context.
 5. ~magent-runtime-queue.el~ starts the turn when the global execution slot is free.
-6. ~magent-agent.el~ chooses the session agent, active skills, capability instructions, and allowed tools.
+6. ~magent-agent.el~ consumes the canonical request context, resolves active
+   capability instructions, and starts the allowed tools without reconstructing
+   a parallel request specification.
 7. ~magent-sampling-gptel.el~ calls ~gptel-request~ for one sampling request.
 8. ~magent-agent-loop.el~ receives normalized text, reasoning, tool-call, and completion events.
 9. Tool calls are accumulated until ~tool-call-batch-end~, then dispatched serially through the orchestrator.
@@ -236,12 +241,12 @@ cleanup damage.
 ACP projects every instruction descriptor as ~$name~, which agent-shell renders
 as ~/$name~, and dispatches it as an ordinary runtime turn with an explicit
 skill selection. Skills never enter the Action registry and do not participate
-in the Action Invocation lifecycle. Project Action definitions and skill
-catalog snapshots remain keyed by canonical project scope; ACP resolves
-discovery and dispatch against each runtime session's exact scope, allowing
-multiple project sessions to coexist safely. A future frontend may consume the
-same descriptor API while presenting command projections and skills as
-separate surfaces.
+in the Action Invocation lifecycle. Project agent, skill, capability, and
+Action definitions remain registered with their canonical project scope; no
+parallel skill catalog snapshot is maintained. ACP and request execution
+resolve against each runtime session's exact scope, allowing multiple project
+sessions to coexist safely. A future frontend may consume the same descriptor
+API while presenting command projections and skills as separate surfaces.
 
 ~magent-action-session.el~ supplies persistence, ledger recording, inspection,
 and cancellation for Actions using ~:session-policy 'isolated~.
@@ -276,7 +281,7 @@ disabling this automatic layer without affecting explicitly selected skills.
 It searches skills.sh, resolves local or public GitHub sources, preflights and
 copies instruction skills into the canonical user directory, records
 provenance, and permanently deletes exact user-level installations. It is not
-a model tool, never manages project overlays, and never reads or writes
+a model tool, never manages project-local definitions, and never reads or writes
 ~~/.agents/skills/~.
 
 The distinction is:

--- a/docs/ARCHITECTURE.zh.org
+++ b/docs/ARCHITECTURE.zh.org
@@ -162,9 +162,9 @@ session 私有、带 TTL/quota 的 spill，只能凭 opaque id 通过 ~read_tool
 1. 用户 prompt 通过 agent-shell 进入 ACP ~session/prompt~ request。
 2. ACP 按 runtime session 的精确 scope 解析已注册 slash command projection；未知 slash input 仍作为普通 prompt。
 3. 对应 Action 进入 ~magent-action.el~，执行参数处理、feature preflight 和 session-policy 设置，然后启动 generator-backed Workflow。Process 和 callback Step 不进入 agent queue；agent 与 terminal Answer Step 进入 ~magent-runtime-api.el~，普通 prompt 则直接进入同一 API。
-4. ~magent-runtime-api.el~ 先解析 request-local agent 和精确 tool set，再记录 queued turn 和 completed user item。
+4. ~magent-runtime-api.el~ 先解析 request-local agent 和精确 tool set，把全部执行输入冻结到唯一的 ~magent-request-context~，再记录 queued turn 和 completed user item；submission 本身只保留 queue lifecycle、精确 runtime session 与该 context。
 5. ~magent-runtime-queue.el~ 在全局执行槽空闲时启动 turn。
-6. ~magent-agent.el~ 选择 session agent、active skills、capability instructions 和允许的工具。
+6. ~magent-agent.el~ 只消费 canonical request context，解析 active capability instructions，并启动允许的工具，不再重建一份并行 request specification。
 7. ~magent-sampling-gptel.el~ 调用 ~gptel-request~ 发起一次 sampling。
 8. ~magent-agent-loop.el~ 接收 normalized text、reasoning、tool-call 和 completion events。
 9. tool call 累积到 ~tool-call-batch-end~ 后，通过 orchestrator 串行执行。
@@ -213,11 +213,12 @@ Finalization error 是 terminal failure，不会伪装成成功结果。
 ~magent-skills.el~ 还拥有 frontend-neutral、scope-aware 的 skill descriptors。ACP
 会把每个 instruction descriptor 投影成 ~$name~，agent-shell 将其显示为
 ~/$name~，分派时则作为带显式 skill selection 的普通 runtime turn。该路径不要求
-Action Invocation lifecycle，也不会进入 Action registry。Project Action definitions
-与 skill catalog snapshot 都以 canonical project scope 为键保留；ACP 的发现和
-分派按每个 runtime session 的精确 scope 解析，因此多个 project session 可以安全
-共存。未来 frontend 可以消费同一 descriptor API，同时把 command projections 和
-skills 展示为两个独立入口。
+Action Invocation lifecycle，也不会进入 Action registry。Project agent、skill、
+capability 与 Action definitions 都携带 canonical project scope 并保留在各自
+registry 中，不再维护平行的 skill catalog snapshot。ACP 的发现、分派和 request
+execution 都按 runtime session 的精确 scope 解析，因此多个 project session 可以
+安全共存。未来 frontend 可以消费同一 descriptor API，同时把 command projections
+和 skills 展示为两个独立入口。
 
 ~magent-action-session.el~ 为 ~:session-policy 'isolated~ 的 Action 提供持久化、
 ledger 记录和取消；~magent-action-session-view.el~ 单独负责交互式列表与查看。
@@ -247,7 +248,7 @@ Keyword 使用词边界匹配；如果 linked skill 声明的工具对 selected 
 ~magent-skill-manager.el~ 是独立且按需加载的用户维护层：它搜索 skills.sh，
 解析本地或公开 GitHub source，预检后把 instruction skill 复制到 canonical 用户
 目录，记录 provenance，并永久删除精确选中的用户级安装。它不是 model tool，
-不会管理 project overlay，也绝不读写 ~~/.agents/skills/~。
+不会管理 project-local definitions，也绝不读写 ~~/.agents/skills/~。
 
 这些概念的区别是：
 

--- a/docs/DOCTOR.org
+++ b/docs/DOCTOR.org
@@ -42,6 +42,9 @@ but it does not install its Action session as the user's current session.
 ~/doctor~ follows the originating runtime session's effective model route;
 the M-x entry point falls back to the current gptel defaults.  Sampling uses
 gptel's streaming path while Doctor exposes only the completed diagnosis.
+If gptel fails synchronously before contacting the provider, Doctor classifies
+the failure at this boundary and reports actionable backend configuration
+guidance without collecting or displaying credential values.
 
 Doctor never intentionally collects a gptel backend object, API keys,
 ~auth-source~, environment variables, HTTP headers, or raw ~*gptel-log*~

--- a/docs/DOCTOR.zh.org
+++ b/docs/DOCTOR.zh.org
@@ -37,7 +37,8 @@ Provider request 不包含工具，也不进入普通 Magent agent loop 或 runt
 queue。它可以和普通对话并发，但不会把 Action session 安装成用户当前
 session。~/doctor~ 使用发起请求的 runtime session 的有效 model route；M-x
 入口回退到当前 gptel defaults。Sampling 使用 gptel streaming 路径，但 Doctor
-只公开完成后的诊断结果。
+只公开完成后的诊断结果。如果 gptel 在联系 provider 前同步失败，Doctor 会在
+这个边界分类失败并给出可操作的 backend 配置提示，而不会采集或显示凭据值。
 
 Doctor 不会主动采集 gptel backend 对象、API key、~auth-source~、环境变量、
 HTTP headers 或原始 ~*gptel-log*~。绝对路径会被规范化为 ~$PROJECT~、

--- a/docs/ONBOARDING.org
+++ b/docs/ONBOARDING.org
@@ -38,7 +38,7 @@ registry, skills, slash commands, and capabilities) happens on demand.
 
 ** Layer 2: Session & Runtime State Management
 
-Manages conversation history, scoped overlays, and runtime state.
+Manages conversation history, scoped definitions, and runtime state.
 
 *Key Files:*
 - ~magent-ledger.el~ — Thread/turn/item ledger, status transitions, snapshot shape
@@ -49,12 +49,12 @@ Manages conversation history, scoped overlays, and runtime state.
 - ~magent-redaction.el~ — Fail-closed redaction for Magent-owned outbound values
 - ~magent-agent-job.el~ — Durable child-agent job records and JSON shape
 - ~magent-action.el~ — Workflow DSL, Step runtime, layered Action registry, and Invocation lifecycle
-- ~magent-runtime.el~ — Static initialization plus project-local overlay activation for agents, skills, Actions, and capabilities
+- ~magent-runtime.el~ — Static initialization plus retained project-local definition loading
 - ~magent-runtime-api.el~ — UI/backend-facing runtime session and prompt API
 - ~magent-runtime-queue.el~ — Global single-execution runtime queue with session-scoped cancellation
 - ~magent-audit.el~ — Live-buffer or JSONL-file audit recording for permissions and sensitive actions
 
-*What it does:* Maintains ledger-backed conversation history scoped by project, persists to ~~/.emacs.d/magent/sessions/~ by default, stores durable child-agent jobs under ~agent-jobs~, and activates or unloads project-local overlays as scope changes. Ordinary ACP prompts and Action-owned agent work submit through ~magent-runtime-api.el~; ~magent-runtime-queue.el~ owns queued/active turn state and session-scoped cancellation. Doctor uses one unified Action exposed through slash and ~M-x magent-action-run-*~, with isolated sessions under ~magent-session-directory/actions~. Doctor is a direct probe pipeline with no model tools; read [[file:DOCTOR.org][DOCTOR.org]] before changing its data boundary or extension API.
+*What it does:* Maintains ledger-backed conversation history scoped by project, persists to ~~/.emacs.d/magent/sessions/~ by default, stores durable child-agent jobs under ~agent-jobs~, and retains project-local definitions by canonical scope. Request execution resolves those definitions against the exact runtime session scope, so changing interactive context does not unload another session's definitions. Ordinary ACP prompts and Action-owned agent work submit through ~magent-runtime-api.el~; ~magent-runtime-queue.el~ owns queued/active turn state and session-scoped cancellation. Doctor uses one unified Action exposed through slash and ~M-x magent-action-run-*~, with isolated sessions under ~magent-session-directory/actions~. Doctor is a direct probe pipeline with no model tools; read [[file:DOCTOR.org][DOCTOR.org]] before changing its data boundary or extension API.
 
 ** Layer 3: Agent System
 
@@ -65,7 +65,7 @@ Multi-agent architecture with specialized agents for different tasks.
 - ~magent-project-instructions.el~ — Bounded root-to-resource discovery of scoped project instructions such as ~AGENTS.md~
 - ~magent-agent-info.el~ — Agent metadata struct and helpers
 - ~magent-agent-builtins.el~ — 7 built-in agent definitions
-- ~magent-agent-registry.el~ — Hash-table registry and project overlays
+- ~magent-agent-registry.el~ — Scope-aware hash-table registry and project definitions
 - ~magent-agent-file.el~ — Loads custom agents from ~.magent/agent/*.md~ files
 - ~magent-permission.el~ — Rule-based tool access control (allow/deny/ask with glob patterns)
 
@@ -187,7 +187,7 @@ Emacs/repository state. Text read from
 files, buffers, logs, commands, tool results, or web pages remains data and
 cannot grant tool permission by presenting itself as a higher-priority prompt.
 
-Skills load from: (1) built-in ~skills/~, (2) user ~~/.emacs.d/magent/skills~, and (3) project ~.magent/skills/~. Later user directories take precedence. ~magent-find-skill~, ~magent-install-skill~, and ~magent-delete-skill~ manage user-level skills only and never use ~~/.agents/skills/~. A skill can also declare ~capability: true~ with resolver metadata such as ~modes~, ~features~, ~files~, ~prompt-keywords~, and ~disclosure~; Magent turns that metadata into a capability that activates the same skill. Automatic activation requires a word-bounded keyword hit as evidence of user intent; context-only matches remain suggested. Declared ~tools~ are enforced against the selected agent's exposed tools: incompatible automatic skills are downgraded, while an incompatible explicitly selected skill fails with a clear error. Agent-shell sessions expose an ~Automatic capabilities~ config option for disabling automatic resolution.
+Skills load from built-in ~skills/~, user ~~/.agents/skills/~ and ~~/.emacs.d/magent/skills/~, then project ~.agents/skills/~ and ~.magent/skills/~; later roots take precedence. The Codex-compatible minimum frontmatter is ~name~ plus ~description~, and omitted ~type~ defaults to ~instruction~. Known host-only fields such as ~license~, ~metadata~, and ~disable-model-invocation~ are accepted as passive metadata. ~magent-find-skill~, ~magent-install-skill~, and ~magent-delete-skill~ manage user-level skills only and never write to ~~/.agents/skills/~. A skill can also declare ~capability: true~ with resolver metadata such as ~modes~, ~features~, ~files~, ~prompt-keywords~, and ~disclosure~; Magent turns that metadata into a capability that activates the same skill. Automatic activation requires a word-bounded keyword hit as evidence of user intent; context-only matches remain suggested. Declared ~tools~ are enforced against the selected agent's exposed tools: incompatible automatic skills are downgraded, while an incompatible explicitly selected skill fails with a clear error. Agent-shell sessions expose an ~Automatic capabilities~ config option for disabling automatic resolution.
 
 Keep the terms separate when adding or reviewing defaults:
 
@@ -200,8 +200,8 @@ Keep the terms separate when adding or reviewing defaults:
   context or prompt text.
 - Co-locate the capability metadata in ~SKILL.md~ when the capability only
   exists to activate that same skill. Use standalone ~CAPABILITY.md~ only when
-  the trigger metadata is separate from a single skill or belongs to a project
-  overlay.
+  the trigger metadata is separate from a single skill or belongs to a scoped
+  project definition.
 
 ** Session Scoping
 
@@ -296,7 +296,7 @@ Look at ~test/magent-test.el~ to see how the codebase is tested. Tests mock ~gpt
 ** Sampling & Runtime
 - *magent-sampling.el* — Provider-neutral request/event contract
 - *magent-sampling-gptel.el* — One-request ~gptel-request~ adapter
-- *magent-runtime.el* — Static initialization and project-local overlay activation
+- *magent-runtime.el* — Static initialization and retained project-local definition loading
 - *magent-runtime-queue.el* — Global execution queue and session-scoped cancellation
 - *magent-runtime-api.el* — Frontend-neutral runtime session and submission API
 - *magent-agent-loop.el* — Normalized event loop, serial tool queue, abort, and continuation
@@ -314,7 +314,7 @@ Look at ~test/magent-test.el~ to see how the codebase is tested. Tests mock ~gpt
 - *magent-agent.el* — Prompt assembly, request-local agent/tool resolution, and loop startup
 - *magent-agent-info.el* — Agent metadata struct and helpers
 - *magent-agent-builtins.el* — 7 built-in agent definitions
-- *magent-agent-registry.el* — Agent registry and project overlays
+- *magent-agent-registry.el* — Scope-aware agent registry and project definitions
 - *magent-agent-file.el* — Custom agent loader from ~.magent/agent/*.md~
 - *magent-permission.el* — Tool access control with glob patterns
 
@@ -323,7 +323,7 @@ Look at ~test/magent-test.el~ to see how the codebase is tested. Tests mock ~gpt
 - *magent-tool-orchestrator.el* — Permission, approval, audit, and tool-call orchestration
 - *magent-approval.el* — User approval prompts for sensitive operations
 - *magent-file-loader.el* — Shared file-backed frontmatter parser
-- *magent-skills.el* — Instruction-skill registry, overlays, descriptors, and inspection
+- *magent-skills.el* — Scope-aware instruction-skill registry, descriptors, and inspection
 - *magent-skill-manager.el* — Lazy, network-aware user skill discovery and installation
 - *magent-capability.el* — Capability definitions, resolution, and file-backed loading
 
@@ -486,12 +486,13 @@ Create ~skills/my-skill/SKILL.md~:
 ---
 name: my-skill
 description: Brief description
-type: instruction
 tools: [read_file, grep]
 ---
 
 Skill instructions for the agent.
 #+end_src
+
+~type: instruction~ is optional; it is the only supported explicit type.
 
 * Getting Help
 

--- a/docs/ONBOARDING.zh.org
+++ b/docs/ONBOARDING.zh.org
@@ -39,7 +39,7 @@ lazy initialization；agent registry、skills、slash commands 和 capabilities 
 
 ** 第 2 层：Session 与 Runtime State
 
-这一层管理 conversation history、scoped overlays 和 runtime state。
+这一层管理 conversation history、scoped definitions 和 runtime state。
 
 *关键文件：*
 
@@ -51,12 +51,12 @@ lazy initialization；agent registry、skills、slash commands 和 capabilities 
 - ~magent-redaction.el~ ：Magent-owned outbound values 的 fail-closed 脱敏。
 - ~magent-agent-job.el~ ：durable child-agent job records 和 JSON shape。
 - ~magent-action.el~ ：Workflow DSL、Step runtime、分层 Action registry 和 Invocation lifecycle。
-- ~magent-runtime.el~ ：静态初始化，以及 agents、skills、Actions、capabilities 的 project-local overlay activation。
+- ~magent-runtime.el~ ：静态初始化与 project-local definitions 的保留式加载。
 - ~magent-runtime-api.el~ ：UI/backend-facing runtime session 和 prompt API。
 - ~magent-runtime-queue.el~ ：全局单执行 runtime queue 和 session-scoped cancellation。
 - ~magent-audit.el~ ：permission 和 sensitive action 的 live buffer 或 JSONL 文件 audit 记录。
 
-*职责：* 维护 project-scoped、ledger-backed conversation history，默认持久化到 ~~/.emacs.d/magent/sessions/~ ，在 ~agent-jobs~ 下保存 durable child-agent jobs，并在 scope 变化时加载或卸载 project-local overlays。普通 ACP prompt 和 Action-owned agent work 都通过 ~magent-runtime-api.el~ 提交； ~magent-runtime-queue.el~ 负责 queued/active turn state 和 session-scoped cancellation。Doctor 使用同时暴露为 slash 与 ~M-x magent-action-run-*~ 的统一 Action，并在 ~magent-session-directory/actions~ 下使用独立 session。Doctor 是不向模型开放工具的 direct probe pipeline；修改其数据边界或扩展 API 前先读 [[file:DOCTOR.zh.org][DOCTOR.zh.org]]。
+*职责：* 维护 project-scoped、ledger-backed conversation history，默认持久化到 ~~/.emacs.d/magent/sessions/~ ，在 ~agent-jobs~ 下保存 durable child-agent jobs，并按 canonical scope 保留 project-local definitions。Request execution 始终按 runtime session 的精确 scope 解析，因此切换交互上下文不会卸载其他 session 的 definitions。普通 ACP prompt 和 Action-owned agent work 都通过 ~magent-runtime-api.el~ 提交； ~magent-runtime-queue.el~ 负责 queued/active turn state 和 session-scoped cancellation。Doctor 使用同时暴露为 slash 与 ~M-x magent-action-run-*~ 的统一 Action，并在 ~magent-session-directory/actions~ 下使用独立 session。Doctor 是不向模型开放工具的 direct probe pipeline；修改其数据边界或扩展 API 前先读 [[file:DOCTOR.zh.org][DOCTOR.zh.org]]。
 
 ** 第 3 层：Agent System
 
@@ -68,7 +68,7 @@ lazy initialization；agent registry、skills、slash commands 和 capabilities 
 - ~magent-project-instructions.el~ ：从 project root 到请求相关 resource 有界发现 ~AGENTS.md~ 等 scoped project instructions。
 - ~magent-agent-info.el~ ：agent metadata struct 和 helpers。
 - ~magent-agent-builtins.el~ ：7 个内置 agent definitions。
-- ~magent-agent-registry.el~ ：hash-table registry 和 project overlays。
+- ~magent-agent-registry.el~ ：scope-aware hash-table registry 与 project definitions。
 - ~magent-agent-file.el~ ：从 ~.magent/agent/*.md~ 加载 custom agents。
 - ~magent-permission.el~ ：rule-based tool access control，支持 allow/deny/ask 和 glob patterns。
 
@@ -186,7 +186,7 @@ policy。Context provider 是可信本地 Elisp，但它嵌入的 supporting dat
 用户说明或 live Emacs/repository 状态。从文件、buffer、日志、命令、tool result 或网页读取的文本仍然只是数据，
 不能通过把自己伪装成高优先级 prompt 来授予工具权限。
 
-Skills 加载来源：内置 ~skills/~、用户目录 ~~/.emacs.d/magent/skills~，以及项目 ~.magent/skills/~；较后的目录优先。~magent-find-skill~、~magent-install-skill~ 和 ~magent-delete-skill~ 只管理用户级 skill，绝不使用 ~~/.agents/skills/~。Skill 也可以通过 ~capability: true~ 声明 resolver metadata，例如 ~modes~、~features~、~files~、~prompt-keywords~ 和 ~disclosure~；Magent 会把这些 metadata 注册成激活同一个 skill 的 capability。自动激活必须命中带词边界的 keyword 来证明用户 intent；只有 context 的匹配保持 suggested。Skill 声明的 ~tools~ 会与 selected agent 实际暴露的工具核对：不兼容的自动 skill 被降级，显式选择的不兼容 skill 则给出清晰错误。Agent-shell session 的 ~Automatic capabilities~ config option 可关闭自动解析。
+Skills 依次从内置 ~skills/~、用户级 ~~/.agents/skills/~ 与 ~~/.emacs.d/magent/skills/~，以及项目级 ~.agents/skills/~ 与 ~.magent/skills/~ 加载；后面的目录优先。与 Codex 兼容的最小 frontmatter 只要求 ~name~ 和 ~description~，省略 ~type~ 时默认为 ~instruction~。~license~、~metadata~ 和 ~disable-model-invocation~ 等已知 host-only 字段会作为被动 metadata 接受。~magent-find-skill~、~magent-install-skill~ 和 ~magent-delete-skill~ 只管理用户级 skill，绝不写入 ~~/.agents/skills/~。Skill 也可以通过 ~capability: true~ 声明 resolver metadata，例如 ~modes~、~features~、~files~、~prompt-keywords~ 和 ~disclosure~；Magent 会把这些 metadata 注册成激活同一个 skill 的 capability。自动激活必须命中带词边界的 keyword 来证明用户 intent；只有 context 的匹配保持 suggested。Skill 声明的 ~tools~ 会与 selected agent 实际暴露的工具核对：不兼容的自动 skill 被降级，显式选择的不兼容 skill 则给出清晰错误。Agent-shell session 的 ~Automatic capabilities~ config option 可关闭自动解析。
 
 新增或 review 默认能力时保持这些概念分开：
 
@@ -197,8 +197,8 @@ Skills 加载来源：内置 ~skills/~、用户目录 ~~/.emacs.d/magent/skills~
   ~/$name~ 是 ACP projection，不会创建 Action。
 - 需要根据 live context 或 prompt text 自动选择某个 skill 时，用 ~capability~ 。
 - 如果 capability 只是为了激活同一个 skill，就把 metadata 和说明共址在
-  ~SKILL.md~ 。只有当触发 metadata 不属于单个 skill，或属于 project overlay 时，
-  才使用独立 ~CAPABILITY.md~ 。
+  ~SKILL.md~ 。只有当触发 metadata 不属于单个 skill，或属于 scoped project
+  definition 时，才使用独立 ~CAPABILITY.md~ 。
 
 ** Session Scoping
 
@@ -298,7 +298,7 @@ API。
 ** Sampling 与 Runtime
 - *magent-sampling.el* — provider-neutral request/event contract
 - *magent-sampling-gptel.el* — 单次请求的 ~gptel-request~ adapter
-- *magent-runtime.el* — static initialization 与 project-local overlay activation
+- *magent-runtime.el* — static initialization 与 project-local definitions 的保留式加载
 - *magent-runtime-queue.el* — global execution queue 与 session-scoped cancellation
 - *magent-runtime-api.el* — frontend-neutral runtime session 与 submission API
 - *magent-agent-loop.el* — normalized event loop、serial tool queue、abort 与 continuation
@@ -316,7 +316,7 @@ API。
 - *magent-agent.el* — prompt 装配、request-local agent/tool resolution 与 loop startup
 - *magent-agent-info.el* — agent metadata struct 与 helpers
 - *magent-agent-builtins.el* — 7 个 built-in agent definitions
-- *magent-agent-registry.el* — agent registry 与 project overlays
+- *magent-agent-registry.el* — scope-aware agent registry 与 project definitions
 - *magent-agent-file.el* — 从 ~.magent/agent/*.md~ 加载 custom agent
 - *magent-permission.el* — 带 glob pattern 的 tool access control
 
@@ -325,7 +325,7 @@ API。
 - *magent-tool-orchestrator.el* — permission、approval、audit 与 tool-call orchestration
 - *magent-approval.el* — sensitive operation 的 user approval prompts
 - *magent-file-loader.el* — 共用的 file-backed frontmatter parser
-- *magent-skills.el* — instruction-skill registry、overlays、descriptors 与 inspection
+- *magent-skills.el* — scope-aware instruction-skill registry、descriptors 与 inspection
 - *magent-skill-manager.el* — lazy、network-aware 的用户 skill discovery 与 installation
 - *magent-capability.el* — capability definitions、resolution 与 file-backed loading
 
@@ -473,12 +473,13 @@ mapping 格式。未知字段、未知 permission key 和其他 shape 会直接�
 ---
 name: my-skill
 description: Brief description
-type: instruction
 tools: [read_file, grep]
 ---
 
 Skill instructions for the agent.
 #+end_src
+
+~type: instruction~ 可以省略；若显式指定，目前只支持该类型。
 
 * 获取帮助
 

--- a/docs/UI_BACKENDS.org
+++ b/docs/UI_BACKENDS.org
@@ -44,9 +44,9 @@ explicit command registration and invocation belong in ~magent-action.el~.
    scope and invokes it through ~magent-action.el~. Ordinary prompts go
    directly to ~magent-runtime-api.el~. Command-owned turns and workflow steps
    also use that API; direct handlers may complete without a general agent turn.
-5. The runtime queue starts exactly one active turn at a time, builds a
-   ~magent-request-context~ with ~:ui-visibility 'none~, and calls
-   ~magent-agent-run-turn~.
+5. The runtime API freezes one ~magent-request-context~ with
+   ~:ui-visibility 'none~ before queueing.  The queue starts exactly one active
+   turn at a time and passes that context unchanged to ~magent-agent-run-turn~.
 6. The agent loop emits Magent-native observer events; ~magent-acp.el~ converts
    them to ACP ~session/update~ messages for agent-shell.
 7. ACP prompt requests remain pending until the corresponding ordinary turn or

--- a/docs/UI_BACKENDS.zh.org
+++ b/docs/UI_BACKENDS.zh.org
@@ -38,8 +38,9 @@ invocation 则属于 ~magent-action.el~ 。
    ~magent-action.el~ 调用；普通 prompt 直接进入 ~magent-runtime-api.el~ 。Command
    拥有的 turn 和 workflow step 同样使用该 API；direct handler 可以不进入通用 agent
    turn 而直接完成。
-5. runtime queue 每次只启动一个 active turn，创建带 ~:ui-visibility 'none~ 的
-   ~magent-request-context~ ，并调用 ~magent-agent-run-turn~ 。
+5. runtime API 在排队前一次创建并冻结带 ~:ui-visibility 'none~ 的
+   ~magent-request-context~；queue 每次只启动一个 active turn，并把该 context 原样交给
+   ~magent-agent-run-turn~ 。
 6. agent loop 发出 Magent-native observer events； ~magent-acp.el~ 将其转换成发给
    agent-shell 的 ACP ~session/update~ 消息。
 7. ACP prompt request 会保持 pending，直到对应的普通 turn 或 command invocation

--- a/lisp/magent-acp.el
+++ b/lisp/magent-acp.el
@@ -93,7 +93,10 @@ all protocol traffic.  Keep that implementation detail off the TRAMP host."
                            magent-default-agent))
     (availableModes . ,(vconcat
                         (mapcar #'magent-acp--mode-entry
-                                (magent-agent-registry-primary-agents))))))
+                                (magent-agent-registry-primary-agents
+                                 (and runtime-session
+                                      (magent-runtime-session-scope
+                                       runtime-session))))))))
 
 (defun magent-acp--model-descriptor-entry (descriptor)
   "Return an ACP legacy model entry for DESCRIPTOR."
@@ -955,7 +958,7 @@ but omit the reason prefix from the ordinary tool-call UI."
 (defun magent-acp--load-candidate (session-id scope)
   "Return a read-only load candidate for SESSION-ID in exact SCOPE.
 The result contains either `:runtime-session' or `:session'.  Validating it
-does not activate overlays or install a session into the runtime registry."
+does not prepare definitions or install a session into the runtime registry."
   (magent-session-validate-id session-id)
   (if-let* ((runtime-session
              (magent-runtime-session-from-id session-id scope)))
@@ -1147,7 +1150,7 @@ does not activate overlays or install a session into the runtime registry."
                   (candidate (magent-acp--load-candidate session-id scope)))
              (unless candidate
                (error "Unknown session in requested cwd: %s" session-id))
-             ;; Preflight exact-session replacement before changing overlays.
+             ;; Preflight exact-session replacement before preparing scope.
              (let ((candidate-session
                     (or (plist-get candidate :session)
                         (when-let* ((runtime-session

--- a/lisp/magent-action-builtin-doctor.el
+++ b/lisp/magent-action-builtin-doctor.el
@@ -49,8 +49,9 @@
                   "magent-runtime-queue")
 (declare-function magent-runtime-submission-id
                   "magent-runtime-queue" t t)
-(declare-function magent-runtime-submission-session-id
+(declare-function magent-runtime-submission-runtime-session
                   "magent-runtime-queue" t t)
+(declare-function magent-runtime-session-id "magent-runtime-api" t t)
 (declare-function magent-runtime-submission-status
                   "magent-runtime-queue" t t)
 (declare-function org-back-to-heading "org" (&optional invisible-ok))
@@ -638,7 +639,10 @@ When BACKEND is nil, use the current global gptel backend."
                    `((submission-id
                       . ,(magent-runtime-submission-id active))
                      (session-id
-                      . ,(magent-runtime-submission-session-id active))
+                      . ,(when-let* ((runtime-session
+                                      (magent-runtime-submission-runtime-session
+                                       active)))
+                           (magent-runtime-session-id runtime-session)))
                      (status
                       . ,(magent-runtime-submission-status active)))))))
       (active-commands
@@ -1342,6 +1346,21 @@ Return nil when either path is unavailable or cannot be inspected."
            state 'failed
            "Doctor analysis failed with a redacted error"))))))))
 
+(defun magent-doctor--analysis-start-error (condition state)
+  "Return an actionable provider-start message for CONDITION using STATE."
+  (if (and (eq (car-safe condition) 'wrong-type-argument)
+           (eq (nth 1 condition) 'stringp)
+           (null (nth 2 condition)))
+      (concat
+       "Doctor analysis could not start before contacting the provider: "
+       "the selected gptel backend supplied nil where text was required. "
+       "Verify its API key/auth-source callback and proxy configuration.")
+    (condition-case nil
+        (format "Doctor analysis could not start: %s"
+                (magent-doctor--safe-error condition state))
+      (magent-doctor-security-error
+       "Doctor analysis could not start because provider configuration failed"))))
+
 (defun magent-doctor--analysis-route (context)
   "Return the effective model route for Doctor CONTEXT.
 Slash invocations retain their originating runtime session as the Action's
@@ -1385,24 +1404,30 @@ invocations without a control session use the current gptel defaults."
      :note (format (concat "Sending %d characters of bounded, redacted probe "
                            "results; provider tools are disabled.")
                    (length bundle-json)))
-    (let ((handle (magent-sampling-gptel-sample request)))
-      (if (or (magent-doctor-state-cancelled-p state)
-              (not (eq (magent-action-invocation-status context) 'active)))
-          (when (and (bufferp handle) (buffer-live-p handle))
-            (kill-buffer handle))
-        (setf (magent-doctor-state-request-handle state) handle)
-        (when (> magent-request-timeout 0)
-          (setf (magent-doctor-state-request-timer state)
-                (run-at-time
-                 magent-request-timeout nil
-                 (lambda ()
-                   (unless (or (magent-doctor-state-cancelled-p state)
-                               (not (eq (magent-action-invocation-status
-                                         context)
-                                        'active)))
-                     (magent-doctor--abort-request state)
-                     (magent-doctor--done
-                      state 'failed "Doctor analysis timed out"))))))))))
+    (condition-case condition
+        (let ((handle (magent-sampling-gptel-sample request)))
+          (if (or (magent-doctor-state-cancelled-p state)
+                  (not (eq (magent-action-invocation-status context) 'active)))
+              (when (and (bufferp handle) (buffer-live-p handle))
+                (kill-buffer handle))
+            (setf (magent-doctor-state-request-handle state) handle)
+            (when (> magent-request-timeout 0)
+              (setf (magent-doctor-state-request-timer state)
+                    (run-at-time
+                     magent-request-timeout nil
+                     (lambda ()
+                       (unless (or (magent-doctor-state-cancelled-p state)
+                                   (not (eq (magent-action-invocation-status
+                                             context)
+                                            'active)))
+                         (magent-doctor--abort-request state)
+                         (magent-doctor--done
+                          state 'failed
+                          "Doctor analysis timed out"))))))))
+      (error
+       (magent-doctor--done
+        state 'failed
+        (magent-doctor--analysis-start-error condition state))))))
 
 (defun magent-doctor--start (context done)
   "Start the safe Doctor pipeline for CONTEXT, completing through DONE."

--- a/lisp/magent-action-builtins.el
+++ b/lisp/magent-action-builtins.el
@@ -112,7 +112,8 @@
   "Describe the exact effective authority for INVOCATION."
   (let* ((runtime (magent-action-invocation-runtime-session invocation))
          (agent-name (magent-runtime-session-agent-name runtime))
-         (agent (magent-agent-registry-get agent-name))
+         (agent (magent-agent-registry-get
+                 agent-name (magent-runtime-session-scope runtime)))
          (permission (and agent (magent-agent-info-permission agent)))
          (session (magent-runtime-session-magent-session runtime))
          (header

--- a/lisp/magent-action.el
+++ b/lisp/magent-action.el
@@ -762,7 +762,7 @@ an optional zero-argument cancellation function."
 
 (defun magent-action--resolution-scope (&optional scope)
   "Return canonical Action resolution scope for optional SCOPE.
-When SCOPE is nil, use the currently active project overlay."
+When SCOPE is nil, use the current interactive project context."
   (magent-session-canonical-scope
    (or scope
        (and (fboundp 'magent-runtime-active-project-scope)
@@ -902,7 +902,7 @@ Nil SOURCE-SCOPE acts as a wildcard.  Return the removal count."
 (defun magent-action-get (name &optional scope exposure)
   "Return effective Action NAME for SCOPE and EXPOSURE, or nil.
 EXPOSURE defaults to `slash'.  When SCOPE is nil, resolve against the
-currently active project overlay."
+current interactive project context."
   (let ((key (magent-action--normalize-name name))
         (resolution-scope (magent-action--resolution-scope scope))
         (kind (or exposure 'slash))
@@ -920,7 +920,7 @@ currently active project overlay."
 (defun magent-action-list (&optional scope exposure)
   "Return effective Action specs for SCOPE and EXPOSURE sorted by name.
 EXPOSURE defaults to `slash'.  When SCOPE is nil, resolve against the
-currently active project overlay."
+current interactive project context."
   (let ((resolution-scope (magent-action--resolution-scope scope))
         (kind (or exposure 'slash))
         names)
@@ -933,16 +933,6 @@ currently active project overlay."
     (mapcar (lambda (name)
               (magent-action-get name (or resolution-scope 'global) kind))
             (sort names #'string<))))
-
-(defun magent-action-load-project-scope (scope)
-  "Load Action definitions for project SCOPE.
-Project Action files are not currently supported."
-  (ignore scope))
-
-(defun magent-action-remove-project-scope (scope)
-  "Remove Action definitions for project SCOPE.
-Project Action files are not currently supported."
-  (ignore scope))
 
 (defun magent-action-initialize-static ()
   "Register bundled actions."

--- a/lisp/magent-agent-file.el
+++ b/lisp/magent-agent-file.el
@@ -262,7 +262,8 @@ Returns number of agents loaded."
    (t (error "Agent model is not file-serializable: %S" model))))
 
 (defun magent-agent-file-load-project-scope (scope)
-  "Load project-local agents for SCOPE."
+  "Reload project-local agents for SCOPE."
+  (magent-agent-registry-remove-project-scope scope)
   (magent-agent-file-load-all scope))
 
 (defun magent-agent-file-save (agent-info &optional directory)

--- a/lisp/magent-agent-registry.el
+++ b/lisp/magent-agent-registry.el
@@ -27,13 +27,35 @@
 (defvar magent-agent-registry--agents (make-hash-table :test 'equal)
   "Hash table mapping agent names to precedence-ordered agent stacks.
 The first item is the effective definition.  Lower-layer definitions remain
-available so removing a project overlay restores the previous definition.")
+available so each request scope can resolve its own effective definition.")
 
 (defvar magent-agent-registry--default-agent nil
   "The default agent name.")
 
 (defvar magent-agent-registry--initialized nil
   "Whether the registry has been initialized.")
+
+(defun magent-agent-registry--resolution-scope (&optional scope)
+  "Return the canonical agent resolution scope for optional SCOPE."
+  (magent-session-canonical-scope
+   (or scope (magent-runtime-active-project-scope) 'global)))
+
+(defun magent-agent-registry--visible-in-scope-p (agent scope)
+  "Return non-nil when AGENT is visible in canonical SCOPE."
+  (let ((source-scope
+         (magent-session-canonical-scope
+          (magent-agent-info-source-scope agent))))
+    (or (null source-scope)
+        (equal source-scope scope))))
+
+(defun magent-agent-registry--effective-agent (value scope)
+  "Return the effective agent from registry VALUE for canonical SCOPE."
+  (let ((stack (if (magent-agent-info-p value) (list value) value)))
+    (cl-find-if
+     (lambda (agent)
+       (and (magent-agent-info-p agent)
+            (magent-agent-registry--visible-in-scope-p agent scope)))
+     stack)))
 
 ;;; Registry initialization
 
@@ -56,7 +78,7 @@ available so removing a project overlay restores the previous definition.")
 (defun magent-agent-registry-register (agent-info)
   "Register an AGENT-INFO in the registry.
 An existing definition from the same source layer and scope is replaced.
-Definitions from lower layers are retained for reversible project overlays.
+Definitions from other layers and scopes remain available for exact lookup.
 Returns the registered agent info."
   (when (magent-agent-info-valid-p agent-info)
     (let* ((name (magent-agent-info-name agent-info))
@@ -101,18 +123,19 @@ Returns the registered agent info."
 
 ;;; Agent retrieval
 
-(defun magent-agent-registry-get (name)
-  "Get agent info by NAME.
+(defun magent-agent-registry-get (name &optional scope)
+  "Get agent info by NAME for SCOPE.
 Returns the agent info structure, or nil if not found."
   (magent-agent-registry-ensure-initialized)
-  (let ((value (gethash name magent-agent-registry--agents)))
-    (if (magent-agent-info-p value) value (car value))))
+  (magent-agent-registry--effective-agent
+   (gethash name magent-agent-registry--agents)
+   (magent-agent-registry--resolution-scope scope)))
 
-(defun magent-agent-registry-get-default ()
-  "Get the default agent info.
+(defun magent-agent-registry-get-default (&optional scope)
+  "Get the default agent info for SCOPE.
 Returns the default agent info structure, or nil if not found."
   (magent-agent-registry-ensure-initialized)
-  (magent-agent-registry-get magent-agent-registry--default-agent))
+  (magent-agent-registry-get magent-agent-registry--default-agent scope))
 
 (defun magent-agent-registry-set-default (name)
   "Set the default agent to NAME.
@@ -124,19 +147,22 @@ Returns the new default agent info, or nil if not found."
 
 ;;; Agent listing
 
-(defun magent-agent-registry-list (&optional include-hidden mode native-only)
-  "List all registered agents.
+(defun magent-agent-registry-list
+    (&optional include-hidden mode native-only scope)
+  "List all registered agents visible in SCOPE.
 Returns list of agent info structures sorted by native status and name.
 
 If INCLUDE-HIDDEN is non-nil, include hidden agents.
 If MODE is non-nil (primary, subagent, or all), filter by mode.
-If NATIVE-ONLY is non-nil, only include native (built-in) agents."
+If NATIVE-ONLY is non-nil, only include native (built-in) agents.
+When SCOPE is nil, use the current interactive project context."
   (magent-agent-registry-ensure-initialized)
-  (let ((agents nil))
+  (let ((agents nil)
+        (resolution-scope
+         (magent-agent-registry--resolution-scope scope)))
     (maphash (lambda (_name value)
-               (let ((info (if (magent-agent-info-p value)
-                               value
-                             (car value))))
+               (let ((info (magent-agent-registry--effective-agent
+                            value resolution-scope)))
                  (when (and info
                             (or include-hidden
                                 (not (magent-agent-info-hidden info)))
@@ -159,15 +185,15 @@ If NATIVE-ONLY is non-nil, only include native (built-in) agents."
                ;; Then sort by name
                (t (string< a-name b-name))))))))
 
-(defun magent-agent-registry-list-names (&optional include-hidden mode)
-  "List all registered agent names.
+(defun magent-agent-registry-list-names (&optional include-hidden mode scope)
+  "List registered agent names visible in SCOPE.
 Returns list of agent name strings."
   (mapcar #'magent-agent-info-name
-          (magent-agent-registry-list include-hidden mode)))
+          (magent-agent-registry-list include-hidden mode nil scope)))
 
-(defun magent-agent-registry-primary-agents ()
-  "List all primary agents (non-hidden, mode is primary or all)."
-  (magent-agent-registry-list nil 'primary))
+(defun magent-agent-registry-primary-agents (&optional scope)
+  "List primary agents visible in SCOPE."
+  (magent-agent-registry-list nil 'primary nil scope))
 
 ;;; Agent utilities
 

--- a/lisp/magent-agent.el
+++ b/lisp/magent-agent.el
@@ -9,8 +9,9 @@
 
 ;;; Commentary:
 
-;; Agent processing for Magent.  Builds prompt lists from session history,
-;; applies per-agent gptel overrides, and starts the Magent-owned loop.
+;; Agent processing for Magent.  Consumes one canonical request context, builds
+;; prompt lists from session history, applies per-agent gptel overrides, and
+;; starts the Magent-owned loop.
 
 ;;; Code:
 
@@ -45,22 +46,17 @@
   (or (null request-live-p)
       (funcall request-live-p)))
 
-(defun magent-agent--ui-visible-p (request-state)
-  "Return non-nil when REQUEST-STATE allows UI writes."
-  (or (null request-state)
-      (magent-request-context-ui-visible-p request-state)))
-
-(defun magent-agent--completion-callback-text (loop event streaming-started)
+(defun magent-agent--completion-callback-text (loop event text-delta-seen)
   "Return assistant text that still needs a callback for EVENT.
 LOOP has already accumulated EVENT by the time this helper is called.
-When streaming has not started, the current sample result should be rendered.
-When streaming has started, render only the completed event's text that
+When no text delta was seen, the current sample result should be rendered.
+After text deltas, render only the completed event's text that
 was not already emitted as text deltas."
   (let ((result (magent-agent-loop-result loop))
         (event-text (magent-sampling-event-text event))
         (streamed (magent-agent-loop-sample-text loop)))
     (cond
-     ((not streaming-started)
+     ((not text-delta-seen)
       result)
      ((or (null event-text)
           (string-empty-p event-text))
@@ -93,12 +89,13 @@ was not already emitted as text deltas."
     magent-enable-capabilities))
 
 (defun magent-agent--validate-explicit-skill-tools
-    (skill-names available-tools)
+    (skill-names available-tools scope)
   "Signal when explicit SKILL-NAMES require tools outside AVAILABLE-TOOLS."
   (when (and skill-names (require 'magent-skills nil t))
     (dolist (skill-name skill-names)
       (when-let* ((missing
-                   (magent-skills-missing-tools skill-name available-tools)))
+                   (magent-skills-missing-tools
+                    skill-name available-tools scope)))
         (error "Skill '%s' requires unavailable tool(s): %s"
                skill-name
                (mapconcat #'symbol-name missing ", "))))))
@@ -212,69 +209,48 @@ receives the same instruction-provenance and permission invariants."
      "\n\n")))
 
 (cl-defun magent-agent--execute-turn
-    (&key user-prompt callback agent-info skill-names event-context
-          dispatch-context capability-resolution text-callback request-live-p
-          request-state)
+    (&key user-prompt callback capability-resolution request-state)
   "Execute USER-PROMPT through the Magent-owned agent loop.
 CALLBACK is called with one final `magent-execution-result'.
-AGENT-INFO is the agent to use (defaults to session agent or registry default).
-SKILL-NAMES is a list of skill name strings to activate for this request.
-EVENT-CONTEXT is an optional existing event context to reuse.
-DISPATCH-CONTEXT is an optional structured context plist captured at
-dispatch time.
 CAPABILITY-RESOLUTION is an optional precomputed capability resolver
 result for this turn.
-TEXT-CALLBACK receives streaming text chunks for this request.
-REQUEST-LIVE-P is an optional predicate used to discard stale backend
-callbacks after the UI has moved on to a newer request.
-REQUEST-STATE is an optional `magent-request-context' carrying runtime
-state for the request.
-When SKILL-NAMES is nil, the capability resolver may still auto-activate
-instruction skills for the turn.  Explicit skills are merged with and
-deduplicated against capability-selected skills.
+REQUEST-STATE is the canonical `magent-request-context' carrying request
+inputs and mutable execution state.  The capability resolver may auto-activate
+instruction skills in addition to the explicit skills captured there.
 
 The tool calling loop is managed by `magent-agent-loop'.  This function:
   1. Builds the prompt list from session history
   2. Retrieves per-agent overrides (backend, model, temperature, tools)
   3. Creates a normalized LLM request and starts loop execution
   4. Records the final response in the session via the callback"
-  (let* ((session (or (and request-state
-                           (magent-request-context-session request-state))
-                      (magent-session-get)))
-         (agent (or agent-info
-                    (magent-session-agent session)
-                    (magent-agent-registry-get-default)))
+  (let* ((session (magent-request-context-session request-state))
+         (request-scope (or (magent-request-context-scope request-state)
+                            (magent-session-current-scope)))
+         (dispatch-context
+          (magent-request-context-origin-context request-state))
+         (agent (or (magent-request-context-agent request-state)
+                    (and (magent-session-agent session)
+                         (magent-agent-registry-get
+                          (magent-agent-info-name
+                           (magent-session-agent session))
+                          request-scope))
+                    (magent-agent-registry-get-default request-scope)))
          (effective-permission
-          (or (and request-state
-                   (magent-request-context-permission-profile request-state))
+          (or (magent-request-context-permission-profile request-state)
               (magent-agent-info-permission agent)))
-         (request-scope
-          (or (and request-state
-                   (magent-request-context-scope request-state))
-              (magent-session-current-scope)))
-         (inherited-context
-          (or event-context
-              (and request-state
-                   (magent-request-context-event-context request-state))))
+         (inherited-context (magent-request-context-event-context request-state))
          (owns-context (null inherited-context))
          (context (or inherited-context
                       (magent-lifecycle-events-begin-turn
                        (format "Agent %s" (magent-agent-info-name agent)))))
-         (process-turn-id
-          (and request-state
-               (magent-request-context-turn-id request-state))))
+         (process-turn-id (magent-request-context-turn-id request-state)))
     (condition-case err
         (progn
-          (when request-state
-            (setf (magent-request-context-session request-state) session
-                  (magent-request-context-live-p request-state)
-                  (or (magent-request-context-live-p request-state)
-                      request-live-p)
-                  (magent-request-context-event-context request-state) context))
+          (setf (magent-request-context-agent request-state) agent
+                (magent-request-context-event-context request-state) context)
           ;; Freeze scalar audit attribution after the request-local agent is
           ;; selected.  Later UI/session mutations must not relabel this turn.
-          (when request-state
-            (magent-request-context-audit-snapshot request-state))
+          (magent-request-context-audit-snapshot request-state)
           (let* ((thread (magent-session-thread-ledger session))
                  (state-turn-id process-turn-id)
                  (state-turn
@@ -295,11 +271,10 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                         (and active-turn
                              (magent-thread-turn-id active-turn)))))
               (setq process-turn-id turn-id)
-              (when (and request-state turn-id)
-                (setf (magent-request-context-turn-id request-state)
-                      turn-id))))
-          (let* ((current-turn-id (and request-state
-                                       (magent-request-context-turn-id request-state)))
+              (when turn-id
+                (setf (magent-request-context-turn-id request-state) turn-id))))
+          (let* ((current-turn-id
+                  (magent-request-context-turn-id request-state))
                  (prompt-list (magent-session-context-view
                                session 'provider current-turn-id))
                  (agent-role-msg (magent-agent-info-prompt agent))
@@ -309,20 +284,15 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                  (tools
                   (magent-tools-get-gptel-tools-for-permission
                    effective-permission
-                   (if request-state
-                       (magent-request-context-tool-names request-state)
-                     :all)))
+                   (magent-request-context-tool-names request-state)))
                  (available-tool-names
                   (mapcar (lambda (tool) (intern (gptel-tool-name tool))) tools))
                  (explicit-skill-names
                   (magent-skills-dedupe-names
-                   (append skill-names
-                           (and request-state
-                                (magent-request-context-skill-names
-                                 request-state)))))
+                   (magent-request-context-skill-names request-state)))
                  (_skill-tool-validation
                   (magent-agent--validate-explicit-skill-tools
-                   explicit-skill-names available-tool-names))
+                   explicit-skill-names available-tool-names request-scope))
                  (capability-resolution
                   (or capability-resolution
                       (when (and
@@ -331,7 +301,7 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                              (require 'magent-capability nil t))
                         (magent-capability-resolve
                          user-prompt dispatch-context explicit-skill-names
-                         available-tool-names))))
+                         available-tool-names request-scope))))
                  (resolved-skill-names
                   (magent-skills-dedupe-names
                    (append
@@ -342,7 +312,7 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                  (skill-prompts (when (and (require 'magent-skills nil t)
                                            resolved-skill-names)
                                   (magent-skills-get-instruction-prompts
-                                   resolved-skill-names)))
+                                   resolved-skill-names request-scope)))
                  (context-provider-messages
                   (magent-agent--context-provider-messages
                    user-prompt dispatch-context request-project-root))
@@ -367,21 +337,16 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                        (magent-agent-resolve-model-route
                         agent
                         :explicit-route
-                        (and request-state
-                             (magent-request-context-model-route request-state))
+                        (magent-request-context-model-route request-state)
                         :parent-route
-                        (and request-state
-                             (magent-request-context-parent-model-route
-                              request-state))))
+                        (magent-request-context-parent-model-route
+                         request-state)))
                       (inherited-temperature
-                       (and request-state
-                            (magent-request-context-temperature request-state)))
+                       (magent-request-context-temperature request-state))
                       (inherited-top-p
-                       (and request-state
-                            (magent-request-context-top-p request-state)))
+                       (magent-request-context-top-p request-state))
                       (inherited-effort
-                       (and request-state
-                            (magent-request-context-effort request-state)))
+                       (magent-request-context-effort request-state))
                       (backend (magent-model-route-backend route))
                       (model (magent-model-route-model route))
                       (temperature (or inherited-temperature
@@ -395,35 +360,35 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                                          (magent-effort-option-or-auto
                                           magent-default-effort)))
                       (effort (magent-effort-effective effort-option)))
-                 (when request-state
-                   (setf (magent-request-context-project-root request-state)
-                         (or (magent-request-context-project-root request-state)
-                             request-project-root)
-                         (magent-request-context-model-route request-state)
-                         route
-                         (magent-request-context-model request-state)
-                         model
-                         (magent-request-context-backend request-state)
-                         backend
-                         (magent-request-context-temperature request-state)
-                         (or (magent-request-context-temperature request-state)
-                             temperature)
-                         (magent-request-context-top-p request-state)
-                         (or (magent-request-context-top-p request-state)
-                             top-p)
-                         (magent-request-context-effort request-state)
-                         (or (magent-request-context-effort request-state)
-                             effort-option)
-                         (magent-request-context-skill-names request-state)
-                         (copy-sequence resolved-skill-names)
-                         (magent-request-context-capability-context request-state)
-                         (or (magent-request-context-capability-context request-state)
-                             (and capability-resolution
-                                  (magent-capability-resolution-to-plist
-                                   capability-resolution))
-                             dispatch-context)
-                         (magent-request-context-permission-profile request-state)
-                         effective-permission))
+                 (setf (magent-request-context-project-root request-state)
+                       (or (magent-request-context-project-root request-state)
+                           request-project-root)
+                       (magent-request-context-model-route request-state)
+                       route
+                       (magent-request-context-model request-state)
+                       model
+                       (magent-request-context-backend request-state)
+                       backend
+                       (magent-request-context-temperature request-state)
+                       (or (magent-request-context-temperature request-state)
+                           temperature)
+                       (magent-request-context-top-p request-state)
+                       (or (magent-request-context-top-p request-state)
+                           top-p)
+                       (magent-request-context-effort request-state)
+                       (or (magent-request-context-effort request-state)
+                           effort-option)
+                       (magent-request-context-skill-names request-state)
+                       (copy-sequence resolved-skill-names)
+                       (magent-request-context-capability-context request-state)
+                       (or (magent-request-context-capability-context
+                            request-state)
+                           (and capability-resolution
+                                (magent-capability-resolution-to-plist
+                                 capability-resolution))
+                           dispatch-context)
+                       (magent-request-context-permission-profile request-state)
+                       effective-permission)
                  (magent-log "INFO agent=%s backend=%s model=%s route-source=%s tools=[%s]"
                              (magent-agent-info-name agent)
                              (gptel-backend-name backend)
@@ -446,11 +411,7 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                             "Magent model %s on backend %s does not support tools"
                             model (gptel-backend-name backend))))
                         (gptel-tools request-tools)
-                        (live-p (or request-live-p
-                                    (and request-state
-                                         (magent-request-context-live-p
-                                          request-state))))
-                        (streaming-started nil)
+                        (live-p (magent-request-context-live-p request-state))
                         (text-delta-seen nil)
                         (assistant-item nil)
                         (reasoning-item nil)
@@ -460,8 +421,7 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                    (cl-labels
                        ((current-turn-id
                           ()
-                          (or (and request-state
-                                   (magent-request-context-turn-id request-state))
+                          (or (magent-request-context-turn-id request-state)
                               (and loop
                                    (magent-agent-loop-turn-id loop))
                               (and (magent-thread-active-turn
@@ -595,7 +555,6 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                                 (and assistant-item
                                      (copy-tree
                                       (magent-thread-item-content assistant-item)))
-                                streaming-started nil
                                 text-delta-seen nil)
                           (magent-agent-loop-begin-sample loop))
                         (sample
@@ -687,29 +646,16 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                                           response metadata)
                                        (magent-execution-result-failed
                                         response metadata)))))
-                        (start-streaming
-                          ()
-                          (close-reasoning)
-                          (setq streaming-started t))
                         (handle-completed-event
                           (event)
                           (let ((observer-text
                                  (magent-agent--completion-callback-text
-                                  loop event text-delta-seen))
-                                (callback-text
-                                 (magent-agent--completion-callback-text
-                                  loop event streaming-started)))
+                                  loop event text-delta-seen)))
                             (when (and (stringp observer-text)
                                        (not (string-empty-p observer-text)))
                               (magent-request-context-notify
                                request-state 'assistant-delta
-                               :text observer-text))
-                            (when (and (stringp callback-text)
-                                       (not (string-empty-p callback-text)))
-                              (start-streaming)
-                              (when (and text-callback
-                                         (magent-agent--ui-visible-p request-state))
-                                (funcall text-callback callback-text))))
+                               :text observer-text)))
                           (let* ((result (or (magent-agent-loop-result loop) ""))
                                  (empty-p (string-empty-p result))
                                  (metadata (and empty-p
@@ -727,7 +673,7 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                             (let ((event-type (magent-sampling-event-type event)))
                               (pcase event-type
                                 ('text-delta
-                                 (start-streaming)
+                                 (close-reasoning)
                                  (magent-lifecycle-events-emit
                                   'text-delta
                                   :context context
@@ -738,11 +684,8 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                                  (magent-request-context-notify
                                   request-state 'assistant-delta
                                   :text (magent-sampling-event-text event))
-                                 (record-text-delta (magent-sampling-event-text event))
-                                 (when (and text-callback
-                                            (magent-agent--ui-visible-p request-state))
-                                   (funcall text-callback
-                                            (magent-sampling-event-text event))))
+                                 (record-text-delta
+                                  (magent-sampling-event-text event)))
                                 ('reasoning-delta
                                  (magent-request-context-notify
                                   request-state 'reasoning-delta
@@ -815,9 +758,7 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
                             :request-context request-state
                             :event-context context
                             :owns-event-context-p owns-context
-                            :turn-id (and request-state
-                                          (magent-request-context-turn-id
-                                           request-state))
+                            :turn-id (magent-request-context-turn-id request-state)
                             :sampler #'magent-sampling-gptel-sample))
                      (sample)
                      loop)))))))
@@ -829,59 +770,23 @@ The tool calling loop is managed by `magent-agent-loop'.  This function:
            (magent-lifecycle-events-end-turn context 'failed message)))
        (signal (car err) (cdr err))))))
 
-(cl-defun magent-agent--prepare-request-state
-    (&key session request-state context observer approval-provider request-live-p)
-  "Return REQUEST-STATE configured for one SESSION turn.
-Existing request-state values retain precedence for CONTEXT, OBSERVER, and
-APPROVAL-PROVIDER.  REQUEST-LIVE-P can force the request to remain live."
-  (let ((request-state
-         (or request-state
-             (magent-request-context-create
-              :session session
-              :ui-visibility 'none))))
-    (setf (magent-request-context-session request-state) session
-          (magent-request-context-origin-context request-state)
-          (or (magent-request-context-origin-context request-state) context)
-          (magent-request-context-observer request-state)
-          (or (magent-request-context-observer request-state) observer)
-          (magent-request-context-approval-provider request-state)
-          (or (magent-request-context-approval-provider request-state)
-              approval-provider)
-          (magent-request-context-ui-visibility request-state)
-          (or (magent-request-context-ui-visibility request-state) 'none)
-          (magent-request-context-live-p request-state)
-          (or request-live-p
-              (magent-request-context-live-p request-state)))
-    request-state))
-
 (cl-defun magent-agent-run-turn
-    (&key session prompt agent skills context observer request-context
-          approval-provider capability-resolution on-complete request-live-p)
-  "Run one Magent turn for SESSION with PROMPT.
-This is the UI-neutral execution entry point.  OBSERVER receives
-Magent-native request events through REQUEST-CONTEXT.  ON-COMPLETE is
-called with one final `magent-execution-result'."
-  (unless session
-    (error ":session is required"))
-  (unless prompt
-    (error ":prompt is required"))
-  (let ((request-state
-         (magent-agent--prepare-request-state
-          :session session
-          :request-state request-context
-          :context context
-          :observer observer
-          :approval-provider approval-provider
-          :request-live-p request-live-p)))
-    (magent-agent--execute-turn
-     :user-prompt prompt
-     :callback on-complete
-     :agent-info agent
-     :skill-names skills
-     :dispatch-context context
-     :capability-resolution capability-resolution
-     :request-live-p (magent-request-context-live-p request-state)
-     :request-state request-state)))
+    (request-context &key capability-resolution on-complete)
+  "Run the turn captured by REQUEST-CONTEXT.
+This is the UI-neutral execution entry point.  REQUEST-CONTEXT is the single
+request envelope; ON-COMPLETE receives one final `magent-execution-result'."
+  (unless (magent-request-context-p request-context)
+    (error "Expected a Magent request context, got: %S" request-context))
+  (unless (magent-session-p
+           (magent-request-context-session request-context))
+    (error "Request context has no Magent session"))
+  (unless (stringp (magent-request-context-prompt request-context))
+    (error "Request context has no prompt"))
+  (magent-agent--execute-turn
+   :user-prompt (magent-request-context-prompt request-context)
+   :callback on-complete
+   :capability-resolution capability-resolution
+   :request-state request-context))
 
 (provide 'magent-agent)
 ;;; magent-agent.el ends here

--- a/lisp/magent-capability.el
+++ b/lisp/magent-capability.el
@@ -38,6 +38,7 @@
 (require 'magent-skills)
 
 (declare-function magent-runtime-session-current "magent-runtime-api")
+(declare-function magent-runtime-session-scope "magent-runtime-api" t t)
 (declare-function magent-runtime-session-available-tool-names
                   "magent-runtime-api")
 
@@ -97,7 +98,7 @@ The output shape is intentionally inspectable:
 (defvar magent-capability--registry nil
   "Layered alist of (capability-name . `magent-capability').
 The first definition for a name is effective; shadowed definitions are kept
-so project overlays can be removed without rebuilding static registries.")
+so each request scope can resolve without rebuilding static registries.")
 
 (defun magent-capability--same-owner-p (left right)
   "Return non-nil when capabilities LEFT and RIGHT have the same owner."
@@ -106,11 +107,27 @@ so project overlays can be removed without rebuilding static registries.")
        (equal (magent-capability-source-scope left)
               (magent-capability-source-scope right))))
 
-(defun magent-capability--effective-entries ()
-  "Return effective capability entries without shadowed duplicates."
-  (let (seen effective)
+(defun magent-capability--resolution-scope (&optional scope)
+  "Return canonical capability resolution scope for optional SCOPE."
+  (magent-session-canonical-scope
+   (or scope (magent-runtime-active-project-scope) 'global)))
+
+(defun magent-capability--visible-in-scope-p (capability scope)
+  "Return non-nil when CAPABILITY is visible in canonical SCOPE."
+  (let ((source-scope
+         (magent-session-canonical-scope
+          (magent-capability-source-scope capability))))
+    (or (null source-scope)
+        (equal source-scope scope))))
+
+(defun magent-capability--effective-entries (&optional scope)
+  "Return effective capability entries visible in SCOPE."
+  (let ((resolution-scope (magent-capability--resolution-scope scope))
+        seen effective)
     (dolist (entry magent-capability--registry)
-      (unless (member (car entry) seen)
+      (when (and (not (member (car entry) seen))
+                 (magent-capability--visible-in-scope-p
+                  (cdr entry) resolution-scope))
         (push (car entry) seen)
         (push entry effective)))
     (nreverse effective)))
@@ -194,13 +211,13 @@ When EMBEDDED is non-nil, accept the complete SKILL.md schema."
          #'magent-capability-source-scope
          scope)))
 
-(defun magent-capability-get (name)
-  "Return capability NAME from the registry."
-  (cdr (assoc name magent-capability--registry)))
+(defun magent-capability-get (name &optional scope)
+  "Return effective capability NAME visible in SCOPE."
+  (cdr (assoc name (magent-capability--effective-entries scope))))
 
-(defun magent-capability-list ()
-  "Return a sorted list of registered capability names."
-  (sort (mapcar #'car (magent-capability--effective-entries)) #'string<))
+(defun magent-capability-list (&optional scope)
+  "Return sorted capability names visible in SCOPE."
+  (sort (mapcar #'car (magent-capability--effective-entries scope)) #'string<))
 
 (defun magent-capability--source-owner (filepath)
   "Classify FILEPATH for capability governance purposes."
@@ -447,7 +464,8 @@ capabilities."
   (magent-capability-load-all magent-capability-directories))
 
 (defun magent-capability-load-project-scope (scope)
-  "Load project-local capability definitions for SCOPE."
+  "Reload project-local capability definitions for SCOPE."
+  (magent-capability-remove-project-scope scope)
   (let ((skill-directories
          (magent-file-loader-project-subdir-for-scope
           ".magent/skills" scope))
@@ -461,17 +479,27 @@ capabilities."
            (magent-capability-load-all capability-directories)
          0))))
 
+(defun magent-capability--project-scopes ()
+  "Return project scopes to refresh from the registry and current context."
+  (delete-dups
+   (delq nil
+         (cons
+          (magent-runtime-active-project-scope)
+          (mapcar
+           (lambda (entry)
+             (and (eq (magent-capability-source-layer (cdr entry)) 'project)
+                  (magent-capability-source-scope (cdr entry))))
+           magent-capability--registry)))))
+
 (defun magent-capability-reload ()
-  "Reload all file-backed capabilities.
-When a project overlay is currently active, restore that project's
-local capabilities after static definitions are reloaded."
-  (let ((project-scope (magent-runtime-active-project-scope)))
+  "Reload all file-backed capabilities for every known project scope."
+  (let ((project-scopes (magent-capability--project-scopes)))
     (magent-file-loader-reload-file-backed-registry
      'magent-capability--registry
      #'magent-capability-file-path
      #'magent-capability-initialize-static)
-    (when project-scope
-      (magent-capability-load-project-scope project-scope))))
+    (dolist (scope project-scopes)
+      (magent-capability-load-project-scope scope))))
 
 ;;;###autoload
 (defun magent-reload-capabilities ()
@@ -716,11 +744,14 @@ source for contextual capability resolution."
                       :contributions contributions)
        :status status)))
 
-(defun magent-capability--skill-usable-p (skill-name available-tools)
+(defun magent-capability--skill-usable-p
+    (skill-name available-tools &optional scope)
   "Return non-nil when SKILL-NAME's tool requirements are AVAILABLE-TOOLS."
-  (magent-skills-tool-requirements-satisfied-p skill-name available-tools))
+  (magent-skills-tool-requirements-satisfied-p
+   skill-name available-tools scope))
 
-(defun magent-capability--apply-tool-availability (match available-tools)
+(defun magent-capability--apply-tool-availability
+    (match available-tools &optional scope)
   "Downgrade MATCH when no linked skill can use AVAILABLE-TOOLS."
   (when (eq (magent-capability-match-status match) 'active)
     (let* ((capability (magent-capability-match-capability match))
@@ -728,7 +759,7 @@ source for contextual capability resolution."
            (usable (cl-remove-if-not
                     (lambda (skill-name)
                       (magent-capability--skill-usable-p
-                       skill-name available-tools))
+                       skill-name available-tools scope))
                     skills)))
       (when (and skills (null usable))
         (setf (magent-capability-match-status match) 'suggested
@@ -801,7 +832,7 @@ source for contextual capability resolution."
                   (magent-capability-resolution-matches resolution)))))
 
 (defun magent-capability-resolve
-    (prompt request-context explicit-skills available-tools)
+    (prompt request-context explicit-skills available-tools &optional scope)
   "Resolve capabilities for PROMPT and REQUEST-CONTEXT.
 EXPLICIT-SKILLS are user-selected instruction skills that should
 remain active regardless of capability selection.  Linked skills whose
@@ -809,14 +840,20 @@ declared tools are absent from AVAILABLE-TOOLS do not auto-activate."
   (unless (proper-list-p available-tools)
     (error "Capability resolution requires an exact tool-name list: %S"
            available-tools))
-  (let* ((context (magent-capability--merge-context request-context prompt))
+  (let* ((resolution-scope
+          (or scope
+              (and (magent-request-context-p request-context)
+                   (magent-request-context-scope request-context))
+              'global))
+         (context (magent-capability--merge-context request-context prompt))
          (matches (magent-capability--sort-matches
                    (mapcar (lambda (entry)
                              (magent-capability--apply-tool-availability
                               (magent-capability--score
                                (cdr entry) prompt context)
-                              available-tools))
-                           (magent-capability--effective-entries))))
+                              available-tools resolution-scope))
+                           (magent-capability--effective-entries
+                            resolution-scope))))
          (active-all (cl-remove-if-not
                       (lambda (match)
                         (eq (magent-capability-match-status match) 'active))
@@ -835,7 +872,8 @@ declared tools are absent from AVAILABLE-TOOLS do not auto-activate."
                                             (cl-remove-if-not
                                              (lambda (skill-name)
                                                (magent-capability--skill-usable-p
-                                                skill-name available-tools))
+                                                skill-name available-tools
+                                                resolution-scope))
                                              (copy-sequence
                                               (magent-capability-skills
                                                (magent-capability-match-capability
@@ -1051,7 +1089,8 @@ When INCLUDE-HIDDEN is non-nil, include hidden matches too."
          (resolution (magent-capability-resolve
                       (or prompt "")
                       (magent-capability-capture-context)
-                      nil available-tools))
+                      nil available-tools
+                      (magent-runtime-session-scope runtime-session)))
          (buffer-name "*Magent Capability Resolution*"))
     (setq magent-capability--last-resolution resolution)
     (magent--with-display-buffer buffer-name

--- a/lisp/magent-file-loader.el
+++ b/lisp/magent-file-loader.el
@@ -215,7 +215,7 @@ backslash, so a value such as `C:\\\\tmp' otherwise becomes a tab."
 (defun magent-file-loader-lexical-file-under-directory-p (filepath directory)
   "Return non-nil when FILEPATH's entry path is inside DIRECTORY.
 Unlike `magent-file-loader-file-under-directory-p', this ownership check does
-not follow the final symlink.  It is used to classify project overlay entries;
+not follow the final symlink.  It classifies project-owned definitions;
 resource access may still canonicalize the target independently."
   (and filepath directory
        (string-prefix-p

--- a/lisp/magent-runtime-api.el
+++ b/lisp/magent-runtime-api.el
@@ -8,6 +8,8 @@
 
 ;; Stable UI/backend-facing runtime API.  UI backends submit prompts to a
 ;; runtime session and receive request-local Magent-native observer events.
+;; Submission freezes one request context before queueing; the queue does not
+;; reconstruct execution policy when the turn starts.
 
 ;;; Code:
 
@@ -231,16 +233,21 @@ submission so the source frontend stays current."
 (defun magent-runtime-api--resolve-agent (runtime-session &optional agent-or-name)
   "Resolve AGENT-OR-NAME for RUNTIME-SESSION without changing session state."
   (let* ((session (magent-runtime-session-magent-session runtime-session))
+         (scope (magent-runtime-session-scope runtime-session))
          (agent
           (cond
            ((null agent-or-name)
-            (or (magent-session-agent session)
-                (magent-agent-registry-get-default)))
+            (or (and (magent-session-agent session)
+                     (magent-agent-registry-get
+                      (magent-agent-info-name (magent-session-agent session))
+                      scope))
+                (magent-agent-registry-get-default scope)))
            ((magent-agent-info-p agent-or-name) agent-or-name)
            ((stringp agent-or-name)
-            (magent-agent-registry-get agent-or-name))
+            (magent-agent-registry-get agent-or-name scope))
            ((symbolp agent-or-name)
-            (magent-agent-registry-get (symbol-name agent-or-name))))))
+            (magent-agent-registry-get
+             (symbol-name agent-or-name) scope)))))
     (unless agent
       (error "Unknown Magent agent: %S" agent-or-name))
     agent))
@@ -256,9 +263,7 @@ submission so the source frontend stays current."
 
 (defun magent-runtime-session-agent-name (runtime-session)
   "Return RUNTIME-SESSION's active agent name."
-  (let* ((session (magent-runtime-session-magent-session runtime-session))
-         (agent (or (magent-session-agent session)
-                    (magent-agent-registry-get-default))))
+  (let ((agent (magent-runtime-api--resolve-agent runtime-session)))
     (and agent (magent-agent-info-name agent))))
 
 (defun magent-runtime-session-model-route-option (runtime-session)
@@ -410,22 +415,9 @@ Any active or queued work for the session is cancelled first."
 
 (defun magent-runtime-api--notify-submission (submission type &rest props)
   "Notify SUBMISSION's observer of TYPE with PROPS."
-  (when-let* ((observer (magent-runtime-submission-observer submission)))
-    (let ((event (append
-                  (list :type type
-                        :time (float-time)
-                        :session-id
-                        (magent-runtime-submission-session-id submission)
-                        :submission-id
-                        (magent-runtime-submission-id submission)
-                        :turn-id
-                        (magent-runtime-submission-turn-id submission))
-                  props)))
-      (condition-case err
-          (funcall observer event)
-        (error
-         (magent-log "ERROR runtime observer failed: %s"
-                     (error-message-string err)))))))
+  (when-let* ((request-context
+               (magent-runtime-submission-request-context submission)))
+    (apply #'magent-request-context-notify request-context type props)))
 
 (defun magent-runtime-api--prepare-turn
     (runtime-session prompt &optional metadata)
@@ -483,34 +475,39 @@ Any active or queued work for the session is cancelled first."
       (magent-runtime-api--call-completion submission status result))))
 
 (defun magent-runtime-api--submission-execution-scope (submission)
-  "Return the project/global overlay scope for SUBMISSION."
-  (let* ((runtime-session (magent-runtime-submission-session submission))
-         (scope (or (magent-runtime-submission-scope submission)
-                    (and runtime-session
+  "Return the project/global definition scope for SUBMISSION."
+  (let* ((runtime-session
+          (magent-runtime-submission-runtime-session submission))
+         (scope (or (and runtime-session
                          (magent-runtime-session-scope runtime-session))
                     'global)))
     (magent-session-scope-origin scope)))
 
 (defun magent-runtime-api--activate-submission-session (submission)
-  "Activate SUBMISSION's project overlay and install its session."
-  (let ((runtime-session (magent-runtime-submission-session submission)))
+  "Prepare SUBMISSION's definition scope and install its session."
+  (let ((runtime-session
+         (magent-runtime-submission-runtime-session submission)))
     (magent-runtime-activate-scope
      (magent-runtime-api--submission-execution-scope submission))
     (magent-session-install
      (magent-runtime-session-scope runtime-session)
      (magent-runtime-session-magent-session runtime-session))
-    ;; Overlay activation refreshes the session currently registered for its
-    ;; ordinary scope.  Internal sessions and captured sessions installed only
-    ;; after that activation still need an explicit refresh.
+    ;; Scope preparation refreshes the session already registered for its
+    ;; ordinary scope.  Internal and captured sessions installed only after
+    ;; preparation still need an explicit refresh.
     (magent-session-refresh-agent
-     (magent-runtime-session-magent-session runtime-session))))
+     (magent-runtime-session-magent-session runtime-session)
+     (magent-runtime-session-scope runtime-session))))
 
 (defun magent-runtime-api--mark-submission-turn-started (submission)
   "Mark SUBMISSION's ledger turn in progress, when it has one."
-  (when-let* ((runtime-session (magent-runtime-submission-session submission))
+  (when-let* ((runtime-session
+               (magent-runtime-submission-runtime-session submission))
               (session (magent-runtime-session-magent-session runtime-session))
               (thread (magent-session-thread-ledger session))
-              (turn-id (magent-runtime-submission-turn-id submission))
+              (request-context
+               (magent-runtime-submission-request-context submission))
+              (turn-id (magent-request-context-turn-id request-context))
               (turn (magent-thread-find-turn thread turn-id)))
     (unless (magent-thread-terminal-turn-p turn)
       (magent-thread-start-turn thread turn-id)
@@ -519,10 +516,13 @@ Any active or queued work for the session is cancelled first."
 
 (defun magent-runtime-api--mark-submission-turn-dropped (submission detail)
   "Mark queued SUBMISSION's ledger turn dropped with DETAIL."
-  (when-let* ((runtime-session (magent-runtime-submission-session submission))
+  (when-let* ((runtime-session
+               (magent-runtime-submission-runtime-session submission))
               (session (magent-runtime-session-magent-session runtime-session))
               (thread (magent-session-thread-ledger session))
-              (turn-id (magent-runtime-submission-turn-id submission))
+              (request-context
+               (magent-runtime-submission-request-context submission))
+              (turn-id (magent-request-context-turn-id request-context))
               (turn (magent-thread-find-turn thread turn-id)))
     (unless (magent-thread-terminal-turn-p turn)
       (magent-thread-drop-turn thread turn-id detail)
@@ -531,10 +531,13 @@ Any active or queued work for the session is cancelled first."
 
 (defun magent-runtime-api--mark-submission-turn-interrupted (submission detail)
   "Mark active SUBMISSION's ledger turn interrupted with DETAIL."
-  (when-let* ((runtime-session (magent-runtime-submission-session submission))
+  (when-let* ((runtime-session
+               (magent-runtime-submission-runtime-session submission))
               (session (magent-runtime-session-magent-session runtime-session))
               (thread (magent-session-thread-ledger session))
-              (turn-id (magent-runtime-submission-turn-id submission))
+              (request-context
+               (magent-runtime-submission-request-context submission))
+              (turn-id (magent-request-context-turn-id request-context))
               (turn (magent-thread-find-turn thread turn-id)))
     (unless (magent-thread-terminal-turn-p turn)
       (magent-thread-interrupt-turn thread turn-id detail)
@@ -543,10 +546,13 @@ Any active or queued work for the session is cancelled first."
 
 (defun magent-runtime-api--mark-submission-turn-failed (submission detail)
   "Mark SUBMISSION's ledger turn failed with DETAIL."
-  (when-let* ((runtime-session (magent-runtime-submission-session submission))
+  (when-let* ((runtime-session
+               (magent-runtime-submission-runtime-session submission))
               (session (magent-runtime-session-magent-session runtime-session))
               (thread (magent-session-thread-ledger session))
-              (turn-id (magent-runtime-submission-turn-id submission))
+              (request-context
+               (magent-runtime-submission-request-context submission))
+              (turn-id (magent-request-context-turn-id request-context))
               (turn (magent-thread-find-turn thread turn-id)))
     (unless (magent-thread-terminal-turn-p turn)
       (magent-thread-fail-turn thread turn-id detail)
@@ -559,42 +565,19 @@ Any active or queued work for the session is cancelled first."
       (progn
         (magent-runtime-api--activate-submission-session submission)
         (magent-runtime-api--mark-submission-turn-started submission)
-        (let* ((runtime-session (magent-runtime-submission-session submission))
-               (session (magent-runtime-session-magent-session runtime-session))
-               (request-context
-                (magent-request-context-create
-                 :id (magent-runtime-submission-id submission)
-                 :scope (magent-runtime-session-scope runtime-session)
-                 :session session
-                 :turn-id (magent-runtime-submission-turn-id submission)
-                 :approval-session session
-                 :ui-visibility 'none
-                 :origin-context (magent-runtime-submission-context submission)
-                 :tool-names (magent-runtime-submission-tool-names submission)
-                 :model-route (magent-runtime-submission-model-route submission)
-                 :effort (magent-runtime-submission-effort submission)
-                 :skill-names (magent-runtime-submission-skills submission)
-                 :approval-provider
-                 (magent-runtime-submission-approval-provider submission)
-                 :observer (magent-runtime-submission-observer submission)
-                 :submission-id (magent-runtime-submission-id submission)
-                 :live-p (lambda ()
-                           (magent-runtime-api--submission-live-p submission)))))
+        (let* ((request-context
+                (magent-runtime-submission-request-context submission))
+               (prompt (magent-request-context-prompt request-context)))
           (when (magent-runtime-api--submission-live-p submission)
             (magent-runtime-api--notify-submission submission 'turn-start))
           (when (magent-runtime-api--submission-live-p submission)
             (magent-runtime-api--notify-submission
              submission 'user-message
-             :text (magent-runtime-submission-prompt submission)))
+             :text prompt))
           (when (magent-runtime-api--submission-live-p submission)
             (let ((handle
                    (magent-agent-run-turn
-                    :session session
-                    :prompt (magent-runtime-submission-prompt submission)
-                    :agent (magent-runtime-submission-agent submission)
-                    :skills (magent-runtime-submission-skills submission)
-                    :context (magent-runtime-submission-context submission)
-                    :request-context request-context
+                    request-context
                     :on-complete
                     (lambda (result)
                       (let ((status
@@ -629,7 +612,9 @@ Any active or queued work for the session is cancelled first."
       (dolist (name skill-names)
         (let* ((skill-name (if (symbolp name) (symbol-name name) name))
                (skill (and (stringp skill-name)
-                           (magent-skills-get skill-name))))
+                           (magent-skills-get
+                            skill-name
+                            (magent-runtime-session-scope runtime-session)))))
           (when (and skill
                      (magent-skill-requires-project skill)
                      (not (stringp origin)))
@@ -690,19 +675,22 @@ request-local Magent-native events."
            runtime-session effective-agent)))
     (magent-runtime-api--validate-skill-scope
      runtime-session effective-skills)
-    (let* ((turn-id (magent-runtime-api--prepare-turn
+    (let* ((submission-id (magent-protocol-generate-id "submission"))
+           (session (magent-runtime-session-magent-session runtime-session))
+           (turn-id (magent-runtime-api--prepare-turn
                      runtime-session prompt turn-metadata))
-           (submission
-            (magent-runtime-submission-create
-             :id (magent-protocol-generate-id "submission")
-             :session runtime-session
-             :session-id (magent-runtime-session-id runtime-session)
+           (request-context
+            (magent-request-context-create
+             :id submission-id
              :scope (magent-runtime-session-scope runtime-session)
+             :session session
              :prompt prompt
-             :context context
-             :tool-names effective-tools
-             :skills effective-skills
              :agent effective-agent
+             :turn-id turn-id
+             :approval-session session
+             :ui-visibility 'none
+             :origin-context context
+             :tool-names effective-tools
              :model-route
              (and model-routing-configured-p
                   (magent-runtime-session-effective-model-route
@@ -710,10 +698,19 @@ request-local Magent-native events."
              :effort (or (magent-effort-normalize-option effort)
                          (magent-effort-normalize-option
                           (magent-runtime-session-effort runtime-session)))
-             :observer observer
+             :skill-names effective-skills
              :approval-provider approval-provider
-             :on-complete on-complete
-             :turn-id turn-id)))
+             :observer observer
+             :submission-id submission-id))
+           (submission
+            (magent-runtime-submission-create
+             :id submission-id
+             :runtime-session runtime-session
+             :request-context request-context
+             :on-complete on-complete)))
+      (setf (magent-request-context-live-p request-context)
+            (lambda ()
+              (magent-runtime-api--submission-live-p submission)))
       (magent-runtime-session-clear-pending-skills runtime-session)
       (magent-runtime-queue-submit
        submission #'magent-runtime-api--start-submission))))
@@ -730,7 +727,9 @@ session's selected user-facing agent."
   (unless (magent-runtime-session-p runtime-session)
     (error "Expected runtime session, got: %S" runtime-session))
   (magent-runtime-api--assert-session-available runtime-session)
-  (let* ((compaction-agent (magent-agent-registry-get "compaction"))
+  (let* ((compaction-agent
+          (magent-agent-registry-get
+           "compaction" (magent-runtime-session-scope runtime-session)))
          (pending-skills
           (magent-runtime-session-pending-skills runtime-session))
          (extra (string-trim (or instruction "")))
@@ -783,7 +782,8 @@ Return non-nil when an active or queued submission was cancelled."
        (magent-execution-result-cancelled reason (list :reason 'cancelled)))
       t)
      ((and active
-           (eq (magent-runtime-submission-session active) runtime-session)
+           (eq (magent-runtime-submission-runtime-session active)
+               runtime-session)
            (equal (magent-runtime-submission-id active) submission-id))
       (setf (magent-runtime-submission-status active) 'cancelled)
       (when-let* ((handle (magent-runtime-submission-handle active)))
@@ -808,7 +808,7 @@ Return non-nil when an active or queued submission was cancelled."
        (magent-execution-result-cancelled
         "Queued turn cancelled" (list :reason 'cancelled))))
     (when (and active
-               (eq (magent-runtime-submission-session active)
+               (eq (magent-runtime-submission-runtime-session active)
                    runtime-session))
       (setf (magent-runtime-submission-status active) 'cancelled)
       (when-let* ((handle (magent-runtime-submission-handle active)))
@@ -822,7 +822,7 @@ Return non-nil when an active or queued submission was cancelled."
         "Active turn cancelled" (list :reason 'cancelled))))
     (+ (length removed)
        (if (and active
-                (eq (magent-runtime-submission-session active)
+                (eq (magent-runtime-submission-runtime-session active)
                     runtime-session))
            1
          0))))

--- a/lisp/magent-runtime-queue.el
+++ b/lisp/magent-runtime-queue.el
@@ -7,8 +7,9 @@
 ;;; Commentary:
 
 ;; Global single-execution queue for Magent runtime submissions.  Each
-;; submission retains its runtime session object so cancellation remains
-;; identity-scoped even though the first implementation runs one turn at a time.
+;; submission retains its exact runtime session wrapper and one canonical
+;; request context.  Cancellation remains identity-scoped even though the
+;; first implementation runs one turn at a time.
 
 ;;; Code:
 
@@ -19,25 +20,14 @@
                (:constructor magent-runtime-submission-create)
                (:copier nil))
   id
-  session
-  session-id
-  prompt
-  context
-  tool-names
-  skills
-  agent
-  model-route
-  effort
-  observer
-  approval-provider
+  runtime-session
+  request-context
   on-complete
   starter
-  scope
   status
   submitted-at
   started-at
   finished-at
-  turn-id
   handle
   detail
   finalized)
@@ -73,6 +63,8 @@
 Callbacks keep the runtime queue independent of backend-specific token types.")
 
 (declare-function magent-runtime-session-magent-session
+                  "magent-runtime-api" t t)
+(declare-function magent-runtime-session-scope
                   "magent-runtime-api" t t)
 
 (defun magent-runtime-queue--set-ticket-adapters
@@ -291,7 +283,10 @@ was finished without a successor, or nil when TOKEN did not own the lease."
               (token (magent-runtime-arbiter-ticket-token ticket)))
     (let ((scope
            (pcase (magent-runtime-arbiter-ticket-owner ticket)
-             ('runtime (magent-runtime-submission-scope token))
+             ('runtime
+              (when-let* ((runtime-session
+                           (magent-runtime-submission-runtime-session token)))
+                (magent-runtime-session-scope runtime-session)))
              (_ (magent-runtime-queue--ticket-adapter-call
                  ticket :scope)))))
       (if (and scope (fboundp 'magent-session-scope-origin))
@@ -318,7 +313,7 @@ runtime session wrapper."
    (if runtime-session
        (cl-remove-if-not
         (lambda (submission)
-          (eq (magent-runtime-submission-session submission)
+          (eq (magent-runtime-submission-runtime-session submission)
               runtime-session))
         magent-runtime-queue--pending)
      magent-runtime-queue--pending)))
@@ -393,7 +388,8 @@ started."
   "Remove queued submissions for exact RUNTIME-SESSION and return them."
   (let (removed kept)
     (dolist (submission magent-runtime-queue--pending)
-      (if (eq (magent-runtime-submission-session submission) runtime-session)
+      (if (eq (magent-runtime-submission-runtime-session submission)
+              runtime-session)
           (progn
             (setf (magent-runtime-submission-status submission) 'cancelled
                   (magent-runtime-submission-finished-at submission) (float-time))
@@ -410,7 +406,7 @@ Return the removed submission, or nil when it is not queued."
   (let (removed kept)
     (dolist (submission magent-runtime-queue--pending)
       (if (and (null removed)
-               (eq (magent-runtime-submission-session submission)
+               (eq (magent-runtime-submission-runtime-session submission)
                    runtime-session)
                (equal (magent-runtime-submission-id submission)
                       submission-id))
@@ -426,7 +422,7 @@ Return the removed submission, or nil when it is not queued."
 (defun magent-runtime-queue--submission-session-object (submission)
   "Return the Magent session captured by runtime SUBMISSION, or nil."
   (when-let* ((runtime-session
-               (magent-runtime-submission-session submission)))
+               (magent-runtime-submission-runtime-session submission)))
     (when (fboundp 'magent-runtime-session-magent-session)
       (magent-runtime-session-magent-session runtime-session))))
 

--- a/lisp/magent-runtime.el
+++ b/lisp/magent-runtime.el
@@ -8,8 +8,7 @@
 
 ;; Central runtime orchestration for Magent.  This module owns:
 ;; - request-scoped execution context
-;; - project-local overlay activation for agents, skills, commands, and
-;;   capabilities
+;; - project-local definition loading for agents, skills, and capabilities
 
 ;;; Code:
 
@@ -29,10 +28,6 @@
 (declare-function magent-capability-load-project-scope "magent-capability")
 (declare-function magent-capability-remove-project-scope "magent-capability")
 (declare-function magent-action-initialize-static "magent-action")
-(declare-function magent-action-load-project-scope "magent-action")
-(declare-function magent-action-remove-project-scope "magent-action")
-(declare-function magent-runtime-queue-active-scope "magent-runtime-queue")
-(declare-function magent-runtime-queue-execution-active-p "magent-runtime-queue")
 (declare-function magent-skills-initialize-static "magent-skills")
 (declare-function magent-skills-load-project-scope "magent-skills")
 (declare-function magent-skills-remove-project-scope "magent-skills")
@@ -49,42 +44,33 @@ Each function is called without arguments.  The first non-nil return value
 wins; when all functions return nil, scope is derived from
 `default-directory'.")
 
-(defconst magent-runtime--overlay-specs
+(defconst magent-runtime--definition-specs
   '((:name agents
-           :state-variable magent-agent-registry--agents
            :static-feature magent-agent-registry
            :static magent-agent-initialize-static
            :load-project-feature magent-agent-file
            :load-project magent-agent-file-load-project-scope
-           :unload-project-feature magent-agent-registry
-           :unload-project magent-agent-registry-remove-project-scope
+           :remove-project-feature magent-agent-registry
+           :remove-project magent-agent-registry-remove-project-scope
            :project-enabled magent-load-custom-agents)
     (:name skills
-           :state-variables (magent-skills--registry
-                             magent-skills--scope-catalog)
            :static-feature magent-skills
            :static magent-skills-initialize-static
            :load-project-feature magent-skills
            :load-project magent-skills-load-project-scope
-           :unload-project-feature magent-skills
-           :unload-project magent-skills-remove-project-scope)
+           :remove-project-feature magent-skills
+           :remove-project magent-skills-remove-project-scope)
     (:name actions
-           :state-variable magent-action--registry
            :static-feature magent-action
-           :static magent-action-initialize-static
-           :load-project-feature magent-action
-           :load-project magent-action-load-project-scope
-           :unload-project-feature magent-action
-           :unload-project magent-action-remove-project-scope)
+           :static magent-action-initialize-static)
     (:name capabilities
-           :state-variable magent-capability--registry
            :static-feature magent-capability
            :static magent-capability-initialize-static
            :load-project-feature magent-capability
            :load-project magent-capability-load-project-scope
-           :unload-project-feature magent-capability
-           :unload-project magent-capability-remove-project-scope))
-  "Ordered overlay pipeline for Magent runtime definitions.")
+           :remove-project-feature magent-capability
+           :remove-project magent-capability-remove-project-scope))
+  "Ordered initialization and project-loading pipeline for definitions.")
 
 (cl-defstruct (magent-request-context
                (:constructor magent-request-context-create)
@@ -93,6 +79,8 @@ wins; when all functions return nil, scope is derived from
   id
   scope
   session
+  prompt
+  agent
   turn-id
   approval-session
   origin-buffer-name
@@ -160,8 +148,9 @@ objects, and other live runtime state so lifecycle sinks and completed
                      (condition-case nil
                          (magent-session-canonical-scope project-root)
                        (error (expand-file-name project-root)))))
-               (agent (and valid-session
-                           (magent-session-agent valid-session)))
+               (agent (or (magent-request-context-agent context)
+                          (and valid-session
+                               (magent-session-agent valid-session))))
                (candidate-event-context
                 (magent-request-context-event-context context))
                (event-context
@@ -223,15 +212,16 @@ isolated so UI/backend rendering cannot break the active agent turn."
     t))
 
 (defvar magent-runtime--active-project-scope nil
-  "Current project scope whose overlay definitions are active.
-Nil means only static definitions are loaded.")
+  "Most recently prepared interactive project scope.
+Project definitions for other scopes remain registered.  Nil means the
+interactive context is global, not that project definitions were unloaded.")
 
 (defun magent-runtime-active-project-scope ()
-  "Return the currently active project overlay scope, or nil."
+  "Return the most recently prepared interactive project scope, or nil."
   magent-runtime--active-project-scope)
 
-(defun magent-runtime--project-overlay-enabled-p (spec)
-  "Return non-nil when project overlay SPEC should load."
+(defun magent-runtime--project-definitions-enabled-p (spec)
+  "Return non-nil when project definitions for SPEC should load."
   (let ((enabled (plist-get spec :project-enabled)))
     (cond
      ((null enabled) t)
@@ -241,56 +231,28 @@ Nil means only static definitions are loaded.")
 
 (defun magent-runtime--run-static-initializers ()
   "Run all static definition initializers in dependency order."
-  (dolist (spec magent-runtime--overlay-specs)
+  (dolist (spec magent-runtime--definition-specs)
     (when-let* ((feature (plist-get spec :static-feature)))
       (require feature))
     (when-let* ((fn (plist-get spec :static)))
       (funcall fn))))
 
 (defun magent-runtime--phase-feature-key (phase)
-  "Return the feature key associated with overlay PHASE."
+  "Return the feature key associated with definition PHASE."
   (pcase phase
     (:load-project :load-project-feature)
-    (:unload-project :unload-project-feature)))
+    (:remove-project :remove-project-feature)))
 
-(defun magent-runtime--run-project-overlay-phase (phase scope)
-  "Run project overlay PHASE for SCOPE across all registered specs."
-  (dolist (spec magent-runtime--overlay-specs)
-    (when (or (eq phase :unload-project)
-              (magent-runtime--project-overlay-enabled-p spec))
+(defun magent-runtime--run-project-definition-phase (phase scope)
+  "Run project definition PHASE for SCOPE across all registered specs."
+  (dolist (spec magent-runtime--definition-specs)
+    (when (or (eq phase :remove-project)
+              (magent-runtime--project-definitions-enabled-p spec))
       (when-let* ((feature-key (magent-runtime--phase-feature-key phase))
                   (feature (plist-get spec feature-key)))
         (require feature))
       (when-let* ((fn (plist-get spec phase)))
         (funcall fn scope)))))
-
-(defun magent-runtime--copy-overlay-state (value)
-  "Return a transaction snapshot of overlay registry VALUE."
-  (cond
-   ((hash-table-p value) (copy-hash-table value))
-   ((consp value) (copy-tree value))
-   ((sequencep value) (copy-sequence value))
-   (t value)))
-
-(defun magent-runtime--snapshot-overlay-state ()
-  "Capture the registry state owned by every project overlay spec."
-  (cl-loop
-   for spec in magent-runtime--overlay-specs
-   append
-   (cl-loop
-    for variable in
-    (or (plist-get spec :state-variables)
-        (when-let* ((single (plist-get spec :state-variable)))
-          (list single)))
-    when (and variable (boundp variable))
-    collect (cons variable
-                  (magent-runtime--copy-overlay-state
-                   (symbol-value variable))))))
-
-(defun magent-runtime--restore-overlay-state (snapshot)
-  "Restore project overlay registries from SNAPSHOT."
-  (dolist (entry snapshot)
-    (set (car entry) (cdr entry))))
 
 (defun magent-runtime-initialize-static ()
   "Load Magent definitions that are independent of project scope."
@@ -317,63 +279,55 @@ Nil means only static definitions are loaded.")
 When SCOPE is nil, derive it from the current buffer context."
   (magent-runtime-ensure-initialized)
   (let ((target (or scope (magent-runtime-context-scope))))
-    (when (and (fboundp 'magent-runtime-queue-execution-active-p)
-               (magent-runtime-queue-execution-active-p)
-               (not (equal target
-                           (magent-runtime-queue-active-scope))))
-      (user-error
-       "Magent: cannot switch project definitions while a turn is active"))
     (magent-runtime-activate-scope target)))
 
-(defun magent-runtime--unload-project-overlay (scope)
-  "Unload project-local overlay definitions for SCOPE."
+(defun magent-runtime--remove-project-definitions (scope)
+  "Remove retained project definitions for SCOPE."
   (when scope
-    (magent-runtime--run-project-overlay-phase :unload-project scope)
-    (magent-log "INFO unloaded project overlay for %s" scope)))
+    (magent-runtime--run-project-definition-phase :remove-project scope)))
 
-(defun magent-runtime--load-project-overlay (scope)
-  "Load project-local overlay definitions for SCOPE."
+(defun magent-runtime--load-project-definitions (scope)
+  "Load or refresh project definitions for SCOPE."
   (when scope
-    (magent-runtime--run-project-overlay-phase :load-project scope)
-    (magent-log "INFO loaded project overlay for %s" scope)))
+    (magent-runtime--run-project-definition-phase :load-project scope)
+    (magent-log "INFO loaded project definitions for %s" scope)))
 
 (defun magent-runtime-activate-scope (scope &optional force)
-  "Activate project-local overlay definitions for SCOPE.
+  "Prepare SCOPE and load or refresh its project-local definitions.
 SCOPE must be either the symbol `global' or a normalized project root.
-When FORCE is non-nil, reload the overlay even if SCOPE is unchanged."
+Definitions from other project scopes remain registered and are filtered at
+resolution time.  When FORCE is non-nil, reload SCOPE even if it is unchanged."
   (let ((target-project-scope (unless (eq scope 'global) scope)))
     (when (or force
               (not (equal target-project-scope magent-runtime--active-project-scope)))
-      (let ((previous-scope magent-runtime--active-project-scope)
-            (snapshot (magent-runtime--snapshot-overlay-state)))
+      (let ((previous-scope magent-runtime--active-project-scope))
         (condition-case err
             (progn
-              (magent-runtime--unload-project-overlay previous-scope)
-              (setq magent-runtime--active-project-scope nil)
               (when target-project-scope
-                (magent-runtime--load-project-overlay target-project-scope))
+                (magent-runtime--load-project-definitions target-project-scope))
               (setq magent-runtime--active-project-scope target-project-scope))
           (error
-           ;; A loader may fail after registering only part of an overlay.
-           ;; Give every owner a chance to release non-registry state, then
-           ;; restore the exact definitions that were active before the
-           ;; switch.  The original activation error remains authoritative.
+           ;; Project definitions remain retained across ordinary scope
+           ;; switches.  A failed target load is removed fail-closed without
+           ;; disturbing definitions owned by another scope.
            (when target-project-scope
              (condition-case cleanup-error
-                 (magent-runtime--unload-project-overlay target-project-scope)
+                 (magent-runtime--remove-project-definitions
+                  target-project-scope)
                (error
                 (magent-log
-                 "WARN failed to unload partial project overlay during rollback: %s"
+                 "WARN failed to remove partial project definitions: %s"
                  (error-message-string cleanup-error)))))
-           (magent-runtime--restore-overlay-state snapshot)
-           (setq magent-runtime--active-project-scope previous-scope)
+           (setq magent-runtime--active-project-scope
+                 (unless (equal previous-scope target-project-scope)
+                   previous-scope))
            (signal (car err) (cdr err)))))))
   (when-let* ((session (and (not (eq scope 'global))
                             (magent-session-get-if-present scope))))
-    (magent-session-refresh-agent session))
+    (magent-session-refresh-agent session scope))
   (when (eq scope 'global)
     (when-let* ((session (magent-session-get-if-present 'global)))
-      (magent-session-refresh-agent session)))
+      (magent-session-refresh-agent session 'global)))
   scope)
 
 (provide 'magent-runtime)

--- a/lisp/magent-session.el
+++ b/lisp/magent-session.el
@@ -1051,14 +1051,13 @@ available, then saved atomically through the explicit session/scope API."
           (error-message-string err)))))
     session))
 
-(defun magent-session-refresh-agent (session)
-  "Refresh SESSION's agent pointer from the current registry.
-When the session references a custom agent that is no longer active for the
-current scope, clear it so Magent falls back to the default agent."
+(defun magent-session-refresh-agent (session &optional scope)
+  "Refresh SESSION's selected agent from the registry for SCOPE."
   (when-let* ((agent (magent-session-agent session)))
     (when (fboundp 'magent-agent-registry-get)
       (setf (magent-session-agent session)
-            (magent-agent-registry-get (magent-agent-info-name agent)))))
+            (magent-agent-registry-get
+             (magent-agent-info-name agent) scope))))
   session)
 
 (defun magent-session-list-files ()

--- a/lisp/magent-skills.el
+++ b/lisp/magent-skills.el
@@ -47,7 +47,7 @@ through these stages: understand intent -> write SKILL.md -> test in Emacs -> it
 ---
 name: skill-name
 description: When to trigger and what this skill does
-type: instruction
+type: instruction        # optional: instruction is the default
 tools: [bash, read_file] # optional: exact provider tool names this skill needs
 requires-project: true   # optional: reject the skill in global sessions
 capability: true         # optional: auto-activate this instruction skill by context
@@ -75,8 +75,10 @@ capability only exists to activate that same skill.
 
 ## Skill Locations
 
+- Codex user global: `~/.agents/skills/<name>/SKILL.md`
 - User global: `magent/skills/<name>/SKILL.md` under `user-emacs-directory`
-- Project-local: `.magent/skills/<name>/SKILL.md`
+- Project-local: `.agents/skills/<name>/SKILL.md` or
+  `.magent/skills/<name>/SKILL.md`
 
 Place each skill in its own subdirectory named after the skill.
 
@@ -170,12 +172,7 @@ use a skill - make it count."
 (defvar magent-skills--registry nil
   "Layered alist of (skill-name . magent-skill) definitions.
 For duplicate names the first entry is effective; lower-layer entries are
-kept so unloading a project overlay restores the previous definition.")
-
-(defvar magent-skills--scope-catalog (make-hash-table :test #'equal)
-  "Effective skill snapshots keyed by canonical project scope.
-The nil key stores the global snapshot.  Project snapshots are retained while
-their overlays are inactive so live frontend sessions remain scope-correct.")
+kept so each request scope can resolve its own effective definition.")
 
 (defun magent-skills--same-owner-p (left right)
   "Return non-nil when skills LEFT and RIGHT belong to the same layer."
@@ -184,11 +181,14 @@ their overlays are inactive so live frontend sessions remain scope-correct.")
        (equal (magent-skill-source-scope left)
               (magent-skill-source-scope right))))
 
-(defun magent-skills--effective-entries ()
-  "Return effective skill registry entries without shadowed duplicates."
-  (let (seen effective)
+(defun magent-skills--effective-entries (&optional scope)
+  "Return effective skill entries visible in SCOPE."
+  (let ((resolution-scope (magent-skills--resolution-scope scope))
+        seen effective)
     (dolist (entry magent-skills--registry)
-      (unless (member (car entry) seen)
+      (when (and (not (member (car entry) seen))
+                 (magent-skills--visible-in-scope-p
+                  (cdr entry) resolution-scope))
         (push (car entry) seen)
         (push entry effective)))
     (nreverse effective)))
@@ -208,40 +208,6 @@ their overlays are inactive so live frontend sessions remain scope-correct.")
     (or (null source-scope)
         (equal source-scope scope))))
 
-(defun magent-skills--registry-skills-for-scope (scope)
-  "Return effective registry skills visible in canonical SCOPE."
-  (let (seen skills)
-    (dolist (entry magent-skills--registry)
-      (let ((name (car entry))
-            (skill (cdr entry)))
-        (when (and (not (member name seen))
-                   (magent-skills--visible-in-scope-p skill scope))
-          (push name seen)
-          (push skill skills))))
-    (sort skills
-          (lambda (left right)
-            (string< (magent-skill-name left)
-                     (magent-skill-name right))))))
-
-(defun magent-skills--rebase-project-catalogs ()
-  "Rebase cached project catalogs on the current registry state."
-  (maphash
-   (lambda (scope _skills)
-     (when scope
-       (puthash scope
-                (magent-skills--registry-skills-for-scope scope)
-                magent-skills--scope-catalog)))
-   magent-skills--scope-catalog))
-
-(defun magent-skills--record-scope-catalog (&optional scope)
-  "Record effective skills for SCOPE from the active registry."
-  (let ((key (magent-skills--resolution-scope scope)))
-    (puthash key
-             (magent-skills--registry-skills-for-scope key)
-             magent-skills--scope-catalog)
-    (when (null key)
-      (magent-skills--rebase-project-catalogs))))
-
 (defun magent-skills--descriptor (skill)
   "Return frontend-neutral descriptor for SKILL."
   (magent-skill-descriptor-create
@@ -255,21 +221,12 @@ their overlays are inactive so live frontend sessions remain scope-correct.")
 
 (defun magent-skills-list-descriptors (&optional scope type)
   "Return effective skill descriptors for SCOPE, optionally limited to TYPE.
-When SCOPE is nil, use the currently active project overlay.  Results are
+When SCOPE is nil, use the current interactive project context.  Results are
 sorted by skill name and do not expose prompt bodies or executable handlers."
   (let* ((key (magent-skills--resolution-scope scope))
-         (active-key
-          (magent-session-canonical-scope
-           (or (magent-runtime-active-project-scope) 'global)))
          (skills
-          (if (equal key active-key)
-              (magent-skills--registry-skills-for-scope key)
-            (let ((cached (gethash key magent-skills--scope-catalog
-                                   'magent-skills--missing)))
-              (if (eq cached 'magent-skills--missing)
-                  (copy-sequence
-                   (gethash nil magent-skills--scope-catalog))
-                (copy-sequence cached))))))
+          (mapcar #'cdr
+                  (magent-skills--effective-entries (or key 'global)))))
     (setq skills
           (cl-remove-if
            (lambda (skill)
@@ -278,11 +235,15 @@ sorted by skill name and do not expose prompt bodies or executable handlers."
            skills))
     (mapcar
      #'magent-skills--descriptor
-     (if type
-         (cl-remove-if-not
-          (lambda (skill) (eq (magent-skill-type skill) type))
-          skills)
-       skills))))
+     (sort
+      (if type
+          (cl-remove-if-not
+           (lambda (skill) (eq (magent-skill-type skill) type))
+           skills)
+        skills)
+      (lambda (left right)
+        (string< (magent-skill-name left)
+                 (magent-skill-name right)))))))
 
 (defun magent-skills-resolve-descriptor (name &optional scope)
   "Return effective skill descriptor NAME for SCOPE, or nil."
@@ -290,21 +251,21 @@ sorted by skill name and do not expose prompt bodies or executable handlers."
            :key #'magent-skill-descriptor-name
            :test #'equal))
 
-(defun magent-skills-get (name)
-  "Get skill by NAME from registry."
-  (cdr (assoc name magent-skills--registry)))
+(defun magent-skills-get (name &optional scope)
+  "Return effective skill NAME visible in SCOPE."
+  (cdr (assoc name (magent-skills--effective-entries scope))))
 
-(defun magent-skills-list ()
-  "Return list of all registered skill names."
-  (mapcar #'car (magent-skills--effective-entries)))
+(defun magent-skills-list (&optional scope)
+  "Return registered skill names visible in SCOPE."
+  (mapcar #'car (magent-skills--effective-entries scope)))
 
-(defun magent-skills-list-by-type (type)
-  "Return list of skill names of TYPE."
+(defun magent-skills-list-by-type (type &optional scope)
+  "Return names of skills of TYPE visible in SCOPE."
   (delq nil
         (mapcar (lambda (entry)
                   (when (eq (magent-skill-type (cdr entry)) type)
                     (car entry)))
-                (magent-skills--effective-entries))))
+                (magent-skills--effective-entries scope))))
 
 (defun magent-skills-dedupe-names (names)
   "Return string NAMES without duplicates, preserving order."
@@ -314,10 +275,10 @@ sorted by skill name and do not expose prompt bodies or executable handlers."
         (push name seen)
         (push name result)))))
 
-(defun magent-skills-missing-tools (skill-name available-tools)
+(defun magent-skills-missing-tools (skill-name available-tools &optional scope)
   "Return SKILL-NAME's declared tools absent from AVAILABLE-TOOLS.
 Tool names may be strings or symbols.  An unknown skill has no requirements."
-  (when-let* ((skill (magent-skills-get skill-name)))
+  (when-let* ((skill (magent-skills-get skill-name scope)))
     (let ((available
            (mapcar (lambda (tool)
                      (if (symbolp tool) tool (intern (format "%s" tool))))
@@ -326,9 +287,9 @@ Tool names may be strings or symbols.  An unknown skill has no requirements."
                     (magent-skill-tools skill)))))
 
 (defun magent-skills-tool-requirements-satisfied-p
-    (skill-name available-tools)
+    (skill-name available-tools &optional scope)
   "Return non-nil when AVAILABLE-TOOLS includes all tools SKILL-NAME declares."
-  (null (magent-skills-missing-tools skill-name available-tools)))
+  (null (magent-skills-missing-tools skill-name available-tools scope)))
 
 (defun magent-skills-register (skill)
   "Register SKILL in the registry.
@@ -344,9 +305,7 @@ Shadowed lower-layer definitions remain registered for later restoration."
                                (magent-skills--same-owner-p
                                 (cdr entry) skill)))
                         magent-skills--registry))
-    (push (cons name skill) magent-skills--registry)
-    (magent-skills--record-scope-catalog
-     (or (magent-skill-source-scope skill) 'global)))
+    (push (cons name skill) magent-skills--registry))
   skill)
 
 (defun magent-skills-unregister (name)
@@ -354,34 +313,28 @@ Shadowed lower-layer definitions remain registered for later restoration."
   (setq magent-skills--registry
         (cl-remove-if (lambda (entry) (equal (car entry) name))
                       magent-skills--registry))
-  (maphash
-   (lambda (scope skills)
-     (puthash scope
-              (cl-remove name skills
-                         :key #'magent-skill-name
-                         :test #'equal)
-              magent-skills--scope-catalog))
-   magent-skills--scope-catalog)
-  (magent-skills--record-scope-catalog 'global))
+  nil)
 
 (defun magent-skills-clear ()
   "Clear all skills from registry."
-  (setq magent-skills--registry nil)
-  (clrhash magent-skills--scope-catalog))
+  (setq magent-skills--registry nil))
 
 ;;; Instruction skill prompts
 
-(defun magent-skills-get-instruction-prompts (&optional skill-names)
+(defun magent-skills-get-instruction-prompts (&optional skill-names scope)
   "Get combined prompts from instruction-type skills.
 If SKILL-NAMES is nil, return all instruction-type skill prompts.
 If SKILL-NAMES is a list, only include those skills."
   (let ((skills (if skill-names
-                    (delq nil (mapcar #'magent-skills-get skill-names))
+                    (delq nil
+                          (mapcar (lambda (name)
+                                    (magent-skills-get name scope))
+                                  skill-names))
                   (mapcar #'cdr
                           (cl-remove-if-not
                            (lambda (entry)
                              (eq (magent-skill-type (cdr entry)) 'instruction))
-                           (magent-skills--effective-entries))))))
+                           (magent-skills--effective-entries scope))))))
     (delq nil
           (mapcar (lambda (skill)
                     (when-let* ((prompt (magent-skill-prompt skill))
@@ -425,12 +378,19 @@ If SKILL-NAMES is a list, only include those skills."
         (expand-file-name "skills" dir)))
   "Directory containing built-in skills bundled with magent.")
 
+(defconst magent-skills--project-relative-directories
+  '(".agents/skills" ".magent/skills")
+  "Project-relative skill roots in increasing precedence order.")
+
 (defcustom magent-skill-directories
-  (list (expand-file-name "magent/skills" user-emacs-directory))
+  (list (expand-file-name ".agents/skills" (expand-file-name "~"))
+        (expand-file-name "magent/skills" user-emacs-directory))
   "List of directories to scan for skill files.
 Each directory can contain subdirectories with SKILL.md files.
 Later directories take precedence over earlier directories when skill
-names collide.  The final entry is the canonical installation target."
+names collide.  The final entry is the canonical installation target.
+The default reads Codex user skills while keeping Magent's own directory as
+the managed installation target."
   :type '(repeat directory)
   :group 'magent)
 
@@ -442,37 +402,53 @@ names collide.  The final entry is the canonical installation target."
 (defconst magent-skills--frontmatter-keys
   '(:name :description :type :tools :requires-project
           :capability :title :family :source :source-name :capability-skills
-          :modes :features :files :prompt-keywords :disclosure :risk)
-  "Supported SKILL.md frontmatter keys.")
+          :modes :features :files :prompt-keywords :disclosure :risk
+          :license :metadata :disable-model-invocation)
+  "Accepted SKILL.md frontmatter keys.
+The final three keys are passive cross-agent metadata; Magent does not
+interpret them.")
 
 (defun magent-skills--validate-frontmatter (frontmatter)
-  "Reject unsupported or incomplete skill FRONTMATTER."
+  "Reject unsupported skill FRONTMATTER or missing Codex core fields."
   (cl-loop for (key _value) on frontmatter by #'cddr
            unless (memq key magent-skills--frontmatter-keys)
            do (error "Unsupported skill frontmatter key: %s" key))
-  (dolist (key '(:name :description :type))
+  (dolist (key '(:name :description))
     (unless (plist-member frontmatter key)
       (error "Skill frontmatter is missing required key: %s" key)))
   frontmatter)
 
 (defun magent-skills-definition-directories (&optional scope)
   "Return skill definition directories for static loading and SCOPE.
-When SCOPE is non-nil, include that project's `.magent/skills'
-directory if it exists."
+When SCOPE is non-nil, include existing Codex and Magent project skill roots."
   (append (list magent-skills--builtin-dir)
           magent-skill-directories
-          (when scope
-            (magent-file-loader-project-subdir-for-scope
-             ".magent/skills" scope))))
+          (when scope (magent-skills--project-directories scope))))
+
+(defun magent-skills--project-directories (&optional scope)
+  "Return existing project skill roots for optional SCOPE."
+  (cl-loop for relative-dir in magent-skills--project-relative-directories
+           append
+           (if scope
+               (magent-file-loader-project-subdir-for-scope relative-dir scope)
+             (magent-file-loader-project-subdir relative-dir))))
 
 (defun magent-skills-classify-source (filepath)
   "Return a plist describing the source classification for FILEPATH."
-  (magent-file-loader-classify-source
-   filepath
-   :builtin-dirs (list magent-skills--builtin-dir)
-   :user-dirs magent-skill-directories
-   :project-relative-dir ".magent/skills"
-   :default-layer 'external))
+  (let ((base-source
+         (magent-file-loader-classify-source
+          filepath
+          :builtin-dirs (list magent-skills--builtin-dir)
+          :user-dirs magent-skill-directories
+          :default-layer 'external)))
+    (if (not (eq (plist-get base-source :layer) 'external))
+        base-source
+      (or (cl-loop
+           for relative-dir in magent-skills--project-relative-directories
+           for scope = (magent-file-loader-project-root-for-file
+                        filepath relative-dir)
+           when scope return (list :layer 'project :scope scope))
+          base-source))))
 
 (defun magent-skills--list-files (&optional directories)
   "List all SKILL.md files in DIRECTORIES or `magent-skill-directories'."
@@ -480,7 +456,7 @@ directory if it exists."
          (or directories
              (append (list magent-skills--builtin-dir)
                      magent-skill-directories
-                     (magent-file-loader-project-subdir ".magent/skills")))))
+                     (magent-skills--project-directories)))))
     (magent-file-loader-list-named-files-ordered
      ordered-directories magent-skill-file-name)))
 
@@ -556,35 +532,36 @@ Returns number of skills loaded."
 (defun magent-skills-initialize-static ()
   "Load built-in and user-global skill definitions."
   (magent-skills--register-builtin)
-  (prog1
-      (magent-skills-load-all (magent-skills-definition-directories))
-    (magent-skills--record-scope-catalog 'global)))
+  (magent-skills-load-all (magent-skills-definition-directories)))
 
 (defun magent-skills-load-project-scope (scope)
-  "Load project-local skill definitions for SCOPE."
-  (let ((count
-         (if-let* ((directories
-                    (magent-file-loader-project-subdir-for-scope
-                     ".magent/skills" scope)))
-             (magent-skills-load-all directories)
-           0)))
-    (magent-skills--record-scope-catalog scope)
-    count))
+  "Reload project-local skill definitions for SCOPE."
+  (magent-skills-remove-project-scope scope)
+  (if-let* ((directories (magent-skills--project-directories scope)))
+      (magent-skills-load-all directories)
+    0))
+
+(defun magent-skills--project-scopes ()
+  "Return project scopes to refresh from the skill registry and context."
+  (delete-dups
+   (delq nil
+         (cons
+          (magent-runtime-active-project-scope)
+          (mapcar
+           (lambda (entry)
+             (and (eq (magent-skill-source-layer (cdr entry)) 'project)
+                  (magent-skill-source-scope (cdr entry))))
+           magent-skills--registry)))))
 
 (defun magent-skills-reload ()
-  "Reload all skills from files.
-When a project overlay is currently active, restore that project's
-local skills after static definitions are reloaded."
-  (let ((project-scope (magent-runtime-active-project-scope)))
+  "Reload all file-backed skills, including known project scopes."
+  (let ((project-scopes (magent-skills--project-scopes)))
     (magent-file-loader-reload-file-backed-registry
      'magent-skills--registry
      #'magent-skill-file-path
      #'magent-skills-initialize-static)
-    (when project-scope
-      (magent-skills-load-project-scope project-scope))
-    (magent-skills--record-scope-catalog 'global)
-    (when project-scope
-      (magent-skills--record-scope-catalog project-scope))))
+    (dolist (scope project-scopes)
+      (magent-skills-load-project-scope scope))))
 
 (defun magent-skills-remove-project-scope (scope)
   "Remove project-local skills registered for SCOPE."

--- a/lisp/magent-tools.el
+++ b/lisp/magent-tools.el
@@ -1756,6 +1756,8 @@ Return the child loop handle when startup succeeds."
            :scope (and parent-context
                        (magent-request-context-scope parent-context))
            :session child-session
+           :prompt prompt
+           :agent agent
            :approval-session parent-session
            :origin-buffer-name (and parent-context
                                     (magent-request-context-origin-buffer-name
@@ -1807,12 +1809,7 @@ Return the child loop handle when startup succeeds."
         (progn
           (setq child-loop
                 (magent-agent-run-turn
-                 :session child-session
-                 :prompt prompt
-                 :agent agent
-                 :context
-                 (magent-request-context-origin-context child-request-context)
-                 :request-context child-request-context
+                 child-request-context
                  :on-complete
                  (lambda (response)
                    (magent-lifecycle-events-stop-subagent subagent-context)
@@ -1870,7 +1867,8 @@ Return the child loop handle when startup succeeds."
 
 (defun magent-tools--spawn-agent (callback agent-name prompt &optional task-name)
   "Spawn a durable child-agent job using AGENT-NAME and PROMPT."
-  (let ((agent (magent-agent-registry-get agent-name)))
+  (let ((agent (magent-agent-registry-get
+                agent-name (magent-tools--parent-scope))))
     (cond
      ((null agent)
       (magent-tools--fail

--- a/test/magent-live-test.el
+++ b/test/magent-live-test.el
@@ -713,7 +713,7 @@ return that path."
                     (and (fboundp 'magent-runtime-queue-active-submission)
                          (magent-runtime-queue-active-submission)))
                    (runtime-session
-                    (magent-runtime-submission-session submission)))
+                    (magent-runtime-submission-runtime-session submission)))
          (ignore-errors (magent-runtime-cancel runtime-session)))
        (magent-live-test--kill-magent-test-buffers)
        (when (file-directory-p magent-session-directory)

--- a/test/magent-test.el
+++ b/test/magent-test.el
@@ -159,6 +159,19 @@
               (magent-request-context-create
                :session session :ui-visibility 'none)))
          (existing-observer (magent-request-context-observer request-context)))
+    (setf (magent-request-context-session request-context) session
+          (magent-request-context-prompt request-context) prompt
+          (magent-request-context-agent request-context)
+          (or agent (magent-request-context-agent request-context))
+          (magent-request-context-skill-names request-context)
+          (append skills
+                  (magent-request-context-skill-names request-context))
+          (magent-request-context-origin-context request-context)
+          (or context
+              (magent-request-context-origin-context request-context))
+          (magent-request-context-live-p request-context)
+          (or request-live-p
+              (magent-request-context-live-p request-context)))
     (when event-context
       (setf (magent-request-context-event-context request-context) event-context))
     (when text-callback
@@ -168,10 +181,9 @@
               (when (eq (plist-get event :type) 'assistant-delta)
                 (funcall text-callback (plist-get event :text))))))
     (magent-agent-run-turn
-     :session session :prompt prompt :agent agent :skills skills
-     :context context :request-context request-context
+     request-context
      :capability-resolution capability-resolution
-     :on-complete callback :request-live-p request-live-p)))
+     :on-complete callback)))
 
 (defun magent-test--read-audit-records (directory)
   "Return all JSONL audit records stored under DIRECTORY."
@@ -713,10 +725,9 @@
                :session session
                :ui-visibility 'none
                :observer (lambda (event) (push event events)))))
+        (setf (magent-request-context-prompt request-context) "Hello")
         (magent-agent-run-turn
-         :session session
-         :prompt "Hello"
-         :request-context request-context
+         request-context
          :on-complete (lambda (result) (setq response result)))))
     (should (equal (magent-execution-result-content-string response)
                    "MAGENT_HELLO"))
@@ -2085,7 +2096,7 @@
                (lambda (_title) 'turn))
               ((symbol-function 'magent-lifecycle-events-end-turn) #'ignore)
               ((symbol-function 'magent-skills-get-instruction-prompts)
-               (lambda (_skills) nil)))
+               (lambda (_skills _scope) nil)))
       (magent-test--run-turn
        "inspect"
        nil
@@ -2143,7 +2154,7 @@
               ((symbol-function 'magent-tools-get-gptel-tools-for-permission)
                (lambda (&rest _args) nil))
               ((symbol-function 'magent-skills-get-instruction-prompts)
-               (lambda (skill-names)
+               (lambda (skill-names _scope)
                  (setq captured-skills skill-names)
                  '("captured skill prompt")))
               ((symbol-function 'magent-log) #'ignore)
@@ -2257,7 +2268,7 @@
                (lambda (_title) 'turn))
               ((symbol-function 'magent-lifecycle-events-end-turn) #'ignore)
               ((symbol-function 'magent-skills-get-instruction-prompts)
-               (lambda (_skills) nil)))
+               (lambda (_skills _scope) nil)))
       (magent-test--run-turn
        "summarize this repo"
        nil
@@ -2629,6 +2640,55 @@
           (let* ((file (car (magent-session-list-action-files "doctor")))
                  (meta (magent-session--read-file-metadata-cached file)))
             (should (equal (plist-get meta :status) "completed"))))
+      (delete-directory magent-session-directory t))))
+
+(ert-deftest magent-test-doctor-provider-start-error-is-actionable ()
+  "Doctor classifies a synchronous gptel configuration failure."
+  (require 'magent-action-builtin-doctor)
+  (let* ((magent-session-directory (make-temp-file "magent-sessions-" t))
+         (magent-action-session-directory nil)
+         (magent-action--registry nil)
+         (magent-action--active-invocations (make-hash-table :test #'eq))
+         (magent-action-session--active-invocations
+          (make-hash-table :test #'equal))
+         (magent-doctor--registry (make-hash-table :test #'equal))
+         (magent-session--scoped-sessions (make-hash-table :test #'equal))
+         (magent-bypass-permission t)
+         (parent (magent-session-create :id "session-parent"))
+         (runtime (magent-runtime-session-create
+                   :id "session-parent" :scope 'global
+                   :magent-session parent))
+         (route (magent-model-route-create
+                 :backend 'doctor-backend :model 'doctor-model))
+         completion)
+    (unwind-protect
+        (progn
+          (magent-session-install 'global parent)
+          (magent-doctor-register-probe
+           "safe" :collector (lambda (_invocation _state) '((ok . t)))
+           :required t)
+          (let ((magent-action--allow-core-registration t))
+            (magent-action-builtin-doctor-register))
+          (cl-letf (((symbol-function
+                      'magent-runtime-session-effective-model-route)
+                     (lambda (&rest _) route))
+                    ((symbol-function 'magent-session-save-deferred-for-session)
+                     #'ignore)
+                    ((symbol-function 'magent-sampling-gptel-sample)
+                     (lambda (_request)
+                       (signal 'wrong-type-argument '(stringp nil)))))
+            (magent-action-invoke
+             "doctor" runtime
+             :on-complete (lambda (status result)
+                            (setq completion (list status result)))))
+          (should (eq (car completion) 'failed))
+          (let ((message
+                 (magent-execution-result-content-string (cadr completion))))
+            (should (string-match-p
+                     (regexp-quote
+                      "Verify its API key/auth-source callback and proxy configuration")
+                     message))
+            (should-not (string-match-p "Wrong type argument" message))))
       (delete-directory magent-session-directory t))))
 
 (ert-deftest magent-test-doctor-confirm-reuses-interactive-buffer ()
@@ -3430,7 +3490,6 @@
   "Descriptors expose instruction skills without requiring a default prompt."
   (require 'magent-skills)
   (let* ((magent-skills--registry nil)
-        (magent-skills--scope-catalog (make-hash-table :test #'equal))
         (magent-runtime--active-project-scope nil)
         (project-root (make-temp-file "magent-skill-project-" t)))
     (unwind-protect
@@ -3464,7 +3523,6 @@
   "Project skill catalogs remain exact while another scope is active."
   (require 'magent-skills)
   (let* ((magent-skills--registry nil)
-         (magent-skills--scope-catalog (make-hash-table :test #'equal))
          (magent-runtime--active-project-scope nil)
          (project-a (file-truename
                      (directory-file-name
@@ -3483,7 +3541,6 @@
             :name "policy" :description "Project A policy."
             :type 'instruction :source-layer 'project
             :source-scope project-a))
-          (magent-skills-remove-project-scope project-a)
           (magent-skills-register
            (magent-skill-create
             :name "policy" :description "Project B policy."
@@ -3836,7 +3893,6 @@
   (let ((magent-action--registry nil)
         (magent-action--active-invocations (make-hash-table :test #'eq))
         (magent-skills--registry nil)
-        (magent-skills--scope-catalog (make-hash-table :test #'equal))
         (runtime-session
          (magent-runtime-session-create
           :id "session-1"
@@ -5263,11 +5319,11 @@
       :tools '(emacs_eval)))
     (should-error
      (magent-agent--validate-explicit-skill-tools
-      '("runtime-skill") '(read_file))
+      '("runtime-skill") '(read_file) 'global)
      :type 'error)
     (should-not
      (magent-agent--validate-explicit-skill-tools
-      '("runtime-skill") '(emacs_eval)))))
+      '("runtime-skill") '(emacs_eval) 'global))))
 
 (ert-deftest magent-test-capability-resolve-mixed-org-and-git-context ()
   "Test org context plus git wording does not hide the org capability."
@@ -5337,6 +5393,23 @@
   (should-error (magent-skills--parse-type "tool"))
   (should-error (magent-skills--parse-type "unknown")))
 
+(ert-deftest magent-test-skills-validate-codex-frontmatter-contract ()
+  "Codex core fields suffice while unsupported fields still fail visibly."
+  (require 'magent-skills)
+  (let ((frontmatter
+         '(:name "codex-skill"
+           :description "A Codex-compatible skill."
+           :metadata (:short-description "Codex skill"))))
+    (should (equal (magent-skills--validate-frontmatter frontmatter)
+                   frontmatter)))
+  (should-error
+   (magent-skills--validate-frontmatter '(:name "missing-description"))
+   :type 'error)
+  (should-error
+   (magent-skills--validate-frontmatter
+    '(:name "unknown-field" :description "Invalid." :typo t))
+   :type 'error))
+
 (ert-deftest magent-test-skills-parse-tools ()
   "Test canonical YAML-sequence tool parsing."
   (require 'magent-skills)
@@ -5366,6 +5439,60 @@
             (should (magent-skill-requires-project skill))
             (should (string-match-p "Do the thing" (magent-skill-prompt skill)))))
       (delete-directory tmpdir t))))
+
+(ert-deftest magent-test-skills-load-codex-compatible-file ()
+  "A shared Codex skill defaults to instruction and keeps host metadata passive."
+  (require 'magent-skills)
+  (let* ((magent-skills--registry nil)
+         (tmpdir (make-temp-file "codex-skill-" t))
+         (skillfile (expand-file-name "SKILL.md" tmpdir)))
+    (unwind-protect
+        (progn
+          (with-temp-file skillfile
+            (insert "---\n"
+                    "name: codex-compatible\n"
+                    "description: Shared with Codex\n"
+                    "license: MIT\n"
+                    "metadata:\n"
+                    "  tags: compatibility\n"
+                    "disable-model-invocation: true\n"
+                    "---\n"
+                    "Follow the shared instructions.\n"))
+          (let ((skill (magent-skills-load-file skillfile)))
+            (should skill)
+            (should (eq (magent-skill-type skill) 'instruction))
+            (should (equal (magent-skill-name skill) "codex-compatible"))
+            (should (equal (magent-skill-description skill)
+                           "Shared with Codex"))
+            (should (string-match-p "shared instructions"
+                                    (magent-skill-prompt skill)))))
+      (delete-directory tmpdir t))))
+
+(ert-deftest magent-test-skills-load-codex-project-directory ()
+  "Project loading discovers Codex's repository-local skill root."
+  (require 'magent-skills)
+  (let* ((magent-skills--registry nil)
+         (project-root (file-truename
+                        (directory-file-name
+                         (make-temp-file "codex-project-skill-" t))))
+         (skill-dir (expand-file-name ".agents/skills/project-codex"
+                                      project-root))
+         (skillfile (expand-file-name "SKILL.md" skill-dir)))
+    (unwind-protect
+        (progn
+          (make-directory skill-dir t)
+          (with-temp-file skillfile
+            (insert "---\n"
+                    "name: project-codex\n"
+                    "description: Repository-local Codex skill\n"
+                    "---\n"
+                    "Use the repository workflow.\n"))
+          (should (= (magent-skills-load-project-scope project-root) 1))
+          (let ((skill (magent-skills-get "project-codex" project-root)))
+            (should skill)
+            (should (eq (magent-skill-source-layer skill) 'project))
+            (should (equal (magent-skill-source-scope skill) project-root))))
+      (delete-directory project-root t))))
 
 (ert-deftest magent-test-skills-load-all-includes-emacs-runtime-inspection ()
   "Test builtin skill loading includes the Emacs runtime inspection workflow."
@@ -6256,7 +6383,7 @@
           (magent-tools--register-cancel (lambda (fn) (setq cleanup fn)))
           (magent-agent-job--runtimes (make-hash-table :test #'equal)))
       (cl-letf (((symbol-function 'magent-agent-registry-get)
-                 (lambda (_name) agent))
+                 (lambda (_name _scope) agent))
                 ((symbol-function 'magent-lifecycle-events-create-subagent-context)
                  (lambda (title parent _audit-context)
                    (list :title title :parent parent)))
@@ -6265,10 +6392,10 @@
                    (setq stopped context)))
                 ((symbol-function 'magent-agent-run-turn)
                  (lambda (&rest args)
-                   (let* ((request-state (plist-get args :request-context))
+                   (let* ((request-state (car args))
                           (route
                            (magent-agent-resolve-model-route
-                            (plist-get args :agent)
+                            (magent-request-context-agent request-state)
                             :parent-route
                             (magent-request-context-parent-model-route
                              request-state))))
@@ -6279,15 +6406,19 @@
                          (magent-request-context-backend request-state)
                          (magent-model-route-backend route))
                    (setq captured
-                         (list :prompt (plist-get args :prompt)
-                               :agent (plist-get args :agent)
+                         (list :prompt
+                               (magent-request-context-prompt request-state)
+                               :agent
+                               (magent-request-context-agent request-state)
                                :event-context
                                (magent-request-context-event-context request-state)
-                               :request-context (plist-get args :context)
+                               :request-context
+                               (magent-request-context-origin-context
+                                request-state)
                                :capability-resolution
-                               (plist-get args :capability-resolution)
+                               (plist-get (cdr args) :capability-resolution)
                                :request-state request-state))
-                   (funcall (plist-get args :on-complete)
+                   (funcall (plist-get (cdr args) :on-complete)
                             (magent-execution-result-completed "child answer"))
                    child-loop)))
                 ((symbol-function 'magent-agent-loop-abort)
@@ -6394,7 +6525,7 @@
     (let ((magent-tools--request-context parent-context)
           (magent-agent-job--runtimes (make-hash-table :test #'equal)))
       (cl-letf (((symbol-function 'magent-agent-registry-get)
-                 (lambda (_name) agent))
+                 (lambda (_name _scope) agent))
                 ((symbol-function 'magent-agent-run-turn)
                  (lambda (&rest _args)
                    (setq started t))))
@@ -6435,14 +6566,14 @@
     (let ((magent-tools--request-context parent-context)
           (magent-agent-job--runtimes (make-hash-table :test #'equal)))
       (cl-letf (((symbol-function 'magent-agent-registry-get)
-                 (lambda (_name) agent))
+                 (lambda (_name _scope) agent))
                 ((symbol-function 'magent-lifecycle-events-create-subagent-context)
                  (lambda (title parent _audit-context)
                    (list :title title :parent parent)))
                 ((symbol-function 'magent-lifecycle-events-stop-subagent) #'ignore)
                 ((symbol-function 'magent-agent-run-turn)
                  (lambda (&rest args)
-                   (funcall (plist-get args :on-complete)
+                   (funcall (plist-get (cdr args) :on-complete)
                             (magent-execution-result-failed
                              "Request timed out after 5 seconds"))
                    nil)))
@@ -6530,9 +6661,10 @@
                   ((symbol-function 'magent-lifecycle-events-stop-subagent) #'ignore)
                   ((symbol-function 'magent-agent-run-turn)
                    (lambda (&rest args)
-                     (let ((prompt (plist-get args :prompt)))
+                     (let ((prompt
+                            (magent-request-context-prompt (car args))))
                      (push prompt captured-prompts)
-                     (funcall (plist-get args :on-complete)
+                     (funcall (plist-get (cdr args) :on-complete)
                               (magent-execution-result-completed
                                (concat "reply: " prompt)))
                      nil)))
@@ -9368,16 +9500,17 @@
           (magent-session-install 'global parent-session)
           (magent-test--record-session-entry parent-session 'user "spawn child")
           (cl-letf (((symbol-function 'magent-agent-registry-get)
-                     (lambda (_name) agent))
+                     (lambda (_name _scope) agent))
                     ((symbol-function 'magent-lifecycle-events-create-subagent-context)
                      (lambda (_title _parent _audit-context) 'child-context))
                     ((symbol-function 'magent-lifecycle-events-stop-subagent) #'ignore)
                     ((symbol-function 'magent-agent-run-turn)
                      (lambda (&rest args)
-                       (let* ((prompt (plist-get args :prompt))
-                              (request-state
-                               (plist-get args :request-context)))
-                       (setq child-callback (plist-get args :on-complete))
+                       (let* ((request-state (car args))
+                              (prompt
+                               (magent-request-context-prompt request-state)))
+                       (setq child-callback
+                             (plist-get (cdr args) :on-complete))
                        (magent-test--record-session-entry
                         (magent-request-context-session request-state)
                         'user prompt)
@@ -11174,7 +11307,7 @@
     (should (equal (magent-session-summary-title derived) "First prompt"))))
 
 (ert-deftest magent-test-runtime-activate-scope-switches-project-overlays ()
-  "Test runtime activation unloads the old overlay before loading the new one."
+  "Runtime activation retains old definitions and loads only the target scope."
   (require 'magent-runtime)
   (let ((magent-runtime--active-project-scope nil)
         (magent-load-custom-agents t)
@@ -11199,8 +11332,8 @@
               ((symbol-function 'magent-capability-remove-project-scope)
                (lambda (scope) (push (list 'unload-capability scope) events)))
               ((symbol-function 'magent-session-refresh-agent)
-               (lambda (session)
-                 (push (list 'refresh (magent-session-id session)) events)
+               (lambda (session scope)
+                 (push (list 'refresh (magent-session-id session) scope) events)
                  session))
               ((symbol-function 'magent-log) #'ignore))
       (magent-runtime-activate-scope scope-a)
@@ -11210,72 +11343,52 @@
                    `((load-agent ,scope-a)
                      (load-skill ,scope-a)
                      (load-capability ,scope-a)
-                     (refresh "session-a")
-                     (unload-agent ,scope-a)
-                     (unload-skill ,scope-a)
-                     (unload-capability ,scope-a)
+                     (refresh "session-a" ,scope-a)
                      (load-agent ,scope-b)
                      (load-skill ,scope-b)
                      (load-capability ,scope-b)
-                     (refresh "session-b")
-                     (unload-agent ,scope-b)
-                     (unload-skill ,scope-b)
-                     (unload-capability ,scope-b))))
+                     (refresh "session-b" ,scope-b))))
     (should-not (magent-runtime-active-project-scope))))
 
 (ert-deftest magent-test-runtime-activate-scope-rolls-back-partial-overlay ()
-  "A failed project load restores the exact previously active registries."
+  "A failed project load removes only the partial target definitions."
   (require 'magent-runtime)
   (let* ((old-scope "/tmp/magent-project-old")
          (new-scope "/tmp/magent-project-new")
-         (old-agent (list :owner 'old-agent))
-         (old-skill (list (cons "old-skill" (list :owner 'old-skill))))
-         (old-capability
-          (list (cons "old-capability" (list :owner 'old-capability))))
          (magent-runtime--active-project-scope old-scope)
          (magent-load-custom-agents t)
-         (magent-agent-registry--agents (make-hash-table :test #'equal))
-         (magent-skills--registry old-skill)
-         (magent-capability--registry old-capability)
-         logs)
-    (puthash "old-agent" old-agent magent-agent-registry--agents)
+         events)
     (cl-letf (((symbol-function 'magent-agent-registry-remove-project-scope)
                (lambda (scope)
-                 (if (equal scope new-scope)
-                     (error "cleanup failed")
-                   (clrhash magent-agent-registry--agents))))
+                 (push (list 'remove-agent scope) events)))
               ((symbol-function 'magent-skills-remove-project-scope)
-               (lambda (_scope) (setq magent-skills--registry nil)))
+               (lambda (scope) (push (list 'remove-skill scope) events)))
               ((symbol-function 'magent-capability-remove-project-scope)
-               (lambda (_scope) (setq magent-capability--registry nil)))
+               (lambda (scope) (push (list 'remove-capability scope) events)))
               ((symbol-function 'magent-agent-file-load-project-scope)
-               (lambda (_scope)
-                 (puthash "new-agent" (list :owner 'new-agent)
-                          magent-agent-registry--agents)))
+               (lambda (scope) (push (list 'load-agent scope) events)))
               ((symbol-function 'magent-skills-load-project-scope)
-               (lambda (_scope)
-                 (setq magent-skills--registry
-                       (list (cons "new-skill" (list :owner 'new-skill))))))
+               (lambda (scope) (push (list 'load-skill scope) events)))
               ((symbol-function 'magent-capability-load-project-scope)
-               (lambda (_scope) (error "broken capability")))
-              ((symbol-function 'magent-log)
-               (lambda (format-string &rest args)
-                 (push (apply #'format format-string args) logs))))
+               (lambda (scope)
+                 (push (list 'load-capability scope) events)
+                 (error "broken capability")))
+              ((symbol-function 'magent-log) #'ignore))
       (let ((error-data
              (should-error (magent-runtime-activate-scope new-scope)
                            :type 'error)))
         (should (equal (error-message-string error-data)
                        "broken capability")))
-      (should (cl-some
-               (lambda (text)
-                 (string-match-p "cleanup failed" text))
-               logs))
       (should (equal (magent-runtime-active-project-scope) old-scope))
-      (should (equal (gethash "old-agent" magent-agent-registry--agents)
-                     old-agent))
-      (should-not (gethash "new-agent" magent-agent-registry--agents))
-      (should (equal magent-skills--registry old-skill))
-      (should (equal magent-capability--registry old-capability)))))
+      (should
+       (equal
+        (nreverse events)
+        `((load-agent ,new-scope)
+          (load-skill ,new-scope)
+          (load-capability ,new-scope)
+          (remove-agent ,new-scope)
+          (remove-skill ,new-scope)
+          (remove-capability ,new-scope)))))))
 
 (ert-deftest magent-test-runtime-prepare-context-initializes-and-activates-scope ()
   "Test command-context preparation initializes static state once and activates scope."
@@ -11434,7 +11547,7 @@
       :prompt-keywords '("heading")
       :disclosure 'active))
     (cl-letf (((symbol-function 'magent-skills-get-instruction-prompts)
-               (lambda (skill-names)
+               (lambda (skill-names _scope)
                  (setq captured-skill-names skill-names)
                  '("## Skill: captured\n\nDo things.")))
               ((symbol-function 'gptel-request)
@@ -11458,7 +11571,7 @@
         (gptel-model 'gpt-4o-mini)
         (captured-skill-names nil))
     (cl-letf (((symbol-function 'magent-skills-get-instruction-prompts)
-               (lambda (skill-names)
+               (lambda (skill-names _scope)
                  (setq captured-skill-names skill-names)
                  '("## Skill: captured\n\nDo things.")))
               ((symbol-function 'gptel-request)
@@ -11497,7 +11610,7 @@
       :prompt-keywords '("heading")
       :disclosure 'active))
     (cl-letf (((symbol-function 'magent-skills-get-instruction-prompts)
-               (lambda (_skill-names)
+               (lambda (_skill-names _scope)
                  '("## Skill: captured\n\nDo things.")))
               ((symbol-function 'gptel-request)
                (lambda (_prompt &rest kwargs)
@@ -11750,10 +11863,10 @@
   (require 'magent-acp)
   (let (response failure)
     (cl-letf (((symbol-function 'run-at-time)
-               (lambda (_secs _repeat fn &rest args)
+              (lambda (_secs _repeat fn &rest args)
                  (apply fn args)))
               ((symbol-function 'magent-agent-registry-primary-agents)
-               (lambda ()
+               (lambda (&optional _scope)
                  (list (magent-agent-info-create
                         :name "build"
                         :description "Build"
@@ -11769,6 +11882,41 @@
                magent-acp-protocol-version))
     (should (equal (map-nested-elt response '(modes currentModeId))
                    magent-default-agent))))
+
+(ert-deftest magent-test-acp-modes-use-runtime-session-scope ()
+  "ACP advertises only agents visible in the exact runtime session scope."
+  (require 'magent-acp)
+  (let* ((magent-agent-registry--agents (make-hash-table :test #'equal))
+         (magent-agent-registry--initialized t)
+         (magent-agent-registry--default-agent "build")
+         (project-a "/tmp/magent-acp-modes-a")
+         (project-b "/tmp/magent-acp-modes-b")
+         (base (magent-agent-info-create
+                :name "build" :mode 'primary :source-layer 'builtin))
+         (agent-a (magent-agent-info-create
+                   :name "project-a" :mode 'primary :source-layer 'project
+                   :source-scope project-a))
+         (agent-b (magent-agent-info-create
+                   :name "project-b" :mode 'primary :source-layer 'project
+                   :source-scope project-b))
+         (runtime-a
+          (magent-runtime-session-create
+           :id "session-a" :scope project-a
+           :magent-session (magent-session-create :agent base)))
+         (runtime-b
+          (magent-runtime-session-create
+           :id "session-b" :scope project-b
+           :magent-session (magent-session-create :agent base))))
+    (dolist (agent (list base agent-a agent-b))
+      (magent-agent-registry-register agent))
+    (cl-labels
+        ((mode-ids (runtime)
+           (mapcar (lambda (entry) (map-elt entry 'id))
+                   (append (map-elt (magent-acp--modes runtime)
+                                    'availableModes)
+                           nil))))
+      (should (equal (mode-ids runtime-a) '("build" "project-a")))
+      (should (equal (mode-ids runtime-b) '("build" "project-b"))))))
 
 (ert-deftest magent-test-acp-in-process-client-starts-on-local-host ()
   "Magent's ACP placeholder process cannot inherit a remote shell cwd."
@@ -11792,7 +11940,6 @@
   (require 'magent-acp)
   (require 'magent-action-controls)
   (let* ((magent-skills--registry nil)
-        (magent-skills--scope-catalog (make-hash-table :test #'equal))
         (magent-action--registry nil))
     (magent-action-controls-register)
     (magent-skills-register
@@ -11823,8 +11970,7 @@
   "Test ACP available commands expose every bundled Elisp command."
   (require 'magent-acp)
   (let* ((magent-action--registry nil)
-        (magent-skills--registry nil)
-        (magent-skills--scope-catalog (make-hash-table :test #'equal)))
+        (magent-skills--registry nil))
     (magent-test--register-builtin-commands-only)
     (let* ((commands (append (magent-acp--available-commands) nil))
            (names (mapcar (lambda (command)
@@ -11925,7 +12071,6 @@
   (require 'magent-acp)
   (let* ((magent-action--registry nil)
          (magent-skills--registry nil)
-         (magent-skills--scope-catalog (make-hash-table :test #'equal))
          (magent-runtime--active-project-scope nil)
          (project-a (file-truename
                      (directory-file-name
@@ -11948,7 +12093,6 @@
             :name "project-a" :type 'instruction
             :description "Project A."
             :source-layer 'project :source-scope project-a))
-          (magent-skills-remove-project-scope project-a)
           (magent-skills-register
            (magent-skill-create
             :name "project-b" :type 'instruction
@@ -11971,7 +12115,6 @@
   "ACP `/$skill' syntax resolves against instruction skill descriptors."
   (require 'magent-acp)
   (let ((magent-skills--registry nil)
-        (magent-skills--scope-catalog (make-hash-table :test #'equal))
         (project-root (make-temp-file "magent-acp-skill-project-" t)))
     (unwind-protect
         (progn
@@ -12071,7 +12214,7 @@
               ((symbol-function 'magent-runtime-session-new)
                (lambda (_scope) runtime-session))
               ((symbol-function 'magent-agent-registry-primary-agents)
-               (lambda ()
+               (lambda (&optional _scope)
                  (list (magent-agent-info-create
                         :name "build"
                         :description "Build"))))
@@ -12291,7 +12434,7 @@
     (cl-letf (((symbol-function 'magent-runtime-session-agent-name)
                (lambda (_session) "build"))
               ((symbol-function 'magent-agent-registry-primary-agents)
-               (lambda ()
+               (lambda (&optional _scope)
                  (list (magent-agent-info-create
                         :name "build"
                         :description "Build")))))
@@ -12427,7 +12570,6 @@
   "ACP `/$skill' keeps raw input while explicitly selecting the skill."
   (require 'magent-acp)
   (let* ((magent-skills--registry nil)
-        (magent-skills--scope-catalog (make-hash-table :test #'equal))
         (runtime-session
          (magent-runtime-session-create
           :id "session-1"
@@ -12486,7 +12628,6 @@
   "Unknown `/$skill' input fails before an ordinary model submission."
   (require 'magent-acp)
   (let* ((magent-skills--registry nil)
-        (magent-skills--scope-catalog (make-hash-table :test #'equal))
         (runtime-session
          (magent-runtime-session-create :id "session-1" :scope 'global))
         (client (magent-test--acp-client-for-runtime runtime-session))
@@ -13290,7 +13431,7 @@
               ((symbol-function 'magent-runtime-session-agent-name)
                (lambda (_session) "build"))
               ((symbol-function 'magent-agent-registry-primary-agents)
-               (lambda () (list agent))))
+               (lambda (&optional _scope) (list agent))))
       (setq response
             (magent-acp--handle-set-model
              '((sessionId . "session-1")
@@ -13328,7 +13469,7 @@
     (cl-letf (((symbol-function 'magent-acp--runtime-session-by-id)
                (lambda (_id _scope) runtime-session))
               ((symbol-function 'magent-agent-registry-primary-agents)
-               (lambda () (list agent))))
+               (lambda (&optional _scope) (list agent))))
       (setq response
             (magent-acp--handle-set-config-option
              '((sessionId . "session-auto")
@@ -13360,7 +13501,7 @@
               ((symbol-function 'magent-runtime-session-agent-name)
                (lambda (_session) "build"))
               ((symbol-function 'magent-agent-registry-primary-agents)
-               (lambda ()
+               (lambda (&optional _scope)
                  (list (magent-agent-info-create
                         :name "build"
                         :description "Build")))))
@@ -13383,7 +13524,7 @@
               ((symbol-function 'magent-runtime-session-agent-name)
                (lambda (_session) "build"))
               ((symbol-function 'magent-agent-registry-primary-agents)
-               (lambda () nil)))
+               (lambda (&optional _scope) nil)))
       (let ((response
              (magent-acp--handle-set-config-option
               '((sessionId . "session-1")
@@ -13678,20 +13819,25 @@
             :magent-session (magent-session-create :id id)))
          (make-submission
            (id session)
-           (let* ((session-id (magent-runtime-session-id session))
-                  (magent-session
+           (let* ((magent-session
                    (magent-runtime-session-magent-session session))
                   (thread (magent-session-thread-ledger magent-session))
                   (turn (magent-thread-queue-turn
                          thread id nil (list :source 'test))))
              (magent-runtime-submission-create
               :id id
-              :session session
-              :session-id session-id
-              :turn-id (magent-thread-turn-id turn)
-              :observer
-              (lambda (event)
-		(push (list id (plist-get event :type)) notifications))
+              :runtime-session session
+              :request-context
+              (magent-request-context-create
+               :id id
+               :scope (magent-runtime-session-scope session)
+               :session magent-session
+               :prompt id
+               :turn-id (magent-thread-turn-id turn)
+               :submission-id id
+               :observer
+               (lambda (event)
+		 (push (list id (plist-get event :type)) notifications)))
               :on-complete
               (lambda (status result)
 		(push (list id status result) callbacks))))))
@@ -13738,10 +13884,14 @@
                  (magent-runtime-session-magent-session session-a)))
                (active-turn
                 (magent-thread-find-turn
-                 thread-a (magent-runtime-submission-turn-id active-a)))
+                 thread-a
+                 (magent-request-context-turn-id
+                  (magent-runtime-submission-request-context active-a))))
                (queued-turn
                 (magent-thread-find-turn
-                 thread-a (magent-runtime-submission-turn-id queued-a))))
+                 thread-a
+                 (magent-request-context-turn-id
+                  (magent-runtime-submission-request-context queued-a)))))
           (should (eq (magent-thread-turn-status active-turn)
                       'interrupted))
           (should (eq (magent-thread-turn-status queued-turn)
@@ -13827,7 +13977,7 @@
            :pending-skills '("review")))
          submitted completion pending-during-submit)
     (cl-letf (((symbol-function 'magent-agent-registry-get)
-               (lambda (name)
+               (lambda (name _scope)
                  (and (equal name "compaction") compaction-agent)))
               ((symbol-function 'magent-runtime-submit)
                (lambda (_runtime prompt &rest args)
@@ -13878,13 +14028,21 @@
          (blocker (magent-runtime-submission-create :id "blocker")))
     (magent-runtime-queue-submit blocker #'ignore)
     (cl-letf (((symbol-function 'magent-agent-registry-get)
-               (lambda (name)
+               (lambda (name _scope)
                  (and (equal name "review") review-agent))))
       (magent-runtime-submit
        runtime-session "review this" :agent 'review :tools nil))
     (let ((submission (car magent-runtime-queue--pending)))
-      (should (eq (magent-runtime-submission-agent submission) review-agent))
-      (should-not (magent-runtime-submission-tool-names submission))
+      (let ((request-context
+             (magent-runtime-submission-request-context submission)))
+        (should (eq (magent-request-context-agent request-context)
+                    review-agent))
+        (should-not (magent-request-context-tool-names request-context))
+        (should (equal
+                 (plist-get
+                  (magent-request-context-audit-snapshot request-context)
+                  :agent)
+                 "review")))
       (should (eq (magent-session-agent session) selected-agent)))))
 
 (ert-deftest magent-test-runtime-cancel-submission-leaves-peer-queued ()
@@ -13903,10 +14061,10 @@
          (blocker (magent-runtime-submission-create :id "blocker"))
          (target
           (magent-runtime-submission-create
-           :id "target" :session runtime-session :session-id "session-1"))
+           :id "target" :runtime-session runtime-session))
          (peer
           (magent-runtime-submission-create
-           :id "peer" :session runtime-session :session-id "session-1"))
+           :id "peer" :runtime-session runtime-session))
          completion)
     (setf (magent-runtime-submission-on-complete target)
           (lambda (status _result) (setq completion status)))
@@ -13937,7 +14095,7 @@
          captured-context)
     (cl-letf (((symbol-function 'magent-agent-run-turn)
                (lambda (&rest args)
-                 (setq captured-context (plist-get args :request-context))
+                 (setq captured-context (car args))
                  'loop))
               ((symbol-function 'magent-runtime-api--finish-submission)
                #'ignore)
@@ -13990,9 +14148,11 @@
       (magent-runtime-submit runtime-session "second"))
     (let* ((queued magent-runtime-queue--pending)
            (first-route
-            (magent-runtime-submission-model-route (nth 0 queued)))
+            (magent-request-context-model-route
+             (magent-runtime-submission-request-context (nth 0 queued))))
            (second-route
-            (magent-runtime-submission-model-route (nth 1 queued))))
+            (magent-request-context-model-route
+             (magent-runtime-submission-request-context (nth 1 queued)))))
       (should (= (length queued) 2))
       (should (eq (magent-model-route-backend first-route) backend-a))
       (should (eq (magent-model-route-model first-route) 'model-a))
@@ -14013,7 +14173,7 @@
          captured-context)
     (cl-letf (((symbol-function 'magent-agent-run-turn)
                (lambda (&rest args)
-                 (setq captured-context (plist-get args :request-context))
+                 (setq captured-context (car args))
                  'loop))
               ((symbol-function 'magent-runtime-api--finish-submission)
                #'ignore)
@@ -14063,7 +14223,7 @@
          captured-context)
     (cl-letf (((symbol-function 'magent-agent-run-turn)
                (lambda (&rest args)
-                 (setq captured-context (plist-get args :request-context))
+                 (setq captured-context (car args))
                  'loop))
               ((symbol-function 'magent-runtime-api--finish-submission)
                #'ignore)
@@ -14122,8 +14282,7 @@
   (require 'magent-runtime-api)
   (let* ((magent-runtime-queue--active nil)
          (magent-runtime-queue--pending nil)
-         (dummy (magent-runtime-submission-create
-                 :id "dummy" :session-id "dummy"))
+         (dummy (magent-runtime-submission-create :id "dummy"))
          (bad-session (magent-session-create :id "bad-session"))
          (good-session (magent-session-create :id "good-session"))
          (bad-runtime (magent-runtime-session-create
@@ -14138,7 +14297,8 @@
                #'ignore)
               ((symbol-function 'magent-agent-run-turn)
                (lambda (&rest args)
-                 (let ((prompt (plist-get args :prompt)))
+                 (let ((prompt
+                        (magent-request-context-prompt (car args))))
                    (push prompt started)
                    (if (equal prompt "bad")
                        (error "startup exploded")
@@ -14155,8 +14315,9 @@
       (magent-runtime-api--finish-submission dummy 'completed "done"))
     (should (equal (nreverse started) '("bad" "good")))
     (should (equal (cdr (assq 'bad completions)) 'failed))
-    (should (equal (magent-runtime-submission-prompt
-                    (magent-runtime-queue-active-submission))
+    (should (equal (magent-request-context-prompt
+                    (magent-runtime-submission-request-context
+                     (magent-runtime-queue-active-submission)))
                    "good"))
     (let* ((thread (magent-session-thread-ledger bad-session))
            (turn (car (magent-thread-turns thread))))
@@ -14173,7 +14334,7 @@
            :id "session-cancel" :scope 'global :magent-session session))
          callbacks)
     (magent-runtime-queue-submit
-     (magent-runtime-submission-create :id "active" :session-id "other")
+     (magent-runtime-submission-create :id "active")
      #'ignore)
     (dolist (entry '(("first" . bad) ("second" . good)))
       (let* ((turn (magent-thread-queue-turn
@@ -14182,9 +14343,12 @@
         (magent-runtime-queue-submit
          (magent-runtime-submission-create
           :id (car entry)
-          :session runtime-session
-          :session-id "session-cancel"
-          :turn-id (magent-thread-turn-id turn)
+          :runtime-session runtime-session
+          :request-context
+          (magent-request-context-create
+           :session session
+           :prompt (car entry)
+           :turn-id (magent-thread-turn-id turn))
           :on-complete
           (lambda (_status _result)
             (push kind callbacks)
@@ -14208,9 +14372,11 @@
          (submission
           (magent-runtime-submission-create
            :id "submission-1"
-           :session-id "session-1"
-           :observer (lambda (event)
-                       (push (plist-get event :type) events))
+           :request-context
+           (magent-request-context-create
+            :submission-id "submission-1"
+            :observer (lambda (event)
+                        (push (plist-get event :type) events)))
            :on-complete
            (lambda (_status _result)
              (should-not (magent-runtime-queue-active-submission))
@@ -16065,7 +16231,7 @@
       (delete-directory outside t))))
 
 (ert-deftest magent-test-layered-registries-restore-shadowed-definitions ()
-  "Removing project definitions reveals the prior agent/skill/capability."
+  "Layered definitions resolve independently for each retained scope."
   (require 'magent-agent-registry)
   (require 'magent-skills)
   (require 'magent-capability)
@@ -16094,15 +16260,24 @@
       (magent-skills-register project-skill)
       (magent-capability-register base-cap)
       (magent-capability-register project-cap)
-      (should (eq (magent-agent-registry-get "same") project-agent))
-      (should (eq (magent-skills-get "same") project-skill))
-      (should (eq (magent-capability-get "same") project-cap))
+      (should (eq (magent-agent-registry-get "same" "/project-a")
+                  project-agent))
+      (should (eq (magent-skills-get "same" "/project-a") project-skill))
+      (should (eq (magent-capability-get "same" "/project-a") project-cap))
+      (should (eq (magent-agent-registry-get "same" "/project-b")
+                  base-agent))
+      (should (eq (magent-skills-get "same" "/project-b") base-skill))
+      (should (eq (magent-capability-get "same" "/project-b") base-cap))
+      (should (eq (magent-agent-registry-get "same" 'global) base-agent))
+      (should (eq (magent-skills-get "same" 'global) base-skill))
+      (should (eq (magent-capability-get "same" 'global) base-cap))
       (magent-agent-registry-remove-project-scope "/project-a")
       (magent-skills-remove-project-scope "/project-a")
       (magent-capability-remove-project-scope "/project-a")
-      (should (eq (magent-agent-registry-get "same") base-agent))
-      (should (eq (magent-skills-get "same") base-skill))
-      (should (eq (magent-capability-get "same") base-cap)))))
+      (should (eq (magent-agent-registry-get "same" "/project-a")
+                  base-agent))
+      (should (eq (magent-skills-get "same" "/project-a") base-skill))
+      (should (eq (magent-capability-get "same" "/project-a") base-cap)))))
 
 (ert-deftest magent-test-global-arbiter-rolls-back-failed-starter-before-next ()
   "A failed backend starter is rolled back before the next FIFO ticket starts."
@@ -16248,12 +16423,12 @@
          started-b
          (submission-a
           (magent-runtime-submission-create
-           :id "a" :session runtime-a :session-id "same"
+           :id "a" :runtime-session runtime-a
            :on-complete
            (lambda (status _result) (setq completion-a status))))
          (submission-b
           (magent-runtime-submission-create
-           :id "b" :session runtime-b :session-id "same")))
+           :id "b" :runtime-session runtime-b)))
     (magent-runtime-queue-submit blocker #'ignore)
     (magent-runtime-queue-submit submission-a #'ignore)
     (magent-runtime-queue-submit
@@ -16334,8 +16509,8 @@
                       (magent-session-thread-ledger session)))))
       (should (eq (magent-thread-turn-status turn) 'interrupted)))))
 
-(ert-deftest magent-test-runtime-prepare-context-refuses-cross-scope-during-lease ()
-  "Interactive registry activation cannot steal another turn's project scope."
+(ert-deftest magent-test-runtime-prepare-context-allows-cross-scope-during-lease ()
+  "Interactive activation cannot change an active turn's captured scope."
   (require 'magent-runtime)
   (require 'magent-runtime-queue)
   (let* ((magent--initialized t)
@@ -16343,17 +16518,24 @@
          (magent-runtime-queue--pending nil)
          (magent-runtime-queue--arbiter-active nil)
          (magent-runtime-queue--arbiter-pending nil)
+         (runtime-session
+          (magent-runtime-session-create
+           :id "leased" :scope "/a"
+           :magent-session (magent-session-create :id "leased")))
          (submission
-          (magent-runtime-submission-create :id "leased" :scope "/a"))
+          (magent-runtime-submission-create
+           :id "leased" :runtime-session runtime-session))
          activated)
     (magent-runtime-queue-submit submission #'ignore)
     (cl-letf (((symbol-function 'magent-runtime-activate-scope)
                (lambda (scope &optional _force) (push scope activated))))
-      (should-error (magent-runtime-prepare-context "/b")
-                    :type 'user-error)
-      (should-not activated)
+      (magent-runtime-prepare-context "/b")
       (magent-runtime-prepare-context "/a")
-      (should (equal activated '("/a"))))))
+      (should (equal activated '("/a" "/b")))
+      (should (equal
+               (magent-runtime-session-scope
+                (magent-runtime-submission-runtime-session submission))
+               "/a")))))
 
 (ert-deftest magent-test-acp-prompt-and-cancel-use-client-exact-scope ()
   "ACP does not resolve an equal session id from another project."
@@ -16507,7 +16689,7 @@
            :id "first" :scope scope :magent-session first))
          (submission
           (magent-runtime-submission-create
-           :id "leased" :scope scope :session runtime)))
+           :id "leased" :runtime-session runtime)))
     (magent-session-install scope first)
     (puthash (list scope "first") runtime magent-runtime-api--sessions)
     (magent-runtime-queue-submit submission #'ignore)
@@ -16535,7 +16717,7 @@
            :id "first" :scope scope :magent-session first))
          (submission
           (magent-runtime-submission-create
-           :id "leased" :scope scope :session active-runtime))
+           :id "leased" :runtime-session active-runtime))
          (client '((:notification-handlers . nil)
                    (:request-handlers . nil)))
          response failure)
@@ -16548,7 +16730,7 @@
               ((symbol-function 'magent-runtime-prepare-context)
                #'ignore)
               ((symbol-function 'magent-agent-registry-primary-agents)
-               (lambda () nil))
+               (lambda (&optional _scope) nil))
               ((symbol-function 'magent-acp--available-commands)
                (lambda (&optional _runtime-session) [])))
       (magent-acp--handle-request
@@ -16584,7 +16766,7 @@
            :id "leased" :scope "/same" :magent-session session))
          (submission
           (magent-runtime-submission-create
-           :id "active" :scope "/same" :session runtime)))
+           :id "active" :runtime-session runtime)))
     (magent-runtime-queue-submit submission #'ignore)
     (should-error (magent-runtime-session-current "/same")
                   :type 'user-error)
@@ -16604,10 +16786,14 @@
          (runtime
           (magent-runtime-session-create
            :id "same-id" :scope "/queued" :magent-session first))
+         (blocker-runtime
+          (magent-runtime-session-create
+           :id "blocker" :scope "/other"
+           :magent-session (magent-session-create :id "blocker")))
          (blocker (magent-runtime-submission-create
-                   :id "blocker" :scope "/other"))
+                   :id "blocker" :runtime-session blocker-runtime))
          (queued (magent-runtime-submission-create
-                  :id "queued" :scope "/queued" :session runtime)))
+                  :id "queued" :runtime-session runtime)))
     (magent-session-install "/queued" first)
     (puthash (list "/queued" "same-id") runtime
              magent-runtime-api--sessions)
@@ -16638,7 +16824,7 @@
          reentrant-error
          (submission
           (magent-runtime-submission-create
-           :id "active" :scope 'global :session runtime
+           :id "active" :runtime-session runtime
            :on-complete
            (lambda (_status _result)
              (condition-case err
@@ -16937,7 +17123,7 @@
               ((symbol-function 'magent-runtime-session-title)
                (lambda (_runtime-session) nil))
               ((symbol-function 'magent-agent-registry-primary-agents)
-               (lambda () nil)))
+               (lambda (&optional _scope) nil)))
       (magent-acp--handle-request
        client
        '((:method . "session/fork")
@@ -16978,9 +17164,9 @@
   "Runtime structs expose the current request and submission contract."
   (require 'magent-agent-loop)
   (should (= (length (magent-lifecycle-events-context-create)) 6))
-  (should (= (length (magent-request-context-create)) 31))
+  (should (= (length (magent-request-context-create)) 33))
   (should (= (length (magent-agent-loop-create)) 23))
-  (should (= (length (magent-runtime-submission-create)) 24)))
+  (should (= (length (magent-runtime-submission-create)) 13)))
 
 (provide 'magent-test)
 ;;; magent-test.el ends here


### PR DESCRIPTION
## Summary

- make one canonical request context the sole runtime turn envelope and remove duplicate queue/submission state
- retain project-local agents, skills, capabilities, and Actions by canonical scope so concurrent sessions resolve independently
- accept Codex-compatible skill roots/frontmatter and attribute tool/approval audit records to the request-local agent
- make Doctor provider-start credential/configuration failures actionable
- update English/Chinese architecture documentation and expand regression coverage
- validate with clean byte compilation, declaration/package lint, 622 unit tests, and isolated live smoke